### PR TITLE
Add Cloudflare-native target and unified runtime core (Workers/Pages/D1/R2)

### DIFF
--- a/.github/workflows/parity-gates.yml
+++ b/.github/workflows/parity-gates.yml
@@ -1,0 +1,36 @@
+name: parity-gates
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  parity-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cloudflare deploy readiness checks (config shape)
+        run: pnpm cf:check
+
+      - name: Runtime-core contract tests
+        run: pnpm --filter @everycal/runtime-core test
+
+      - name: Cloudflare worker parity tests
+        run: pnpm --filter @everycal/cloudflare-worker test

--- a/README.md
+++ b/README.md
@@ -174,8 +174,37 @@ Common flags:
 - `--account-id <id>` to pin a specific Cloudflare account.
 - `--rotate-keys` to force regeneration of federation/job secrets.
 - `--reminders-webhook-url` / `--scrapers-webhook-url` to configure companion worker executor targets (recommended for behavioral parity checks).
+- `--smtp-host`, `--smtp-port`, `--smtp-from` (plus optional `--smtp-secure`, `--smtp-user`, `--smtp-pass`) to supply and validate production SMTP during bootstrap.
+- `--allow-no-smtp` only for non-production/testing; production bootstrap enforces SMTP by default.
 - `--write-tracked-configs` to overwrite repo-tracked `wrangler.toml` and `packages/web/wrangler.toml` from generated production configs.
 - `--skip-secrets`, `--skip-companion-workers`, `--skip-config-check`, `--skip-remote-verify` for advanced flows.
+
+### Production source of truth: generated config
+
+For production, generated config under `.generated/` is the default source of truth.
+Use:
+
+```bash
+pnpm cf:migrate:prod
+pnpm cf:deploy:prod
+pnpm cf:pages:deploy:prod
+```
+
+This avoids placeholder drift in repo-tracked template wrangler files.
+
+### Strict go-live gates
+
+Run a strict gate before cutover:
+
+```bash
+pnpm cf:go-live-gate -- --api-origin https://api.calendar.example.com
+```
+
+This enforces:
+- generated config strict validation,
+- SMTP validated in bootstrap receipt,
+- runtime readiness success (including behavioral executor checks), and
+- smoke checks (`/healthz`, `/api/v1/bootstrap`).
 
 ### Deploy readiness validation
 

--- a/README.md
+++ b/README.md
@@ -2,85 +2,191 @@
 
 Federated event calendar built on [ActivityPub](https://www.w3.org/TR/activitypub/).
 
-EveryCal lets you run your own event server, publish rich event pages, follow local and remote accounts, import venue events via scrapers, and expose JSON/iCal feeds.
+EveryCal now supports **three deployment targets**:
 
-## What is in this repo
+1. **Direct Node.js** (existing, unchanged default)
+2. **Docker Compose** (existing, unchanged)
+3. **Cloudflare-native Phase 3** (optional target: Pages + Workers + D1 + R2 + Cron + Queues)
 
-- `packages/server` - Hono API + SSR entry + SQLite + ActivityPub federation
-- `packages/web` - React + Vike frontend (SSR + client routing)
-- `packages/core` - shared types and utilities
-- `packages/scrapers` - scraper framework + venue integrations
-- `packages/jobs` - scheduled scraper/reminder jobs
-- `packages/wordpress` - optional WordPress Gutenberg feed block
+---
 
-## Requirements
+## Monorepo layout
 
-- Node.js >= 22
-- pnpm >= 10
+- `packages/server` - existing Hono API + SSR entry + SQLite + ActivityPub federation
+- `packages/web` - React + Vike frontend
+- `packages/core` - shared types/utilities + storage interfaces
+- `packages/jobs` - scheduled scraper/reminder jobs (Node/Docker path)
+- `packages/cloudflare-worker` - Cloudflare Worker thin platform layer
+- `packages/runtime-core` - shared runtime-agnostic API app used by Worker and Node unified mode
 
-## Quick start (development)
+---
+
+## Deployment Path 1: Direct Node.js (unchanged)
 
 ```bash
 pnpm install
 pnpm dev
 ```
 
-This starts the server on `http://localhost:3000` and mounts Vite in-process for SSR/frontend dev.
-
-## Build and run
+Production:
 
 ```bash
 pnpm build
 pnpm --filter @everycal/server start
 ```
 
-## Docker
+---
+
+## Deployment Path 2: Docker (unchanged)
 
 ```bash
 docker compose up -d --build
 ```
 
-Container behavior:
+Container behavior remains unchanged:
 
-- runs as non-root (UID 1001)
-- serves API + SSR web app from one process
-- runs background jobs by default (`RUN_JOBS_INTERNALLY=true`)
+- Non-root runtime user
+- API + SSR served from one process
+- Optional in-process jobs via `RUN_JOBS_INTERNALLY=true`
 
-## Core environment variables
+---
 
-- `BASE_URL` - public base URL used for federation links
-- `PORT` - server port (default `3000`)
-- `DATABASE_PATH` - SQLite path (default `/data/everycal.db` in Docker)
-- `UPLOAD_DIR` - upload storage directory
-- `OG_DIR` - generated Open Graph image directory
-- `CORS_ORIGIN` - comma-separated allowed origins
-- `RUN_JOBS_INTERNALLY` - run jobs in same container (`true`/`false`)
-- `SCRAPER_API_KEYS_FILE` or `SCRAPER_API_KEYS_JSON` - scraper auth mapping
+## Deployment Path 3: Cloudflare-native (optional MVP)
 
-## Scrapers
+### What this target uses
 
-1. Start the app.
-2. Create scraper accounts and keys:
+- **Cloudflare Pages** for frontend hosting (`packages/web`)
+- **Workers** for API + federation endpoints
+- **D1** for core relational data (accounts/sessions/events/upload metadata)
+- **R2** for upload object storage
+- **Cron Trigger** via Worker `scheduled()` handler for session cleanup
+- **Queues** producer/consumer bindings for job migration
 
-```bash
-./scripts/setup-scraper-accounts.sh http://localhost:3000
-```
-
-3. Run once locally:
+### Frontend deployment (Pages)
 
 ```bash
-pnpm job:scrapers:once
+pnpm cf:pages:build
+pnpm cf:pages:deploy
 ```
 
-4. Or let Docker jobs run on schedule.
+Cloudflare Pages Functions proxy API/federation paths (`/api/*`, `/.well-known/*`, `/users/*`, `/events/*`, `/nodeinfo/*`, `/inbox`) to your Worker API origin, so the frontend can live on Pages while backend stays on Workers.
+
+
+### One-click deploy
+
+Use Cloudflare's Deploy button (replace repo URL if self-hosting your own fork):
+
+
+> **Important:** the Deploy button provisions app code, but production parity with Docker still requires post-deploy configuration (D1/R2 IDs, Worker secrets, Pages API origin, and reminder/scraper executors).
+
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/everycal/everycal)
+
+### Beginner quickstart (copy/paste)
+
+```bash
+pnpm install
+pnpm cf:migrate
+pnpm cf:dev
+# optional readiness checks (warn-only/local and strict)
+pnpm cf:check
+pnpm cf:check:strict
+# then deploy
+pnpm cf:deploy
+pnpm cf:pages:build
+pnpm cf:pages:dev
+pnpm cf:pages:deploy
+pnpm --filter @everycal/server dev:unified
+```
+
+### Required setup before first deploy
+
+1. Create a D1 database in Cloudflare dashboard.
+2. Create an R2 bucket for uploads.
+3. Update `wrangler.toml` with your `database_id`, bucket name, and `BASE_URL`.
+
+---
+
+## Cloudflare compatibility matrix (Phase 3)
+
+### Unified backend rewrite status
+
+- New shared app package: `packages/runtime-core` (`createUnifiedApp`)
+- Cloudflare Worker now runs as a thin adapter over shared runtime-core.
+- Node/Docker default runtime is still the existing server entrypoint (`packages/server/src/index.ts`); unified Node mode is opt-in for migration testing (`pnpm --filter @everycal/server dev:unified`).
+
+
+| Capability | Direct Node | Docker | Cloudflare |
+|---|---:|---:|---:|
+| Health endpoint | ✅ | ✅ | ✅ |
+| Session bootstrap/auth session cookie | ✅ | ✅ | ✅ |
+| Register/login/logout/me | ✅ | ✅ | ✅ |
+| Event create + own list + public list | ✅ | ✅ | ✅ |
+| Identities (create/list basic) | ✅ | ✅ | ✅ |
+| Saved locations API | ✅ | ✅ | ✅ |
+| API followers/following lists | ✅ | ✅ | ✅ (basic) |
+| iCal + JSON feed endpoint | ✅ | ✅ | ✅ |
+| Upload binary storage | local FS | mounted volume | R2 |
+| Upload metadata persistence | SQLite | SQLite | D1 |
+| Basic federation endpoints + federation cache list APIs | ✅ | ✅ | ✅ (basic) |
+| Frontend hosting on Cloudflare | n/a | n/a | ✅ Pages |
+| Full SSR web app rendering parity | ✅ | ✅ | ✅ |
+| Full ActivityPub federation parity | ✅ | ✅ | ⚠️ requires Worker secret/config wiring |
+| Reminder/scraper execution parity | in-process/CLI | in-process | ⚠️ requires connected reminder/scraper executors |
+
+Cloudflare target is intentionally additive and does **not** modify existing Node/Docker runtime behavior.
+
+### Remaining cross-platform workpackages to reach full parity
+
+1. **Cloudflare post-deploy secret/resource wiring**
+   - Set required Worker secrets/env for federation and jobs (for example `ACTIVITYPUB_PRIVATE_KEY_PEM`, job auth token/URLs as used by your deployment model).
+   - Ensure D1/R2/KV/Durable Object bindings and Pages `API_ORIGIN` are all configured with real values.
+2. **Reminder/scraper executor wiring**
+   - Docker runs jobs in-process/CLI; Cloudflare requires connected executors (native service bindings or webhook-backed workers) to achieve equivalent behavior.
+3. **Operational parity hardening**
+   - Add production monitoring/alerts and rollback playbooks specific to Cloudflare resources and queue/cron paths.
+4. **Continuous parity regression gates**
+   - Keep cross-runtime contract and federation integration tests in CI and expand as new features ship.
+
+### Deploy readiness validation
+
+- API readiness endpoint (Worker): `GET /api/v1/system/deploy-readiness`
+  - Returns `200` when required federation/jobs/baseline runtime wiring is present.
+  - Returns `503` with failing checks when required wiring is missing.
+- Local config checker: `pnpm cf:check` (warn-only) and `pnpm cf:check:strict` (fail-fast).
+  - Validates common placeholder mistakes in `wrangler.toml` and `packages/web/wrangler.toml` before production deploy.
+
+
+---
+
+## Troubleshooting + free-tier notes
+
+- D1 free tier has query/size limits; keep scraper volume conservative.
+- R2 free egress/ops limits apply; optimize image size before upload.
+- If `pnpm cf:dev` fails with missing auth, run `wrangler login`.
+- If migrations fail, verify `database_id` and binding name `DB` in `wrangler.toml`.
+
+---
+
+## Rollback/safety notes
+
+- To rollback Cloudflare target, disable Worker routes and keep Node/Docker deployment running as-is.
+- No existing `packages/server` startup path or Docker compose command was replaced.
+- Cloudflare schema is isolated in `packages/cloudflare-worker/migrations`; it does not mutate local SQLite files.
+
+---
 
 ## Useful commands
 
 ```bash
 pnpm lint
 pnpm test
-pnpm --filter @everycal/server test
-pnpm --filter @everycal/web build
+pnpm cf:dev
+pnpm cf:migrate
+pnpm cf:deploy
+pnpm cf:pages:build
+pnpm cf:pages:dev
+pnpm cf:pages:deploy
+pnpm --filter @everycal/server dev:unified
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -155,18 +155,23 @@ A new bootstrap orchestrator is available to minimize required input to essentia
 # plan only (no API calls)
 pnpm cf:bootstrap -- --domain calendar.example.com
 
-# apply: provision resources + generate env-specific wrangler files/receipts
+# apply: provision resources + generate config + set secrets
 export CLOUDFLARE_API_TOKEN=...
 pnpm cf:bootstrap -- --domain calendar.example.com --apply
 
-# optional: run deployment in same command
+# one-command deploy (provision + secrets + deploy + remote readiness verify)
 pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
 ```
 
 What it does:
 - **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Cloudflare API calls and writes generated configs under `.generated/`.
 - **Phase B (convention defaults):** derives `BASE_URL`, `CORS_ORIGIN`, `API_ORIGIN`, and resource names from the domain + env convention.
-- **Phase C (first-run bootstrap artifacts):** generates federation private key + job webhook token and writes a deployment receipt JSON for reproducibility.
+- **Phase C (first-run bootstrap artifacts):** generates federation private key + job webhook token, sets Worker secrets by default, and writes a deployment receipt JSON for reproducibility.
+
+Common flags:
+- `--pages-project <name>` to customize Pages project name (default `everycal-web`).
+- `--account-id <id>` to pin a specific Cloudflare account.
+- `--skip-secrets`, `--skip-config-check`, `--skip-remote-verify` for advanced flows.
 
 ### Deploy readiness validation
 

--- a/README.md
+++ b/README.md
@@ -155,16 +155,20 @@ A new bootstrap orchestrator is available to minimize required input to essentia
 # plan only (no API calls)
 pnpm cf:bootstrap -- --domain calendar.example.com
 
-# apply: provision resources + generate config + set secrets
-export CLOUDFLARE_API_TOKEN=...
+# apply: provision resources + generate config + set secrets (OAuth via wrangler)
+wrangler login
 pnpm cf:bootstrap -- --domain calendar.example.com --apply
+
+# optional fallback: API token mode
+export CLOUDFLARE_API_TOKEN=...
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token
 
 # one-command deploy (provision + secrets + deploy + remote readiness verify)
 pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
 ```
 
 What it does:
-- **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Cloudflare API calls and writes generated configs under `.generated/`.
+- **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Wrangler OAuth by default (or API token fallback) and writes generated configs under `.generated/`.
 - **Phase B (convention defaults):** derives `BASE_URL`, `CORS_ORIGIN`, `API_ORIGIN`, and resource names from the domain + env convention.
 - **Phase C (first-run bootstrap artifacts):** reuses existing generated federation key/job token by default (generate-once behavior), rotates only when explicitly requested via `--rotate-keys`, and sets Worker secrets.
 - **Service-binding mode (Cloudflare-native):** generates and deploys companion reminder/scraper workers (`everycal-reminders-*`, `everycal-scrapers-*`) and binds them automatically. Companions forward to configured executor webhook targets and expose `/healthz` for behavioral readiness checks.
@@ -172,6 +176,7 @@ What it does:
 Common flags:
 - `--pages-project <name>` to customize Pages project name (default `everycal-web`).
 - `--account-id <id>` to pin a specific Cloudflare account.
+- `--auth oauth|api-token` authentication mode (default `oauth` via `wrangler login`).
 - `--rotate-keys` to force regeneration of federation/job secrets.
 - `--reminders-webhook-url` / `--scrapers-webhook-url` to configure companion worker executor targets (recommended for behavioral parity checks).
 - `--smtp-host`, `--smtp-port`, `--smtp-from` (plus optional `--smtp-secure`, `--smtp-user`, `--smtp-pass`) to supply and validate production SMTP during bootstrap.

--- a/README.md
+++ b/README.md
@@ -166,12 +166,15 @@ pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
 What it does:
 - **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Cloudflare API calls and writes generated configs under `.generated/`.
 - **Phase B (convention defaults):** derives `BASE_URL`, `CORS_ORIGIN`, `API_ORIGIN`, and resource names from the domain + env convention.
-- **Phase C (first-run bootstrap artifacts):** generates federation private key + job webhook token, sets Worker secrets by default, and writes a deployment receipt JSON for reproducibility.
+- **Phase C (first-run bootstrap artifacts):** reuses existing generated federation key/job token by default (generate-once behavior), rotates only when explicitly requested via `--rotate-keys`, and sets Worker secrets.
+- **Service-binding mode (Cloudflare-native):** generates and deploys companion reminder/scraper workers (`everycal-reminders-*`, `everycal-scrapers-*`) and binds them automatically.
 
 Common flags:
 - `--pages-project <name>` to customize Pages project name (default `everycal-web`).
 - `--account-id <id>` to pin a specific Cloudflare account.
-- `--skip-secrets`, `--skip-config-check`, `--skip-remote-verify` for advanced flows.
+- `--rotate-keys` to force regeneration of federation/job secrets.
+- `--write-tracked-configs` to overwrite repo-tracked `wrangler.toml` and `packages/web/wrangler.toml` from generated production configs.
+- `--skip-secrets`, `--skip-companion-workers`, `--skip-config-check`, `--skip-remote-verify` for advanced flows.
 
 ### Deploy readiness validation
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,27 @@ Cloudflare target is intentionally additive and does **not** modify existing Nod
 4. **Continuous parity regression gates**
    - Keep cross-runtime contract and federation integration tests in CI and expand as new features ship.
 
+### One-click-ish bootstrap (Phases A-C)
+
+A new bootstrap orchestrator is available to minimize required input to essentially a domain (and a Cloudflare API token/account context):
+
+```bash
+# plan only (no API calls)
+pnpm cf:bootstrap -- --domain calendar.example.com
+
+# apply: provision resources + generate env-specific wrangler files/receipts
+export CLOUDFLARE_API_TOKEN=...
+pnpm cf:bootstrap -- --domain calendar.example.com --apply
+
+# optional: run deployment in same command
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
+```
+
+What it does:
+- **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Cloudflare API calls and writes generated configs under `.generated/`.
+- **Phase B (convention defaults):** derives `BASE_URL`, `CORS_ORIGIN`, `API_ORIGIN`, and resource names from the domain + env convention.
+- **Phase C (first-run bootstrap artifacts):** generates federation private key + job webhook token and writes a deployment receipt JSON for reproducibility.
+
 ### Deploy readiness validation
 
 - API readiness endpoint (Worker): `GET /api/v1/system/deploy-readiness`

--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ pnpm cf:bootstrap -- --domain calendar.example.com
 
 # apply: provision resources + generate config + set secrets (OAuth via wrangler)
 wrangler login
-pnpm cf:bootstrap -- --domain calendar.example.com --apply
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --smtp-host smtp.example.com --smtp-port 587 --smtp-from no-reply@example.com
 
 # optional fallback: API token mode
 export CLOUDFLARE_API_TOKEN=...
-pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token --smtp-host smtp.example.com --smtp-port 587 --smtp-from no-reply@example.com
 
 # one-command deploy (provision + secrets + deploy + remote readiness verify)
 pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy

--- a/README.md
+++ b/README.md
@@ -167,12 +167,13 @@ What it does:
 - **Phase A (provisioning orchestration):** creates/ensures D1, KV, R2, and Queue resources via Cloudflare API calls and writes generated configs under `.generated/`.
 - **Phase B (convention defaults):** derives `BASE_URL`, `CORS_ORIGIN`, `API_ORIGIN`, and resource names from the domain + env convention.
 - **Phase C (first-run bootstrap artifacts):** reuses existing generated federation key/job token by default (generate-once behavior), rotates only when explicitly requested via `--rotate-keys`, and sets Worker secrets.
-- **Service-binding mode (Cloudflare-native):** generates and deploys companion reminder/scraper workers (`everycal-reminders-*`, `everycal-scrapers-*`) and binds them automatically.
+- **Service-binding mode (Cloudflare-native):** generates and deploys companion reminder/scraper workers (`everycal-reminders-*`, `everycal-scrapers-*`) and binds them automatically. Companions forward to configured executor webhook targets and expose `/healthz` for behavioral readiness checks.
 
 Common flags:
 - `--pages-project <name>` to customize Pages project name (default `everycal-web`).
 - `--account-id <id>` to pin a specific Cloudflare account.
 - `--rotate-keys` to force regeneration of federation/job secrets.
+- `--reminders-webhook-url` / `--scrapers-webhook-url` to configure companion worker executor targets (recommended for behavioral parity checks).
 - `--write-tracked-configs` to overwrite repo-tracked `wrangler.toml` and `packages/web/wrangler.toml` from generated production configs.
 - `--skip-secrets`, `--skip-companion-workers`, `--skip-config-check`, `--skip-remote-verify` for advanced flows.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,12 +122,12 @@ This now performs provisioning + generated-config strict validation + Worker sec
 Key behavior:
 - federation/job secrets are **generate-once + reuse** by default across reruns
 - pass `--rotate-keys` to explicitly regenerate key/token material
-- companion reminder/scraper service workers are generated for Cloudflare-native service bindings
+- companion reminder/scraper service workers are generated for Cloudflare-native service bindings and expose `/healthz` for behavioral readiness checks
 
 3. **Deploy + verify readiness (single command)**
 
 ```bash
-pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy --reminders-webhook-url https://jobs.example/reminders --scrapers-webhook-url https://jobs.example/scrapers
 ```
 
 This runs companion worker deploys, migrations, EveryCal Worker deploy, Pages build/deploy, and then verifies:
@@ -137,6 +137,12 @@ curl -fsS https://api.calendar.example.com/api/v1/system/deploy-readiness
 ```
 
 You should see `{ "ok": true, ... }` when all required wiring is present.
+
+For production parity, configure companion executor targets using:
+- `--reminders-webhook-url <url>`
+- `--scrapers-webhook-url <url>`
+
+Without these, service bindings still deploy, but behavioral readiness checks for companion execution can fail by design.
 
 ## Current migration chunk status
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,125 @@
+# Deployment Guide
+
+EveryCal supports three deployment strategies.
+
+## 1) Direct Node.js
+
+```bash
+pnpm install
+pnpm dev
+```
+
+Production:
+
+```bash
+pnpm build
+pnpm --filter @everycal/server start
+```
+
+## 2) Docker Compose
+
+```bash
+docker compose up -d --build
+curl -fsS http://localhost:3000/healthz
+```
+
+Jobs stay in-process as before (`RUN_JOBS_INTERNALLY=true`).
+
+## 3) Cloudflare-native (Phase 3: Pages + Workers)
+
+### Provision resources
+
+1. Create D1 database (`everycal`)
+2. Create R2 bucket (`everycal-uploads`)
+3. Update `wrangler.toml`
+
+### API Worker commands
+
+```bash
+pnpm cf:migrate
+pnpm cf:dev
+pnpm cf:deploy
+```
+
+### Frontend (Cloudflare Pages) commands
+
+```bash
+pnpm cf:pages:build
+pnpm cf:pages:dev
+pnpm cf:pages:deploy
+```
+
+Pages Functions in `packages/web/functions` proxy API/federation paths to your Worker (`API_ORIGIN`). This keeps frontend and backend deploys separate while preserving same-origin browser behavior at the Pages domain.
+
+### Cron and queues
+
+- Session cleanup runs in Worker `scheduled()` hourly cron trigger.
+- Queue producer/consumer bindings are configured for migrating reminders/scrapers jobs.
+- Queue consumer supports native service-binding dispatch for `reminders` and `scrapers` (`REMINDERS_SERVICE`, `SCRAPERS_SERVICE`) with webhook fallback (`REMINDERS_WEBHOOK_URL`, `SCRAPERS_WEBHOOK_URL`).
+- Queue consumer now applies bounded retries and optional dead-letter forwarding (`JOBS_DLQ`).
+
+## Compatibility matrix
+
+| Feature | Node | Docker | Cloudflare |
+|---|---:|---:|---:|
+| Auth/session bootstrap + register/login/logout/me | ✅ | ✅ | ✅ |
+| Events (create + own list + public) + iCal/JSON feed | ✅ | ✅ | ✅ |
+| Identities (create/list basic) | ✅ | ✅ | ✅ |
+| Saved locations API | ✅ | ✅ | ✅ |
+| API followers/following lists | ✅ | ✅ | ✅ (basic) |
+| Upload storage | FS | Volume | R2 |
+| Upload metadata | SQLite | SQLite | D1 |
+| Basic federation endpoints + federation cache list APIs | ✅ | ✅ | ✅ |
+| Full SSR parity | ✅ | ✅ | ✅ (baseline, no edge-cache yet) |
+| Full federation parity (signature delivery, remote fetch cache) | ✅ | ✅ | ⚠️ requires key/secret setup |
+| Reminder/scraper parity | ✅ | ✅ | ⚠️ requires connected executors |
+
+## Safety/rollback
+
+Cloudflare deployment is additive only. Existing Node/Docker commands and runtime paths remain unchanged.
+
+
+## Unified backend rewrite status
+
+- Shared runtime-agnostic server core now lives in `packages/runtime-core`.
+- Cloudflare Worker runs as a thin platform adapter over this shared app.
+- Node/Docker default server path is still the existing server (`packages/server/src/index.ts`) to avoid regressions.
+- Optional Node unified entrypoint is available at `packages/server/src/unified-index.ts` for migration testing.
+
+## Remaining parity gaps
+
+- Existing default Node/Docker server behavior remains unchanged by default.
+
+- Cloudflare SSR now renders via Worker + Vike for HTML routes and includes edge-cache guardrails (toggle/bypass header/tag version) for safe rollouts.
+- Full middleware parity includes strong distributed consistency via Durable Object-backed global rate-limit enforcement (with KV/local fallback modes).
+- Cloudflare federation parity depends on required secret/key configuration (`ACTIVITYPUB_PRIVATE_KEY_PEM` and related runtime values).
+- Cloudflare reminder/scraper parity depends on connected executors (service bindings or webhook targets) with equivalent operational semantics.
+
+
+
+## Current migration chunk status
+
+- ✅ Unified federation cache listing APIs (`/api/v1/federation/actors`, `/api/v1/federation/remote-events`)
+- ✅ Unified federation follow/search basics (`/api/v1/federation/search`, `/api/v1/federation/follow`, `/api/v1/federation/unfollow`, `/api/v1/federation/following`)
+- ✅ Shared adapter support for D1 and SQLite (`remote_actors`, `remote_events`, `remote_following`)
+- ✅ Unified ActivityPub followers/following collections include local + remote relationships
+- ✅ Unified runtime shared-inbox verification hook + signed delivery hooks + remote sync endpoint (`/api/v1/federation/sync`)
+- ✅ Shared inbox verification now enforces keyId actor matching + required signature headers
+- ✅ Cloudflare federation sync now supports remote event lifecycle handling (delete/prune on complete traversal)
+- ✅ Cloudflare remote sync now walks paginated outbox pages with idempotent upserts
+- ✅ Cloudflare cron now enqueues reminder/scraper queue jobs (`scheduled()` -> `JOBS_QUEUE`)
+- ✅ Cloudflare queue consumer now prefers native reminder/scraper service bindings with webhook fallback + retry/DLQ controls
+- ✅ Cloudflare queue execution now includes delivery-attempt semantics + job metadata propagation (`attempts`, `jobId`, `enqueuedAt`)
+- ✅ Cloudflare Worker applies baseline security headers on SSR/API responses
+- ✅ Cloudflare Worker now mirrors API CORS handling + request body size limits
+- ✅ Cloudflare Worker now mirrors Node-style route-level rate-limit policy for auth/federation/events/uploads/inbox paths
+- ✅ Cloudflare Worker supports optional KV-backed distributed/global rate-limit counters (`RATE_LIMITS_KV`)
+- ✅ Cloudflare Worker supports strongly-consistent Durable Object global rate limiting (`RATE_LIMITS_DO`)
+- ✅ Cloudflare SSR now emits configurable CDN cache hints (`SSR_CACHE_MAX_AGE_SECONDS`, `SSR_CACHE_STALE_WHILE_REVALIDATE_SECONDS`)
+- ✅ Cloudflare SSR rollout guardrails added (`SSR_EDGE_CACHE_ENABLED`, `SSR_EDGE_CACHE_BYPASS_HEADER`, `SSR_CACHE_TAG_VERSION`)
+- ✅ Cross-runtime parity CI gate is defined (`.github/workflows/parity-gates.yml`)
+- ✅ Cloudflare deploy readiness endpoint is available at `/api/v1/system/deploy-readiness`
+- ✅ Cloudflare config readiness checker is available (`pnpm cf:check`, `pnpm cf:check:strict`)
+
+Next chunk:
+- Operational hardening and deploy runbook automation (alerts, rollback drills, SLO dashboards).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,11 +120,18 @@ Rollback minimum:
 pnpm cf:bootstrap -- --domain calendar.example.com
 ```
 
-2. **Apply bootstrap provisioning (Cloudflare APIs)**
+2. **Apply bootstrap provisioning (Wrangler OAuth by default)**
+
+```bash
+wrangler login
+pnpm cf:bootstrap -- --domain calendar.example.com --apply
+```
+
+Optional fallback when OAuth is not viable in your environment:
 
 ```bash
 export CLOUDFLARE_API_TOKEN=...
-pnpm cf:bootstrap -- --domain calendar.example.com --apply
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token
 ```
 
 This now performs provisioning + generated-config strict validation + Worker secret setup by default, and writes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -119,13 +119,18 @@ This now performs provisioning + generated-config strict validation + Worker sec
 - `.generated/jobs-webhook-token.prod.txt`
 - `.generated/cf-bootstrap-receipt.prod.json`
 
+Key behavior:
+- federation/job secrets are **generate-once + reuse** by default across reruns
+- pass `--rotate-keys` to explicitly regenerate key/token material
+- companion reminder/scraper service workers are generated for Cloudflare-native service bindings
+
 3. **Deploy + verify readiness (single command)**
 
 ```bash
 pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
 ```
 
-This runs migrations, Worker deploy, Pages build/deploy, and then verifies:
+This runs companion worker deploys, migrations, EveryCal Worker deploy, Pages build/deploy, and then verifies:
 
 ```bash
 curl -fsS https://api.calendar.example.com/api/v1/system/deploy-readiness

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -124,14 +124,14 @@ pnpm cf:bootstrap -- --domain calendar.example.com
 
 ```bash
 wrangler login
-pnpm cf:bootstrap -- --domain calendar.example.com --apply
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --smtp-host smtp.example.com --smtp-port 587 --smtp-from no-reply@example.com
 ```
 
 Optional fallback when OAuth is not viable in your environment:
 
 ```bash
 export CLOUDFLARE_API_TOKEN=...
-pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --auth api-token --smtp-host smtp.example.com --smtp-port 587 --smtp-from no-reply@example.com
 ```
 
 This now performs provisioning + generated-config strict validation + Worker secret setup by default, and writes:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -112,30 +112,20 @@ export CLOUDFLARE_API_TOKEN=...
 pnpm cf:bootstrap -- --domain calendar.example.com --apply
 ```
 
-This writes:
+This now performs provisioning + generated-config strict validation + Worker secret setup by default, and writes:
 - `.generated/wrangler.prod.toml`
 - `.generated/packages.web.wrangler.prod.toml`
 - `.generated/activitypub-private-key.prod.pem`
 - `.generated/jobs-webhook-token.prod.txt`
 - `.generated/cf-bootstrap-receipt.prod.json`
 
-3. **Set generated secrets on Worker**
+3. **Deploy + verify readiness (single command)**
 
 ```bash
-wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config .generated/wrangler.prod.toml < .generated/activitypub-private-key.prod.pem
-wrangler secret put JOBS_WEBHOOK_TOKEN --config .generated/wrangler.prod.toml < .generated/jobs-webhook-token.prod.txt
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy
 ```
 
-4. **Deploy + verify readiness**
-
-```bash
-wrangler d1 migrations apply everycal-prod --config .generated/wrangler.prod.toml
-wrangler deploy --config .generated/wrangler.prod.toml
-pnpm cf:pages:build
-wrangler pages deploy packages/web/dist/client --project-name everycal-web --config .generated/packages.web.wrangler.prod.toml
-```
-
-Then verify:
+This runs migrations, Worker deploy, Pages build/deploy, and then verifies:
 
 ```bash
 curl -fsS https://api.calendar.example.com/api/v1/system/deploy-readiness

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -97,6 +97,52 @@ Cloudflare deployment is additive only. Existing Node/Docker commands and runtim
 
 
 
+## Live test walkthrough for one-click-ish flow
+
+1. **Plan the derived config from a single domain input**
+
+```bash
+pnpm cf:bootstrap -- --domain calendar.example.com
+```
+
+2. **Apply bootstrap provisioning (Cloudflare APIs)**
+
+```bash
+export CLOUDFLARE_API_TOKEN=...
+pnpm cf:bootstrap -- --domain calendar.example.com --apply
+```
+
+This writes:
+- `.generated/wrangler.prod.toml`
+- `.generated/packages.web.wrangler.prod.toml`
+- `.generated/activitypub-private-key.prod.pem`
+- `.generated/jobs-webhook-token.prod.txt`
+- `.generated/cf-bootstrap-receipt.prod.json`
+
+3. **Set generated secrets on Worker**
+
+```bash
+wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config .generated/wrangler.prod.toml < .generated/activitypub-private-key.prod.pem
+wrangler secret put JOBS_WEBHOOK_TOKEN --config .generated/wrangler.prod.toml < .generated/jobs-webhook-token.prod.txt
+```
+
+4. **Deploy + verify readiness**
+
+```bash
+wrangler d1 migrations apply everycal-prod --config .generated/wrangler.prod.toml
+wrangler deploy --config .generated/wrangler.prod.toml
+pnpm cf:pages:build
+wrangler pages deploy packages/web/dist/client --project-name everycal-web --config .generated/packages.web.wrangler.prod.toml
+```
+
+Then verify:
+
+```bash
+curl -fsS https://api.calendar.example.com/api/v1/system/deploy-readiness
+```
+
+You should see `{ "ok": true, ... }` when all required wiring is present.
+
 ## Current migration chunk status
 
 - ✅ Unified federation cache listing APIs (`/api/v1/federation/actors`, `/api/v1/federation/remote-events`)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,6 +99,21 @@ Cloudflare deployment is additive only. Existing Node/Docker commands and runtim
 
 ## Live test walkthrough for one-click-ish flow
 
+## Ops hardening playbook (production)
+
+Before every production cutover:
+- run `pnpm cf:go-live-gate -- --api-origin <origin>` and require pass.
+- verify queues are draining and no DLQ growth after bootstrap/deploy window.
+- verify cron trigger execution and reminder/scraper companion `/healthz` checks.
+- verify federation delivery success rate and signature error rate for newly deployed key material.
+- verify alerting channels + rollback command runbook are ready.
+
+Rollback minimum:
+- redeploy previous known-good worker artifact/config,
+- restore previous companion worker targets if changed,
+- if `--rotate-keys` was used unintentionally, restore prior federation private key secret.
+
+
 1. **Plan the derived config from a single domain input**
 
 ```bash
@@ -127,7 +142,7 @@ Key behavior:
 3. **Deploy + verify readiness (single command)**
 
 ```bash
-pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy --reminders-webhook-url https://jobs.example/reminders --scrapers-webhook-url https://jobs.example/scrapers
+pnpm cf:bootstrap -- --domain calendar.example.com --apply --deploy --reminders-webhook-url https://jobs.example/reminders --scrapers-webhook-url https://jobs.example/scrapers --smtp-host smtp.example.com --smtp-port 587 --smtp-from no-reply@example.com --smtp-secure false --smtp-user smtp-user --smtp-pass smtp-pass
 ```
 
 This runs companion worker deploys, migrations, EveryCal Worker deploy, Pages build/deploy, and then verifies:
@@ -143,6 +158,25 @@ For production parity, configure companion executor targets using:
 - `--scrapers-webhook-url <url>`
 
 Without these, service bindings still deploy, but behavioral readiness checks for companion execution can fail by design.
+
+
+4. **Run strict go-live gate (required for production cutover)**
+
+```bash
+pnpm cf:go-live-gate -- --api-origin https://api.calendar.example.com
+```
+
+This enforces generated-config strictness, SMTP validation status from bootstrap receipt, behavioral readiness checks, and smoke checks (`/healthz`, `/api/v1/bootstrap`).
+
+5. **Use generated config as production source of truth**
+
+```bash
+pnpm cf:migrate:prod
+pnpm cf:deploy:prod
+pnpm cf:pages:deploy:prod
+```
+
+Repo-tracked wrangler files remain templates; production deploy should come from `.generated/` outputs.
 
 ## Current migration chunk status
 

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cf:pages:dev": "wrangler pages dev packages/web/dist/client --config packages/web/wrangler.toml",
     "test:parity": "pnpm --filter @everycal/runtime-core test && pnpm --filter @everycal/cloudflare-worker test",
     "cf:bootstrap": "node scripts/cf-bootstrap.mjs",
-    "cf:bootstrap:apply": "node scripts/cf-bootstrap.mjs --apply"
+    "cf:bootstrap:apply": "node scripts/cf-bootstrap.mjs --apply",
+    "cf:bootstrap:deploy": "node scripts/cf-bootstrap.mjs --apply --deploy"
   }
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,16 @@
     "job:scrapers": "node packages/jobs/dist/index.js scrapers",
     "job:reminders": "node packages/jobs/dist/index.js reminders",
     "job:scrapers:once": "node packages/jobs/dist/index.js scrapers --once",
-    "job:reminders:once": "node packages/jobs/dist/index.js reminders --once"
+    "job:reminders:once": "node packages/jobs/dist/index.js reminders --once",
+    "cf:dev": "wrangler dev",
+    "cf:deploy": "wrangler deploy",
+    "cf:migrate": "wrangler d1 migrations apply everycal",
+    "cf:check": "node scripts/cf-deploy-readiness.mjs --warn",
+    "cf:check:strict": "node scripts/cf-deploy-readiness.mjs",
+    "cf:pages:build": "pnpm --filter @everycal/web build",
+    "cf:pages:deploy": "wrangler pages deploy packages/web/dist/client --project-name everycal-web --config packages/web/wrangler.toml",
+    "dev:unified": "pnpm --filter @everycal/server dev:unified",
+    "cf:pages:dev": "wrangler pages dev packages/web/dist/client --config packages/web/wrangler.toml",
+    "test:parity": "pnpm --filter @everycal/runtime-core test && pnpm --filter @everycal/cloudflare-worker test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "cf:pages:deploy": "wrangler pages deploy packages/web/dist/client --project-name everycal-web --config packages/web/wrangler.toml",
     "dev:unified": "pnpm --filter @everycal/server dev:unified",
     "cf:pages:dev": "wrangler pages dev packages/web/dist/client --config packages/web/wrangler.toml",
-    "test:parity": "pnpm --filter @everycal/runtime-core test && pnpm --filter @everycal/cloudflare-worker test"
+    "test:parity": "pnpm --filter @everycal/runtime-core test && pnpm --filter @everycal/cloudflare-worker test",
+    "cf:bootstrap": "node scripts/cf-bootstrap.mjs",
+    "cf:bootstrap:apply": "node scripts/cf-bootstrap.mjs --apply"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
     "test:parity": "pnpm --filter @everycal/runtime-core test && pnpm --filter @everycal/cloudflare-worker test",
     "cf:bootstrap": "node scripts/cf-bootstrap.mjs",
     "cf:bootstrap:apply": "node scripts/cf-bootstrap.mjs --apply",
-    "cf:bootstrap:deploy": "node scripts/cf-bootstrap.mjs --apply --deploy"
+    "cf:bootstrap:deploy": "node scripts/cf-bootstrap.mjs --apply --deploy",
+    "cf:migrate:prod": "wrangler d1 migrations apply everycal-prod --config .generated/wrangler.prod.toml",
+    "cf:deploy:prod": "wrangler deploy --config .generated/wrangler.prod.toml",
+    "cf:pages:deploy:prod": "wrangler pages deploy packages/web/dist/client --project-name everycal-web --config .generated/packages.web.wrangler.prod.toml",
+    "cf:go-live-gate": "node scripts/cf-go-live-gate.mjs"
   }
 }

--- a/packages/cloudflare-worker/migrations/0001_init.sql
+++ b/packages/cloudflare-worker/migrations/0001_init.sql
@@ -1,0 +1,120 @@
+CREATE TABLE IF NOT EXISTS accounts (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  account_type TEXT NOT NULL DEFAULT 'person' CHECK(account_type IN ('person','identity')),
+  display_name TEXT,
+  bio TEXT,
+  avatar_url TEXT,
+  password_hash TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  expires_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_account ON sessions(account_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  description TEXT,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  visibility TEXT NOT NULL DEFAULT 'public' CHECK(visibility IN ('public','unlisted','followers_only','private')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_account_start ON events(account_id, start_date);
+
+CREATE TABLE IF NOT EXISTS uploads (
+  id TEXT PRIMARY KEY,
+  object_key TEXT NOT NULL UNIQUE,
+  content_type TEXT NOT NULL,
+  created_by_account_id TEXT REFERENCES accounts(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS identity_memberships (
+  identity_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  member_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK(role IN ('owner','editor')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (identity_account_id, member_account_id)
+);
+
+CREATE TABLE IF NOT EXISTS remote_follows (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  follower_actor_uri TEXT NOT NULL,
+  follower_inbox TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, follower_actor_uri)
+);
+
+
+CREATE TABLE IF NOT EXISTS follows (
+  follower_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  following_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (follower_id, following_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_follows_follower ON follows(follower_id);
+CREATE INDEX IF NOT EXISTS idx_follows_following ON follows(following_id);
+
+CREATE TABLE IF NOT EXISTS saved_locations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  address TEXT,
+  latitude REAL,
+  longitude REAL,
+  used_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(account_id, name, address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_locations_account ON saved_locations(account_id, used_at DESC);
+
+
+CREATE TABLE IF NOT EXISTS remote_actors (
+  uri TEXT PRIMARY KEY,
+  preferred_username TEXT NOT NULL,
+  display_name TEXT,
+  inbox TEXT,
+  icon_url TEXT,
+  domain TEXT NOT NULL,
+  last_fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_actors_domain ON remote_actors(domain);
+
+CREATE TABLE IF NOT EXISTS remote_events (
+  uri TEXT PRIMARY KEY,
+  actor_uri TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  fetched_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_events_actor ON remote_events(actor_uri);
+CREATE INDEX IF NOT EXISTS idx_remote_events_start ON remote_events(start_date);
+
+
+CREATE TABLE IF NOT EXISTS remote_following (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  actor_uri TEXT NOT NULL,
+  actor_inbox TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, actor_uri)
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_following_account ON remote_following(account_id);

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@everycal/cloudflare-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "wrangler deploy --dry-run",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "migrate": "wrangler d1 migrations apply everycal",
+    "test": "vitest run",
+    "lint": "tsc -b --pretty false"
+  },
+  "dependencies": {
+    "@everycal/core": "workspace:*",
+    "hono": "^4.12.2",
+    "@everycal/runtime-core": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/cloudflare-worker/src/federation.test.ts
+++ b/packages/cloudflare-worker/src/federation.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { syncRemoteActorAndEvents, verifyInboxRequest } from "./federation";
+
+const upsertRemoteActor = vi.fn(async () => undefined);
+const upsertRemoteEvent = vi.fn(async () => undefined);
+const dbRun = vi.fn(async () => ({ success: true }));
+const dbBind = vi.fn(() => ({ run: dbRun }));
+const dbPrepare = vi.fn(() => ({ bind: dbBind }));
+
+vi.mock("./storage", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("./storage")>();
+  return {
+    ...mod,
+    CloudflareStorage: vi.fn().mockImplementation(() => ({
+      upsertRemoteActor,
+      upsertRemoteEvent,
+    })),
+  };
+});
+
+describe("syncRemoteActorAndEvents", () => {
+  beforeEach(() => {
+    upsertRemoteActor.mockReset();
+    upsertRemoteEvent.mockReset();
+    dbRun.mockReset();
+    dbBind.mockReset();
+    dbPrepare.mockReset();
+    dbPrepare.mockImplementation(() => ({ bind: dbBind }));
+    dbBind.mockImplementation(() => ({ run: dbRun }));
+    vi.unstubAllGlobals();
+  });
+
+  it("syncs paginated outbox events and upserts each event", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        preferredUsername: "bob",
+        name: "Bob",
+        inbox: "https://remote.example/inbox",
+        outbox: "https://remote.example/users/bob/outbox",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        orderedItems: [
+          { object: { type: "Event", id: "https://remote.example/events/1", name: "A", startTime: "2030-01-01T00:00:00.000Z" } },
+        ],
+        next: "https://remote.example/users/bob/outbox?page=2",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        orderedItems: [
+          { object: { type: "Event", id: "https://remote.example/events/2", name: "B", startTime: "2030-01-02T00:00:00.000Z" } },
+        ],
+      }), { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await syncRemoteActorAndEvents({
+      env: {
+        BASE_URL: "https://calendar.example",
+        DB: { prepare: dbPrepare },
+        UPLOADS: { put: vi.fn(), get: vi.fn() },
+      } as never,
+      actorUri: "https://remote.example/users/bob",
+    });
+
+    expect(result.actor?.uri).toBe("https://remote.example/users/bob");
+    expect(result.eventsSynced).toBe(2);
+    expect(upsertRemoteActor).toHaveBeenCalledTimes(1);
+    expect(upsertRemoteEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("prunes stale remote events when sync traversal completes", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        preferredUsername: "bob",
+        name: "Bob",
+        inbox: "https://remote.example/inbox",
+        outbox: "https://remote.example/users/bob/outbox",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        orderedItems: [
+          { object: { type: "Event", id: "https://remote.example/events/1", name: "A", startTime: "2030-01-01T00:00:00.000Z" } },
+        ],
+      }), { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncRemoteActorAndEvents({
+      env: {
+        BASE_URL: "https://calendar.example",
+        DB: { prepare: dbPrepare },
+        UPLOADS: { put: vi.fn(), get: vi.fn() },
+      } as never,
+      actorUri: "https://remote.example/users/bob",
+    });
+
+    expect(dbPrepare).toHaveBeenCalledWith(expect.stringContaining("DELETE FROM remote_events WHERE actor_uri = ?1 AND uri NOT IN"));
+    expect(dbBind).toHaveBeenCalledWith("https://remote.example/users/bob", "https://remote.example/events/1");
+  });
+
+  it("does not prune stale events when outbox traversal is incomplete", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        preferredUsername: "bob",
+        name: "Bob",
+        inbox: "https://remote.example/inbox",
+        outbox: "https://remote.example/users/bob/outbox",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncRemoteActorAndEvents({
+      env: {
+        BASE_URL: "https://calendar.example",
+        DB: { prepare: dbPrepare },
+        UPLOADS: { put: vi.fn(), get: vi.fn() },
+      } as never,
+      actorUri: "https://remote.example/users/bob",
+    });
+
+    const pruneCall = dbPrepare.mock.calls.find((args) => String(args[0]).includes("uri NOT IN"));
+    expect(pruneCall).toBeUndefined();
+  });
+
+  it("removes deleted events from remote cache when Delete activities are received", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        preferredUsername: "bob",
+        name: "Bob",
+        inbox: "https://remote.example/inbox",
+        outbox: "https://remote.example/users/bob/outbox",
+      }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        orderedItems: [
+          { type: "Delete", object: "https://remote.example/events/old" },
+        ],
+      }), { status: 200 }));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await syncRemoteActorAndEvents({
+      env: {
+        BASE_URL: "https://calendar.example",
+        DB: { prepare: dbPrepare },
+        UPLOADS: { put: vi.fn(), get: vi.fn() },
+      } as never,
+      actorUri: "https://remote.example/users/bob",
+    });
+
+    expect(dbPrepare).toHaveBeenCalledWith(expect.stringContaining("DELETE FROM remote_events WHERE actor_uri = ?1 AND uri IN"));
+    expect(dbBind).toHaveBeenCalledWith("https://remote.example/users/bob", "https://remote.example/events/old");
+  });
+
+
+});
+
+describe("verifyInboxRequest", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("rejects signatures missing required signed headers", async () => {
+    const req = new Request("https://calendar.example/inbox", {
+      method: "POST",
+      headers: {
+        signature: 'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",headers="host",signature="abc"',
+      },
+      body: JSON.stringify({ type: "Follow" }),
+    });
+
+    const result = await verifyInboxRequest({ request: req, activity: { actor: "https://remote.example/users/alice" } });
+    expect(result).toEqual({ ok: false, status: 401, error: "missing_required_signature_headers" });
+  });
+
+  it("rejects signatures whose keyId does not match actor", async () => {
+    const req = new Request("https://calendar.example/inbox", {
+      method: "POST",
+      headers: {
+        signature: 'keyId="https://remote.example/users/bob#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc"',
+      },
+      body: JSON.stringify({ type: "Follow" }),
+    });
+
+    const result = await verifyInboxRequest({ request: req, activity: { actor: "https://remote.example/users/alice" } });
+    expect(result).toEqual({ ok: false, status: 401, error: "key_mismatch" });
+  });
+
+  it("rejects unsupported signature algorithm", async () => {
+    const req = new Request("https://calendar.example/inbox", {
+      method: "POST",
+      headers: {
+        signature: 'keyId="https://remote.example/users/alice#main-key",algorithm="ed25519",headers="(request-target) host date digest",signature="abc"',
+      },
+      body: JSON.stringify({ type: "Follow", actor: "https://remote.example/users/alice" }),
+    });
+
+    const result = await verifyInboxRequest({ request: req, activity: { actor: "https://remote.example/users/alice" } });
+    expect(result).toEqual({ ok: false, status: 401, error: "unsupported_signature_algorithm" });
+  });
+
+  it("rejects stale signature date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2030-01-01T00:10:00.000Z"));
+    const body = JSON.stringify({ type: "Follow", actor: "https://remote.example/users/alice" });
+    const digestBytes = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(body));
+    const digest = btoa(String.fromCharCode(...new Uint8Array(digestBytes)));
+
+    const req = new Request("https://calendar.example/inbox", {
+      method: "POST",
+      headers: {
+        signature: 'keyId="https://remote.example/users/alice#main-key",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="abc="',
+        digest: `SHA-256=${digest}`,
+        date: "Tue, 01 Jan 2030 00:00:00 GMT",
+      },
+      body,
+    });
+
+    const result = await verifyInboxRequest({ request: req, activity: { actor: "https://remote.example/users/alice" } });
+    expect(result).toEqual({ ok: false, status: 401, error: "stale_or_invalid_date" });
+  });
+});

--- a/packages/cloudflare-worker/src/federation.ts
+++ b/packages/cloudflare-worker/src/federation.ts
@@ -1,0 +1,321 @@
+import type { DeliveryResult, InboxVerificationResult, RemoteEventSummary, SyncResult } from "@everycal/runtime-core";
+import type { CloudflareBindings } from "./storage";
+import { CloudflareStorage } from "./storage";
+
+type SignatureParts = {
+  keyId: string;
+  algorithm: string;
+  headers: string[];
+  signature: string;
+  hasRequiredHeaders: boolean;
+};
+
+const SIGNATURE_DATE_TOLERANCE_MS = 5 * 60 * 1000;
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const base64 = pem.replace(/-----BEGIN[^-]+-----/g, "").replace(/-----END[^-]+-----/g, "").replace(/\s+/g, "");
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes.buffer;
+}
+
+function parseSignatureHeader(value: string | null): SignatureParts | null {
+  if (!value) return null;
+  const map = new Map<string, string>();
+  for (const part of value.split(",")) {
+    const separator = part.indexOf("=");
+    if (separator <= 0) continue;
+    const key = part.slice(0, separator).trim();
+    const rawValue = part.slice(separator + 1).trim();
+    if (!key || !rawValue) continue;
+    map.set(key, rawValue.replace(/^"|"$/g, ""));
+  }
+  const keyId = map.get("keyId");
+  const algorithm = map.get("algorithm") || "";
+  const signature = map.get("signature");
+  const headers = (map.get("headers") || "(request-target) host date digest").split(/\s+/).filter(Boolean);
+  const hasRequiredHeaders = ["(request-target)", "host", "date", "digest"].every((required) => headers.includes(required));
+  if (!keyId || !signature || !algorithm) return null;
+  return { keyId, algorithm, signature, headers, hasRequiredHeaders };
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let s = "";
+  bytes.forEach((b) => {
+    s += String.fromCharCode(b);
+  });
+  return btoa(s);
+}
+
+function fromBase64(value: string): Uint8Array {
+  const b = atob(value);
+  const out = new Uint8Array(b.length);
+  for (let i = 0; i < b.length; i += 1) out[i] = b.charCodeAt(i);
+  return out;
+}
+
+async function sha256Base64(content: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(content));
+  return toBase64(new Uint8Array(digest));
+}
+
+function buildSigningString(headers: string[], request: Request, digestHeader: string): string {
+  const url = new URL(request.url);
+  const pathAndQuery = `${url.pathname}${url.search}`;
+  return headers.map((h) => {
+    const name = h.toLowerCase();
+    if (name === "(request-target)") return `(request-target): ${request.method.toLowerCase()} ${pathAndQuery}`;
+    if (name === "host") return `host: ${url.host}`;
+    if (name === "digest") return `digest: ${digestHeader}`;
+    return `${name}: ${request.headers.get(name) || ""}`;
+  }).join("\n");
+}
+
+function isKeyIdOwnedByActor(keyId: string, actorUri: string): boolean {
+  return keyId === actorUri || keyId.startsWith(`${actorUri}#`);
+}
+
+function isRecentDateHeader(value: string | null): boolean {
+  if (!value) return false;
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) return false;
+  return Math.abs(Date.now() - parsed) <= SIGNATURE_DATE_TOLERANCE_MS;
+}
+
+async function resolveRemoteActorDocument(actorUri: string): Promise<Record<string, unknown> | null> {
+
+  const res = await fetch(actorUri, {
+    headers: {
+      accept: "application/activity+json, application/ld+json",
+      "user-agent": "everycal-worker/0.1",
+    },
+  });
+  if (!res.ok) return null;
+  return await res.json<Record<string, unknown>>();
+}
+
+
+function extractOutboxItems(payload: Record<string, unknown>): Record<string, unknown>[] {
+  const orderedItems = Array.isArray(payload.orderedItems) ? payload.orderedItems : [];
+  return orderedItems.filter((value): value is Record<string, unknown> => Boolean(value && typeof value === "object"));
+}
+
+function extractNextPage(payload: Record<string, unknown>): string | null {
+  const next = payload.next;
+  return typeof next === "string" ? next : null;
+}
+
+
+function extractDeleteEventUri(activity: Record<string, unknown>): string | null {
+  if (activity.type !== "Delete") return null;
+  const object = activity.object;
+  if (typeof object === "string") return object;
+  if (object && typeof object === "object" && typeof (object as Record<string, unknown>).id === "string") {
+    return (object as Record<string, unknown>).id as string;
+  }
+  return null;
+}
+
+async function pruneRemoteEventsForActor(env: CloudflareBindings, actorUri: string, activeUris: string[]): Promise<void> {
+  if (activeUris.length === 0) {
+    await env.DB.prepare("DELETE FROM remote_events WHERE actor_uri = ?1").bind(actorUri).run();
+    return;
+  }
+  const placeholders = activeUris.map((_, i) => `?${i + 2}`).join(",");
+  const query = `DELETE FROM remote_events WHERE actor_uri = ?1 AND uri NOT IN (${placeholders})`;
+  await env.DB.prepare(query).bind(actorUri, ...activeUris).run();
+}
+
+async function removeRemoteEventsByUri(env: CloudflareBindings, actorUri: string, uris: Set<string>): Promise<void> {
+  if (uris.size === 0) return;
+  const values = [...uris];
+  const placeholders = values.map((_, i) => `?${i + 2}`).join(",");
+  const query = `DELETE FROM remote_events WHERE actor_uri = ?1 AND uri IN (${placeholders})`;
+  await env.DB.prepare(query).bind(actorUri, ...values).run();
+}
+
+function actorToSummary(actorUri: string, doc: Record<string, unknown>) {
+  const username = String(doc.preferredUsername || actorUri.split("/").pop() || "remote");
+  const inbox = typeof doc.inbox === "string" ? doc.inbox : null;
+  const icon = doc.icon as Record<string, unknown> | undefined;
+  const iconUrl = icon && typeof icon.url === "string" ? icon.url : null;
+  const host = new URL(actorUri).host;
+  return {
+    uri: actorUri,
+    username,
+    displayName: typeof doc.name === "string" ? doc.name : null,
+    domain: host,
+    inbox,
+    iconUrl,
+  };
+}
+
+export async function verifyInboxRequest(input: {
+  request: Request;
+  activity: { actor?: string };
+}): Promise<InboxVerificationResult> {
+  const actorUri = input.activity.actor;
+  if (!actorUri) return { ok: false, status: 400, error: "missing_actor" };
+
+  const signature = parseSignatureHeader(input.request.headers.get("signature"));
+  if (!signature) return { ok: false, status: 401, error: "missing_signature" };
+  if (signature.algorithm.toLowerCase() !== "rsa-sha256") return { ok: false, status: 401, error: "unsupported_signature_algorithm" };
+  if (!signature.hasRequiredHeaders) return { ok: false, status: 401, error: "missing_required_signature_headers" };
+  if (!isKeyIdOwnedByActor(signature.keyId, actorUri)) return { ok: false, status: 401, error: "key_mismatch" };
+
+  if (!isRecentDateHeader(input.request.headers.get("date"))) {
+    return { ok: false, status: 401, error: "stale_or_invalid_date" };
+  }
+
+  const digestHeader = input.request.headers.get("digest") || "";
+  const body = await input.request.clone().text();
+  const expected = `SHA-256=${await sha256Base64(body)}`;
+  if (digestHeader !== expected) return { ok: false, status: 401, error: "invalid_digest" };
+
+  const actorDoc = await resolveRemoteActorDocument(actorUri);
+  const publicKeyRecord = actorDoc?.publicKey as Record<string, unknown> | undefined;
+  const publicKey = publicKeyRecord?.publicKeyPem;
+  const keyOwner = typeof publicKeyRecord?.owner === "string" ? publicKeyRecord.owner : null;
+  const keyId = typeof publicKeyRecord?.id === "string" ? publicKeyRecord.id : null;
+  if (!actorDoc || typeof publicKey !== "string") return { ok: false, status: 401, error: "missing_public_key" };
+  if (keyOwner !== actorUri || keyId !== signature.keyId) {
+    return { ok: false, status: 401, error: "untrusted_public_key" };
+  }
+
+  const verifyKey = await crypto.subtle.importKey(
+    "spki",
+    pemToArrayBuffer(publicKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+
+  const signingString = buildSigningString(signature.headers, input.request, digestHeader);
+  const valid = await crypto.subtle.verify(
+    "RSASSA-PKCS1-v1_5",
+    verifyKey,
+    fromBase64(signature.signature),
+    new TextEncoder().encode(signingString)
+  );
+
+  return valid ? { ok: true } : { ok: false, status: 401, error: "invalid_signature" };
+}
+
+export async function deliverActivity(input: {
+  env: CloudflareBindings;
+  inbox: string;
+  activity: Record<string, unknown>;
+  actorKeyId: string;
+}): Promise<DeliveryResult> {
+  if (!input.env.ACTIVITYPUB_PRIVATE_KEY_PEM) {
+    return { ok: false, status: 500, error: "missing_activitypub_private_key" };
+  }
+
+  const payload = JSON.stringify(input.activity);
+  const date = new Date().toUTCString();
+  const digest = `SHA-256=${await sha256Base64(payload)}`;
+  const url = new URL(input.inbox);
+  const signingString = [
+    `(request-target): post ${url.pathname}${url.search}`,
+    `host: ${url.host}`,
+    `date: ${date}`,
+    `digest: ${digest}`,
+  ].join("\n");
+
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToArrayBuffer(input.env.ACTIVITYPUB_PRIVATE_KEY_PEM),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, new TextEncoder().encode(signingString));
+  const signature = toBase64(new Uint8Array(sig));
+
+  const signatureHeader = `keyId="${input.actorKeyId}",algorithm="rsa-sha256",headers="(request-target) host date digest",signature="${signature}"`;
+
+  const res = await fetch(input.inbox, {
+    method: "POST",
+    headers: {
+      "content-type": "application/activity+json",
+      date,
+      digest,
+      signature: signatureHeader,
+    },
+    body: payload,
+  });
+  return res.ok ? { ok: true, status: res.status } : { ok: false, status: res.status, error: `delivery_failed_${res.status}` };
+}
+
+export async function syncRemoteActorAndEvents(input: {
+  env: CloudflareBindings;
+  actorUri: string;
+}): Promise<SyncResult> {
+  const storage = new CloudflareStorage(input.env);
+  const actorDoc = await resolveRemoteActorDocument(input.actorUri);
+  if (!actorDoc) return { actor: null, eventsSynced: 0 };
+
+  const actor = actorToSummary(input.actorUri, actorDoc);
+  if (!actor.inbox) return { actor: null, eventsSynced: 0 };
+  await storage.upsertRemoteActor({ ...actor, inbox: actor.inbox });
+
+  let eventsSynced = 0;
+  const seenEventUris = new Set<string>();
+  const deletedEventUris = new Set<string>();
+  const outbox = typeof actorDoc.outbox === "string" ? actorDoc.outbox : null;
+  let traversalComplete = true;
+
+  if (outbox) {
+    let nextUrl: string | null = outbox;
+    const visited = new Set<string>();
+    let pagesFetched = 0;
+
+    while (nextUrl && pagesFetched < 5 && !visited.has(nextUrl)) {
+      visited.add(nextUrl);
+      pagesFetched += 1;
+      const outboxRes = await fetch(nextUrl, { headers: { accept: "application/activity+json, application/ld+json" } });
+      if (!outboxRes.ok) {
+        traversalComplete = false;
+        break;
+      }
+
+      const payload = await outboxRes.json<Record<string, unknown>>();
+      const items = extractOutboxItems(payload);
+      for (const activity of items) {
+        const deleteUri = extractDeleteEventUri(activity);
+        if (deleteUri) {
+          deletedEventUris.add(deleteUri);
+          continue;
+        }
+
+        const object = (activity.object && typeof activity.object === "object") ? activity.object as Record<string, unknown> : null;
+        if (!object || object.type !== "Event" || typeof object.id !== "string") continue;
+        const startDate = typeof object.startTime === "string" ? object.startTime : null;
+        if (!startDate) continue;
+        seenEventUris.add(object.id);
+        const event: RemoteEventSummary = {
+          uri: object.id,
+          actorUri: input.actorUri,
+          title: typeof object.name === "string" ? object.name : "Untitled",
+          description: typeof object.content === "string" ? object.content : null,
+          startDate,
+          endDate: typeof object.endTime === "string" ? object.endTime : null,
+        };
+        await storage.upsertRemoteEvent(event);
+        eventsSynced += 1;
+      }
+
+      nextUrl = extractNextPage(payload);
+    }
+
+    if (nextUrl && pagesFetched >= 5) traversalComplete = false;
+  }
+
+  await removeRemoteEventsByUri(input.env, input.actorUri, deletedEventUris);
+  if (traversalComplete && outbox) {
+    await pruneRemoteEventsForActor(input.env, input.actorUri, [...seenEventUris]);
+  }
+
+  return { actor: { ...actor, inbox: actor.inbox }, eventsSynced };
+}

--- a/packages/cloudflare-worker/src/index.test.ts
+++ b/packages/cloudflare-worker/src/index.test.ts
@@ -104,6 +104,27 @@ describe("cloudflare worker entry", () => {
     expect(createUnifiedApp).not.toHaveBeenCalled();
   });
 
+
+  it("deploy-readiness fails when configured service binding healthcheck fails", async () => {
+    const request = new Request("https://calendar.example/api/v1/system/deploy-readiness");
+    const env = {
+      BASE_URL: "https://calendar.example",
+      CORS_ORIGIN: "https://app.example",
+      ACTIVITYPUB_PRIVATE_KEY_PEM: "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      JOBS_QUEUE: { send: vi.fn() },
+      REMINDERS_SERVICE: { fetch: vi.fn(async () => new Response(JSON.stringify({ ok: false }), { status: 200, headers: { "content-type": "application/json" } })) },
+      SCRAPERS_WEBHOOK_URL: "https://jobs.example/scrapers",
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+    const payload = await response.json() as { ok: boolean; checks: Array<{ id: string; ok: boolean }> };
+
+    expect(response.status).toBe(503);
+    expect(payload.ok).toBe(false);
+    expect(payload.checks.find((check) => check.id === "reminders_executor_behavior")?.ok).toBe(false);
+  });
   it("returns deploy-readiness failure when required wiring is missing", async () => {
     const request = new Request("https://calendar.example/api/v1/system/deploy-readiness");
     const env = {

--- a/packages/cloudflare-worker/src/index.test.ts
+++ b/packages/cloudflare-worker/src/index.test.ts
@@ -1,0 +1,528 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const appFetch = vi.fn();
+const createUnifiedApp = vi.fn(() => ({ fetch: appFetch }));
+const renderWorkerHtml = vi.fn();
+const verifyInboxRequest = vi.fn(async () => ({ ok: true }));
+const deliverActivity = vi.fn(async () => ({ ok: true }));
+const syncRemoteActorAndEvents = vi.fn(async () => ({ actor: null, eventsSynced: 0 }));
+const fetchMock = vi.fn();
+
+vi.mock("@everycal/runtime-core", () => ({
+  createUnifiedApp,
+}));
+
+vi.mock("./ssr", () => ({
+  renderWorkerHtml,
+}));
+
+vi.mock("./federation", () => ({
+  verifyInboxRequest,
+  deliverActivity,
+  syncRemoteActorAndEvents,
+}));
+
+import worker from "./index";
+
+describe("cloudflare worker entry", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    appFetch.mockReset();
+    createUnifiedApp.mockClear();
+    renderWorkerHtml.mockReset();
+    verifyInboxRequest.mockClear();
+    deliverActivity.mockClear();
+    syncRemoteActorAndEvents.mockClear();
+    fetchMock.mockReset();
+  });
+
+  it("returns SSR HTML response when available", async () => {
+    const expected = new Response("<html>ok</html>", { status: 200, headers: { "content-type": "text/html" } });
+    renderWorkerHtml.mockResolvedValueOnce(expected);
+
+    const request = new Request("https://calendar.example/", { headers: { accept: "text/html" } });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn(() => ({ bind: vi.fn(() => ({ run: vi.fn(async () => ({ success: true })) })) })) },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+    expect(renderWorkerHtml).toHaveBeenCalledWith(request, env);
+    expect(createUnifiedApp).not.toHaveBeenCalled();
+  });
+
+  it("falls back to unified API app when SSR returns null", async () => {
+    renderWorkerHtml.mockResolvedValueOnce(null);
+    const fallback = new Response(JSON.stringify({ ok: true }), { status: 200, headers: { "content-type": "application/json" } });
+    appFetch.mockResolvedValueOnce(fallback);
+
+    const request = new Request("https://calendar.example/api/v1/bootstrap", { headers: { accept: "application/json" } });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn(() => ({ bind: vi.fn(() => ({ run: vi.fn(async () => ({ success: true })) })) })) },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      SESSION_COOKIE_NAME: "everycal_session",
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const ctx = {} as ExecutionContext;
+    const response = await worker.fetch(request, env, ctx);
+
+    expect(renderWorkerHtml).toHaveBeenCalledWith(request, env);
+    expect(createUnifiedApp).toHaveBeenCalledTimes(1);
+    expect(appFetch).toHaveBeenCalledWith(request, env, ctx);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("x-frame-options")).toBe("DENY");
+  });
+
+  it("returns deploy-readiness success when required Cloudflare runtime wiring is present", async () => {
+    const request = new Request("https://calendar.example/api/v1/system/deploy-readiness");
+    const env = {
+      BASE_URL: "https://calendar.example",
+      CORS_ORIGIN: "https://app.example",
+      ACTIVITYPUB_PRIVATE_KEY_PEM: "-----BEGIN PRIVATE KEY-----\\nabc\\n-----END PRIVATE KEY-----",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      JOBS_QUEUE: { send: vi.fn() },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+      SCRAPERS_WEBHOOK_URL: "https://jobs.example/scrapers",
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+    const payload = await response.json() as { ok: boolean; summary: { failing: number }; checks: Array<{ id: string; ok: boolean }> };
+
+    expect(response.status).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.summary.failing).toBe(0);
+    expect(payload.checks.every((check) => check.ok)).toBe(true);
+    expect(renderWorkerHtml).not.toHaveBeenCalled();
+    expect(createUnifiedApp).not.toHaveBeenCalled();
+  });
+
+  it("returns deploy-readiness failure when required wiring is missing", async () => {
+    const request = new Request("https://calendar.example/api/v1/system/deploy-readiness");
+    const env = {
+      BASE_URL: "https://example.workers.dev",
+      CORS_ORIGIN: "https://example.pages.dev",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+    const payload = await response.json() as { ok: boolean; summary: { failing: number }; checks: Array<{ id: string; ok: boolean }> };
+
+    expect(response.status).toBe(503);
+    expect(payload.ok).toBe(false);
+    expect(payload.summary.failing).toBeGreaterThan(0);
+    expect(payload.checks.some((check) => !check.ok)).toBe(true);
+    expect(renderWorkerHtml).not.toHaveBeenCalled();
+    expect(createUnifiedApp).not.toHaveBeenCalled();
+  });
+
+
+
+  it("handles API CORS preflight for allowed origins", async () => {
+    const request = new Request("https://calendar.example/api/v1/bootstrap", {
+      method: "OPTIONS",
+      headers: {
+        origin: "https://app.example",
+        "access-control-request-method": "POST",
+        "access-control-request-headers": "content-type,authorization",
+      },
+    });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      CORS_ORIGIN: "https://app.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://app.example");
+    expect(createUnifiedApp).not.toHaveBeenCalled();
+  });
+
+  it("adds CORS response headers on API responses", async () => {
+    renderWorkerHtml.mockResolvedValueOnce(null);
+    appFetch.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const request = new Request("https://calendar.example/api/v1/bootstrap", {
+      headers: { origin: "https://app.example" },
+    });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      CORS_ORIGIN: "https://app.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://app.example");
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+  });
+
+  it("rejects oversized non-upload request bodies", async () => {
+    const request = new Request("https://calendar.example/api/v1/events", {
+      method: "POST",
+      headers: { "content-length": String(1024 * 1024 + 1) },
+      body: "x",
+    });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({ error: "request_body_too_large" });
+    expect(createUnifiedApp).not.toHaveBeenCalled();
+  });
+
+
+
+  it("adds rate-limit headers on limited routes", async () => {
+    renderWorkerHtml.mockResolvedValueOnce(null);
+    appFetch.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const request = new Request("https://calendar.example/api/v1/auth/login", {
+      headers: { "cf-connecting-ip": "198.51.100.10" },
+    });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-ratelimit-limit")).toBe("10");
+    expect(response.headers.get("x-ratelimit-remaining")).toBe("9");
+    expect(response.headers.get("x-ratelimit-reset")).toBeTruthy();
+    expect(response.headers.get("x-ratelimit-scope")).toBe("local");
+  });
+
+
+
+  it("uses global rate limits when KV binding is configured", async () => {
+    renderWorkerHtml.mockResolvedValue(null);
+    appFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const kv = {
+      get: vi.fn(async () => "10"),
+      put: vi.fn(async () => undefined),
+    };
+
+    const request = new Request("https://calendar.example/api/v1/auth/login", {
+      headers: { "cf-connecting-ip": "198.51.100.12" },
+    });
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      RATE_LIMITS_KV: kv,
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toEqual({ error: "too_many_requests" });
+    expect(response.headers.get("x-ratelimit-scope")).toBe("global_kv");
+    expect(kv.get).toHaveBeenCalledTimes(1);
+    expect(kv.put).toHaveBeenCalledTimes(1);
+  });
+
+
+
+  it("prefers durable-object global rate limits when configured", async () => {
+    renderWorkerHtml.mockResolvedValue(null);
+    appFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const doFetch = vi.fn(async () => new Response(JSON.stringify({ count: 11, resetAt: Date.now() + 60_000 }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }));
+    const durable = {
+      idFromName: vi.fn(() => ({}) as never),
+      get: vi.fn(() => ({ fetch: doFetch })),
+    };
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      RATE_LIMITS_DO: durable,
+      RATE_LIMITS_KV: { get: vi.fn(async () => "0"), put: vi.fn(async () => undefined) },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const request = new Request("https://calendar.example/api/v1/auth/login", {
+      headers: { "cf-connecting-ip": "198.51.100.14" },
+    });
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("x-ratelimit-scope")).toBe("global_do");
+    expect(durable.idFromName).toHaveBeenCalledTimes(1);
+    expect(durable.get).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 429 when route-level limit is exceeded", async () => {
+    renderWorkerHtml.mockResolvedValue(null);
+    appFetch.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    let finalResponse: Response | null = null;
+    for (let i = 0; i < 11; i += 1) {
+      const request = new Request("https://calendar.example/api/v1/auth/login", {
+        headers: { "cf-connecting-ip": "198.51.100.11" },
+      });
+      finalResponse = await worker.fetch(request, env, {} as ExecutionContext);
+    }
+
+    expect(finalResponse?.status).toBe(429);
+    expect(await finalResponse?.json()).toEqual({ error: "too_many_requests" });
+    expect(finalResponse?.headers.get("x-ratelimit-limit")).toBe("10");
+    expect(finalResponse?.headers.get("x-ratelimit-remaining")).toBe("0");
+  });
+
+
+
+  it.each([
+    { path: "/api/v1/bootstrap", status: 200, body: { mode: "unified", authenticated: false } },
+    { path: "/api/v1/events", status: 401, body: { error: "unauthorized" } },
+    { path: "/api/v1/auth/me", status: 401, body: { error: "unauthorized" } },
+  ])("preserves runtime-core contract for %s", async ({ path, status, body }) => {
+    renderWorkerHtml.mockResolvedValueOnce(null);
+    appFetch.mockResolvedValueOnce(new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } }));
+
+    const request = new Request(`https://calendar.example${path}`);
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+    } as unknown as Parameters<typeof worker.fetch>[1];
+
+    const response = await worker.fetch(request, env, {} as ExecutionContext);
+
+    expect(response.status).toBe(status);
+    expect(await response.json()).toEqual(body);
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("scheduled cleanup also enqueues reminder and scraper jobs", async () => {
+    const run = vi.fn(async () => ({ success: true }));
+    const bind = vi.fn(() => ({ run }));
+    const prepare = vi.fn(() => ({ bind }));
+    const send = vi.fn(async () => undefined);
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      JOBS_QUEUE: { send },
+    } as unknown as Parameters<typeof worker.scheduled>[1];
+
+    await worker.scheduled({} as ScheduledController, env);
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenNthCalledWith(1, expect.objectContaining({ type: "reminders", attempts: 0, jobId: expect.any(String) }));
+    expect(send).toHaveBeenNthCalledWith(2, expect.objectContaining({ type: "scrapers", attempts: 0, jobId: expect.any(String) }));
+  });
+
+  it("queue handler executes webhook jobs, retries failures, and acks unknown jobs", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    const ackKnown = vi.fn();
+    const retryKnown = vi.fn();
+    const ackUnknown = vi.fn();
+
+    const batch = {
+      messages: [
+        { body: { type: "reminders", attempts: 0 }, ack: ackKnown, retry: retryKnown },
+        { body: { type: "other" }, ack: ackUnknown },
+      ],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+      JOBS_WEBHOOK_TOKEN: "token-123",
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(retryKnown).toHaveBeenCalledTimes(1);
+    expect(retryKnown).toHaveBeenCalledWith({ delaySeconds: 30 });
+    expect(ackKnown).not.toHaveBeenCalled();
+    expect(ackUnknown).toHaveBeenCalledTimes(1);
+  });
+
+
+
+  it("queue handler prefers native service bindings over webhooks", async () => {
+    const ackKnown = vi.fn();
+    const retryKnown = vi.fn();
+    const nativeFetch = vi.fn(async () => new Response(null, { status: 200 }));
+
+    const batch = {
+      messages: [{ body: { type: "reminders", attempts: 0 }, ack: ackKnown, retry: retryKnown }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      REMINDERS_SERVICE: { fetch: nativeFetch },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(nativeFetch).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(ackKnown).toHaveBeenCalledTimes(1);
+    expect(retryKnown).not.toHaveBeenCalled();
+  });
+
+  it("queue handler retries on native service failures", async () => {
+    const ackKnown = vi.fn();
+    const retryKnown = vi.fn();
+    const nativeFetch = vi.fn(async () => new Response(null, { status: 503 }));
+
+    const batch = {
+      messages: [{ body: { type: "scrapers", attempts: 0 }, ack: ackKnown, retry: retryKnown }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      SCRAPERS_SERVICE: { fetch: nativeFetch },
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(nativeFetch).toHaveBeenCalledTimes(1);
+    expect(retryKnown).toHaveBeenCalledTimes(1);
+    expect(ackKnown).not.toHaveBeenCalled();
+  });
+
+
+
+  it("queue handler forwards attempt metadata to webhook payload", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const batch = {
+      messages: [{ body: { type: "reminders", attempts: 1, jobId: "job-123", enqueuedAt: "2030-01-01T00:00:00.000Z" }, ack: vi.fn(), retry: vi.fn() }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    const req = fetchMock.mock.calls[0];
+    const payload = JSON.parse(String(req[1]?.body || "{}"));
+    expect(payload).toEqual(expect.objectContaining({ attempts: 2, jobId: "job-123", enqueuedAt: "2030-01-01T00:00:00.000Z" }));
+  });
+
+  it("uses delivery attempt metadata for retry cap", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    const ackKnown = vi.fn();
+    const retryKnown = vi.fn();
+    const dlqSend = vi.fn(async () => undefined);
+
+    const batch = {
+      messages: [{ body: { type: "reminders", attempts: 0 }, attempts: 3, ack: ackKnown, retry: retryKnown }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+      JOBS_DLQ: { send: dlqSend },
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(dlqSend).toHaveBeenCalledTimes(1);
+    expect(retryKnown).not.toHaveBeenCalled();
+    expect(ackKnown).toHaveBeenCalledTimes(1);
+  });
+
+  it("queue handler acks successful known jobs", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const ackScraper = vi.fn();
+    const retryScraper = vi.fn();
+
+    const batch = {
+      messages: [{ body: { type: "scrapers" }, ack: ackScraper, retry: retryScraper }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      SCRAPERS_WEBHOOK_URL: "https://jobs.example/scrapers",
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(ackScraper).toHaveBeenCalledTimes(1);
+    expect(retryScraper).not.toHaveBeenCalled();
+  });
+
+
+  it("sends exhausted jobs to dead-letter queue and acks", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    const ackKnown = vi.fn();
+    const retryKnown = vi.fn();
+    const dlqSend = vi.fn(async () => undefined);
+
+    const batch = {
+      messages: [{ body: { type: "reminders", attempts: 2 }, ack: ackKnown, retry: retryKnown }],
+    } as unknown as Parameters<typeof worker.queue>[0];
+
+    const env = {
+      BASE_URL: "https://calendar.example",
+      DB: { prepare: vi.fn() },
+      UPLOADS: { put: vi.fn(), get: vi.fn() },
+      REMINDERS_WEBHOOK_URL: "https://jobs.example/reminders",
+      JOBS_DLQ: { send: dlqSend },
+    } as unknown as Parameters<typeof worker.queue>[1];
+
+    await worker.queue(batch, env);
+
+    expect(dlqSend).toHaveBeenCalledTimes(1);
+    expect(retryKnown).not.toHaveBeenCalled();
+    expect(ackKnown).toHaveBeenCalledTimes(1);
+  });
+
+});

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -1,0 +1,546 @@
+import { createUnifiedApp } from "@everycal/runtime-core";
+import { CloudflareStorage, type CloudflareBindings } from "./storage";
+import { hashPassword, verifyPassword } from "./security";
+import { renderWorkerHtml } from "./ssr";
+import { deliverActivity, syncRemoteActorAndEvents, verifyInboxRequest } from "./federation";
+
+type QueueMessageBody = {
+  type?: string;
+  attempts?: number;
+  enqueuedAt?: string;
+  jobId?: string;
+};
+
+type DeployReadinessCheck = {
+  id: string;
+  ok: boolean;
+  detail: string;
+};
+
+const DEFAULT_SECURITY_HEADERS: Record<string, string> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  "Cross-Origin-Opener-Policy": "same-origin",
+};
+
+const DEFAULT_MAX_BODY_BYTES = 1024 * 1024;
+const UPLOAD_MAX_BODY_BYTES = 6 * 1024 * 1024;
+
+function withSecurityHeaders(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [name, value] of Object.entries(DEFAULT_SECURITY_HEADERS)) {
+    if (!headers.has(name)) headers.set(name, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isApiPath(pathname: string): boolean {
+  return pathname.startsWith("/api/");
+}
+
+function isPlaceholderLike(value: string | undefined): boolean {
+  if (!value) return true;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return true;
+  return normalized.includes("replace_with")
+    || normalized.includes("example.com")
+    || normalized.includes("example.workers.dev")
+    || normalized.includes("example.pages.dev");
+}
+
+function evaluateDeployReadiness(env: CloudflareBindings): DeployReadinessCheck[] {
+  return [
+    {
+      id: "base_url",
+      ok: !isPlaceholderLike(env.BASE_URL),
+      detail: "BASE_URL must point to your real public Worker/API origin.",
+    },
+    {
+      id: "cors_origin",
+      ok: !isPlaceholderLike(env.CORS_ORIGIN),
+      detail: "CORS_ORIGIN should include your real frontend origin(s).",
+    },
+    {
+      id: "federation_private_key",
+      ok: Boolean(env.ACTIVITYPUB_PRIVATE_KEY_PEM && env.ACTIVITYPUB_PRIVATE_KEY_PEM.trim()),
+      detail: "ACTIVITYPUB_PRIVATE_KEY_PEM secret must be configured for signed federation delivery.",
+    },
+    {
+      id: "jobs_queue",
+      ok: Boolean(env.JOBS_QUEUE),
+      detail: "JOBS_QUEUE binding is required for scheduled reminders/scrapers dispatch.",
+    },
+    {
+      id: "reminders_executor",
+      ok: Boolean(env.REMINDERS_SERVICE || env.REMINDERS_WEBHOOK_URL),
+      detail: "Configure REMINDERS_SERVICE or REMINDERS_WEBHOOK_URL.",
+    },
+    {
+      id: "scrapers_executor",
+      ok: Boolean(env.SCRAPERS_SERVICE || env.SCRAPERS_WEBHOOK_URL),
+      detail: "Configure SCRAPERS_SERVICE or SCRAPERS_WEBHOOK_URL.",
+    },
+  ];
+}
+
+function maybeHandleDeployReadiness(request: Request, env: CloudflareBindings): Response | null {
+  const url = new URL(request.url);
+  if (request.method !== "GET" || url.pathname !== "/api/v1/system/deploy-readiness") return null;
+
+  const checks = evaluateDeployReadiness(env);
+  const requiredFailures = checks.filter((check) => !check.ok);
+
+  return withSecurityHeaders(new Response(JSON.stringify({
+    ok: requiredFailures.length === 0,
+    summary: {
+      passing: checks.length - requiredFailures.length,
+      failing: requiredFailures.length,
+      total: checks.length,
+    },
+    checks,
+  }), {
+    status: requiredFailures.length === 0 ? 200 : 503,
+    headers: { "content-type": "application/json" },
+  }));
+}
+
+function allowedCorsOrigins(env: CloudflareBindings): string[] {
+  const value = env.CORS_ORIGIN || env.BASE_URL || "";
+  return value.split(",").map((origin) => origin.trim()).filter(Boolean);
+}
+
+function resolveCorsOrigin(request: Request, env: CloudflareBindings): string | null {
+  const origin = request.headers.get("origin");
+  if (!origin) return null;
+  const allowed = allowedCorsOrigins(env);
+  if (allowed.includes("*")) return origin;
+  return allowed.includes(origin) ? origin : null;
+}
+
+function applyCorsHeaders(headers: Headers, request: Request, env: CloudflareBindings): void {
+  const url = new URL(request.url);
+  if (!isApiPath(url.pathname)) return;
+  const origin = resolveCorsOrigin(request, env);
+  if (!origin) return;
+
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set("Vary", "Origin");
+}
+
+function maybeHandleCorsPreflight(request: Request, env: CloudflareBindings): Response | null {
+  const url = new URL(request.url);
+  if (request.method !== "OPTIONS" || !isApiPath(url.pathname)) return null;
+
+  const origin = resolveCorsOrigin(request, env);
+  if (!origin) return new Response(null, { status: 403 });
+
+  const headers = new Headers();
+  headers.set("Access-Control-Allow-Origin", origin);
+  headers.set("Access-Control-Allow-Credentials", "true");
+  headers.set("Access-Control-Allow-Methods", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS");
+  headers.set(
+    "Access-Control-Allow-Headers",
+    request.headers.get("access-control-request-headers") || "content-type, authorization"
+  );
+  headers.set("Access-Control-Max-Age", "86400");
+  headers.set("Vary", "Origin");
+
+  return withSecurityHeaders(new Response(null, { status: 204, headers }));
+}
+
+function getBodySizeLimit(pathname: string): number {
+  return pathname.startsWith("/api/v1/uploads") ? UPLOAD_MAX_BODY_BYTES : DEFAULT_MAX_BODY_BYTES;
+}
+
+function maybeEnforceBodyLimit(request: Request): Response | null {
+  if (!["POST", "PUT", "PATCH"].includes(request.method.toUpperCase())) return null;
+  const url = new URL(request.url);
+  const contentLength = Number.parseInt(request.headers.get("content-length") || "0", 10);
+  if (!Number.isFinite(contentLength)) return null;
+  if (contentLength <= getBodySizeLimit(url.pathname)) return null;
+  return withSecurityHeaders(new Response(JSON.stringify({ error: "request_body_too_large" }), {
+    status: 413,
+    headers: { "content-type": "application/json" },
+  }));
+}
+
+
+type RateLimitPolicy = {
+  max: number;
+  windowMs: number;
+};
+
+type RateLimitState = {
+  count: number;
+  resetAt: number;
+};
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const rateLimitStore = new Map<string, RateLimitState>();
+
+function resolveClientIp(request: Request): string {
+  const cfIp = request.headers.get("cf-connecting-ip")?.trim();
+  if (cfIp) return cfIp;
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  if (forwarded) return forwarded;
+  return "unknown";
+}
+
+function resolveRateLimitPolicy(pathname: string): RateLimitPolicy | null {
+  if (pathname === "/api/v1/auth/login") return { max: 10, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/auth/register") return { max: 10, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/auth/request-email-change") return { max: 5, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/auth/change-password") return { max: 5, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/federation/fetch-actor") return { max: 10, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/federation/search") return { max: 20, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/events/sync") return { max: 60, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname.startsWith("/api/v1/events")) return { max: 30, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/api/v1/images/search") return { max: 60, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname.startsWith("/api/v1/uploads")) return { max: 30, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (pathname === "/inbox") return { max: 60, windowMs: RATE_LIMIT_WINDOW_MS };
+  if (/^\/users\/[^/]+\/inbox$/.test(pathname)) return { max: 60, windowMs: RATE_LIMIT_WINDOW_MS };
+  return null;
+}
+
+function pruneRateLimitStore(now: number): void {
+  for (const [key, value] of rateLimitStore.entries()) {
+    if (value.resetAt <= now) rateLimitStore.delete(key);
+  }
+}
+
+type RateLimitResult = {
+  headers: Headers | null;
+  response: Response | null;
+};
+
+function createRateLimitHeaders(max: number, count: number, resetAt: number, scope: "local" | "global_kv" | "global_do"): Headers {
+  const headers = new Headers();
+  headers.set("X-RateLimit-Limit", String(max));
+  headers.set("X-RateLimit-Remaining", String(Math.max(0, max - count)));
+  headers.set("X-RateLimit-Reset", String(Math.ceil(resetAt / 1000)));
+  headers.set("X-RateLimit-Scope", scope);
+  return headers;
+}
+
+function toBlockedRateLimitResponse(headers: Headers): Response {
+  const blockedHeaders = new Headers(headers);
+  blockedHeaders.set("content-type", "application/json");
+  return withSecurityHeaders(new Response(JSON.stringify({ error: "too_many_requests" }), {
+    status: 429,
+    headers: blockedHeaders,
+  }));
+}
+
+async function evaluateKvRateLimit(request: Request, policy: RateLimitPolicy, env: CloudflareBindings): Promise<RateLimitResult | null> {
+  if (!env.RATE_LIMITS_KV) return null;
+  const now = Date.now();
+  const windowStart = Math.floor(now / policy.windowMs) * policy.windowMs;
+  const resetAt = windowStart + policy.windowMs;
+  const url = new URL(request.url);
+  const key = `rl:v1:${url.pathname}:${resolveClientIp(request)}:${windowStart}`;
+
+  const existing = await env.RATE_LIMITS_KV.get(key);
+  const count = Number.parseInt(existing || "0", 10) + 1;
+  const expirationTtl = Math.max(1, Math.ceil(policy.windowMs / 1000) + 5);
+  await env.RATE_LIMITS_KV.put(key, String(count), { expirationTtl });
+
+  const headers = createRateLimitHeaders(policy.max, count, resetAt, "global_kv");
+  if (count > policy.max) return { headers, response: toBlockedRateLimitResponse(headers) };
+  return { headers, response: null };
+}
+
+type DurableRateLimitResult = {
+  count: number;
+  resetAt: number;
+};
+
+async function evaluateDurableRateLimit(request: Request, policy: RateLimitPolicy, env: CloudflareBindings): Promise<RateLimitResult | null> {
+  if (!env.RATE_LIMITS_DO) return null;
+  const url = new URL(request.url);
+  const ip = resolveClientIp(request);
+  const id = env.RATE_LIMITS_DO.idFromName(`${url.pathname}:${ip}`);
+  const stub = env.RATE_LIMITS_DO.get(id);
+
+  const res = await stub.fetch("https://rate-limit/hit", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ windowMs: policy.windowMs }),
+  });
+
+  if (!res.ok) throw new Error(`rate_limit_do_failed_${res.status}`);
+  const payload = await res.json<DurableRateLimitResult>();
+  const count = Number.isFinite(payload.count) ? Number(payload.count) : policy.max + 1;
+  const resetAt = Number.isFinite(payload.resetAt) ? Number(payload.resetAt) : Date.now() + policy.windowMs;
+
+  const headers = createRateLimitHeaders(policy.max, count, resetAt, "global_do");
+  if (count > policy.max) return { headers, response: toBlockedRateLimitResponse(headers) };
+  return { headers, response: null };
+}
+
+async function evaluateLocalRateLimit(request: Request, policy: RateLimitPolicy): Promise<RateLimitResult> {
+  const now = Date.now();
+  if (rateLimitStore.size > 1000) pruneRateLimitStore(now);
+
+  const url = new URL(request.url);
+  const key = `${resolveClientIp(request)}:${url.pathname}`;
+  let state = rateLimitStore.get(key);
+  if (!state || state.resetAt <= now) {
+    state = { count: 0, resetAt: now + policy.windowMs };
+    rateLimitStore.set(key, state);
+  }
+
+  state.count += 1;
+  const headers = createRateLimitHeaders(policy.max, state.count, state.resetAt, "local");
+  if (state.count > policy.max) return { headers, response: toBlockedRateLimitResponse(headers) };
+  return { headers, response: null };
+}
+
+async function evaluateRateLimit(request: Request, env: CloudflareBindings): Promise<RateLimitResult> {
+  if (request.method.toUpperCase() === "OPTIONS") return { headers: null, response: null };
+  const url = new URL(request.url);
+  const policy = resolveRateLimitPolicy(url.pathname);
+  if (!policy) return { headers: null, response: null };
+
+  const durableResult = await evaluateDurableRateLimit(request, policy, env);
+  if (durableResult) return durableResult;
+
+  const kvResult = await evaluateKvRateLimit(request, policy, env);
+  if (kvResult) return kvResult;
+
+  return evaluateLocalRateLimit(request, policy);
+}
+
+const JOB_TYPES = ["reminders", "scrapers"] as const;
+const MAX_JOB_ATTEMPTS = 3;
+
+type JobType = (typeof JOB_TYPES)[number];
+
+function isJobType(value: string): value is JobType {
+  return JOB_TYPES.includes(value as JobType);
+}
+
+function createApp(env: CloudflareBindings) {
+  return createUnifiedApp({
+    storage: new CloudflareStorage(env),
+    baseUrl: env.BASE_URL,
+    sessionCookieName: env.SESSION_COOKIE_NAME || "everycal_session",
+    hashPassword,
+    verifyPassword,
+    verifyInboxRequest: ({ request, activity }) => verifyInboxRequest({ request, activity }),
+    deliverActivity: ({ inbox, activity, actorKeyId }) => deliverActivity({ env, inbox, activity, actorKeyId }),
+    syncRemoteActorAndEvents: (actorUri) => syncRemoteActorAndEvents({ env, actorUri }),
+  });
+}
+
+async function dispatchScheduledJobs(env: CloudflareBindings): Promise<void> {
+  if (!env.JOBS_QUEUE) return;
+  for (const type of JOB_TYPES) {
+    await env.JOBS_QUEUE.send({ type, attempts: 0, enqueuedAt: new Date().toISOString(), jobId: crypto.randomUUID() });
+  }
+}
+
+function getNativeJobService(type: JobType, env: CloudflareBindings): Fetcher | null {
+  if (type === "reminders") return env.REMINDERS_SERVICE || null;
+  if (type === "scrapers") return env.SCRAPERS_SERVICE || null;
+  return null;
+}
+
+function getNativeJobPath(type: JobType): string {
+  return `/jobs/${type}`;
+}
+
+async function runNativeQueueJob(type: JobType, env: CloudflareBindings, message: QueueMessageBody, attempts: number): Promise<boolean> {
+  const service = getNativeJobService(type, env);
+  if (!service) return false;
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (env.JOBS_WEBHOOK_TOKEN) headers.authorization = `Bearer ${env.JOBS_WEBHOOK_TOKEN}`;
+
+  const res = await service.fetch(`https://internal.everycal${getNativeJobPath(type)}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ type, source: "cloudflare-queue-native", at: new Date().toISOString(), attempts, jobId: message.jobId || null, enqueuedAt: message.enqueuedAt || null }),
+  });
+
+  if (!res.ok) throw new Error(`job_native_failed_${type}_${res.status}`);
+  return true;
+}
+
+function getJobWebhookUrl(type: JobType, env: CloudflareBindings): string | null {
+  if (type === "reminders") return env.REMINDERS_WEBHOOK_URL || null;
+  if (type === "scrapers") return env.SCRAPERS_WEBHOOK_URL || null;
+  return null;
+}
+
+async function runQueueJob(type: JobType, env: CloudflareBindings, message: QueueMessageBody, attempts: number): Promise<void> {
+  const ranNatively = await runNativeQueueJob(type, env, message, attempts);
+  if (ranNatively) return;
+
+  const webhookUrl = getJobWebhookUrl(type, env);
+  if (!webhookUrl) {
+    console.log(`[queue] ${type} skipped: no native service or webhook configured`);
+    return;
+  }
+
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (env.JOBS_WEBHOOK_TOKEN) headers.authorization = `Bearer ${env.JOBS_WEBHOOK_TOKEN}`;
+
+  const res = await fetch(webhookUrl, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ type, source: "cloudflare-queue-webhook", at: new Date().toISOString(), attempts, jobId: message.jobId || null, enqueuedAt: message.enqueuedAt || null }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`job_webhook_failed_${type}_${res.status}`);
+  }
+}
+
+
+function readAttemptCount(value: unknown): number | null {
+  if (!Number.isFinite(value)) return null;
+  const count = Number(value);
+  if (count < 0) return null;
+  return Math.floor(count);
+}
+
+function resolveJobAttempts(message: { body?: QueueMessageBody; attempts?: number }): number {
+  const deliveryAttempt = readAttemptCount(message.attempts);
+  if (deliveryAttempt !== null) return deliveryAttempt;
+  const payloadAttempts = readAttemptCount(message.body?.attempts);
+  return (payloadAttempts ?? 0) + 1;
+}
+
+function retryDelaySeconds(attempt: number): number {
+  return Math.min(300, Math.max(30, attempt * 30));
+}
+
+async function sendToDeadLetterQueue(body: QueueMessageBody, env: CloudflareBindings, reason: string): Promise<void> {
+  if (!env.JOBS_DLQ) return;
+  await env.JOBS_DLQ.send({ ...body, failedAt: new Date().toISOString(), reason });
+}
+
+async function handleQueueBatch(batch: MessageBatch<QueueMessageBody>, env: CloudflareBindings): Promise<void> {
+  for (const message of batch.messages) {
+    const type = message.body?.type || "";
+    const attempts = resolveJobAttempts(message as { body?: QueueMessageBody; attempts?: number });
+    if (!isJobType(type)) {
+      message.ack();
+      continue;
+    }
+    try {
+      await runQueueJob(type, env, message.body || {}, attempts);
+      message.ack();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : "unknown_queue_failure";
+      if (attempts >= MAX_JOB_ATTEMPTS) {
+        await sendToDeadLetterQueue({ ...message.body, type, attempts }, env, reason);
+        message.ack();
+        continue;
+      }
+      if (typeof message.retry === "function") {
+        message.retry({ delaySeconds: retryDelaySeconds(attempts) });
+      } else {
+        await sendToDeadLetterQueue({ ...message.body, type, attempts }, env, reason);
+        message.ack();
+      }
+    }
+  }
+}
+
+
+type DurableObjectStateLike = {
+  storage: {
+    get<T = unknown>(key: string): Promise<T | undefined>;
+    put(key: string, value: unknown): Promise<void>;
+    delete?(key: string): Promise<void>;
+  };
+};
+
+export class RateLimitCoordinator {
+  constructor(private readonly state: DurableObjectStateLike) {}
+
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+
+    const body = await request.json<{ windowMs?: number }>();
+    const requestedWindow = Number.parseInt(String(body.windowMs ?? RATE_LIMIT_WINDOW_MS), 10);
+    const windowMs = Number.isFinite(requestedWindow) && requestedWindow > 0 ? requestedWindow : RATE_LIMIT_WINDOW_MS;
+
+    const now = Date.now();
+    const current = await this.state.storage.get<{ count: number; resetAt: number }>("bucket");
+    let bucket = current && current.resetAt > now
+      ? { count: current.count, resetAt: current.resetAt }
+      : { count: 0, resetAt: now + windowMs };
+
+    bucket.count += 1;
+    await this.state.storage.put("bucket", bucket);
+
+    return new Response(JSON.stringify(bucket), {
+      headers: { "content-type": "application/json" },
+    });
+  }
+}
+
+
+export default {
+  async fetch(request: Request, env: CloudflareBindings, ctx: ExecutionContext): Promise<Response> {
+    const readiness = maybeHandleDeployReadiness(request, env);
+    if (readiness) {
+      const headers = new Headers(readiness.headers);
+      applyCorsHeaders(headers, request, env);
+      return new Response(readiness.body, { status: readiness.status, statusText: readiness.statusText, headers });
+    }
+
+    const preflight = maybeHandleCorsPreflight(request, env);
+    if (preflight) return preflight;
+
+    const bodyLimit = maybeEnforceBodyLimit(request);
+    if (bodyLimit) return bodyLimit;
+
+    const rateLimit = await evaluateRateLimit(request, env);
+    if (rateLimit.response) {
+      const headers = new Headers(rateLimit.response.headers);
+      if (rateLimit.headers) {
+        for (const [key, value] of rateLimit.headers.entries()) headers.set(key, value);
+      }
+      applyCorsHeaders(headers, request, env);
+      return new Response(rateLimit.response.body, { status: rateLimit.response.status, statusText: rateLimit.response.statusText, headers });
+    }
+
+    const ssrResponse = await renderWorkerHtml(request, env);
+    if (ssrResponse) {
+      const secured = withSecurityHeaders(ssrResponse);
+      const headers = new Headers(secured.headers);
+      if (rateLimit.headers) {
+        for (const [key, value] of rateLimit.headers.entries()) headers.set(key, value);
+      }
+      applyCorsHeaders(headers, request, env);
+      return new Response(secured.body, { status: secured.status, statusText: secured.statusText, headers });
+    }
+
+    const app = createApp(env);
+    const response = await app.fetch(request, env, ctx);
+    const secured = withSecurityHeaders(response);
+    const headers = new Headers(secured.headers);
+    if (rateLimit.headers) {
+      for (const [key, value] of rateLimit.headers.entries()) headers.set(key, value);
+    }
+    applyCorsHeaders(headers, request, env);
+    return new Response(secured.body, { status: secured.status, statusText: secured.statusText, headers });
+  },
+  async scheduled(_controller: ScheduledController, env: CloudflareBindings): Promise<void> {
+    await env.DB.prepare("DELETE FROM sessions WHERE expires_at <= datetime('now')").run();
+    await dispatchScheduledJobs(env);
+  },
+  async queue(batch: MessageBatch<QueueMessageBody>, env: CloudflareBindings): Promise<void> {
+    await handleQueueBatch(batch, env);
+  },
+};

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -15,6 +15,7 @@ type DeployReadinessCheck = {
   id: string;
   ok: boolean;
   detail: string;
+  level?: "required" | "behavior";
 };
 
 const DEFAULT_SECURITY_HEADERS: Record<string, string> = {
@@ -54,8 +55,37 @@ function isPlaceholderLike(value: string | undefined): boolean {
     || normalized.includes("example.pages.dev");
 }
 
-function evaluateDeployReadiness(env: CloudflareBindings): DeployReadinessCheck[] {
-  return [
+async function checkExecutorBehavior(service: Fetcher | undefined, id: string): Promise<DeployReadinessCheck | null> {
+  if (!service) return null;
+  try {
+    const res = await service.fetch("https://internal.everycal/healthz", { method: "GET" });
+    if (!res.ok) {
+      return {
+        id,
+        ok: false,
+        level: "behavior",
+        detail: `Service binding healthcheck returned ${res.status}.`,
+      };
+    }
+    const payload = await res.json<{ ok?: boolean }>();
+    return {
+      id,
+      ok: Boolean(payload?.ok),
+      level: "behavior",
+      detail: "Service binding healthcheck must report ok=true.",
+    };
+  } catch {
+    return {
+      id,
+      ok: false,
+      level: "behavior",
+      detail: "Service binding healthcheck failed to execute.",
+    };
+  }
+}
+
+async function evaluateDeployReadiness(env: CloudflareBindings): Promise<DeployReadinessCheck[]> {
+  const checks: DeployReadinessCheck[] = [
     {
       id: "base_url",
       ok: !isPlaceholderLike(env.BASE_URL),
@@ -87,13 +117,20 @@ function evaluateDeployReadiness(env: CloudflareBindings): DeployReadinessCheck[
       detail: "Configure SCRAPERS_SERVICE or SCRAPERS_WEBHOOK_URL.",
     },
   ];
+
+  const remindersBehavior = await checkExecutorBehavior(env.REMINDERS_SERVICE, "reminders_executor_behavior");
+  const scrapersBehavior = await checkExecutorBehavior(env.SCRAPERS_SERVICE, "scrapers_executor_behavior");
+  if (remindersBehavior) checks.push(remindersBehavior);
+  if (scrapersBehavior) checks.push(scrapersBehavior);
+
+  return checks;
 }
 
-function maybeHandleDeployReadiness(request: Request, env: CloudflareBindings): Response | null {
+async function maybeHandleDeployReadiness(request: Request, env: CloudflareBindings): Promise<Response | null> {
   const url = new URL(request.url);
   if (request.method !== "GET" || url.pathname !== "/api/v1/system/deploy-readiness") return null;
 
-  const checks = evaluateDeployReadiness(env);
+  const checks = await evaluateDeployReadiness(env);
   const requiredFailures = checks.filter((check) => !check.ok);
 
   return withSecurityHeaders(new Response(JSON.stringify({
@@ -492,7 +529,7 @@ export class RateLimitCoordinator {
 
 export default {
   async fetch(request: Request, env: CloudflareBindings, ctx: ExecutionContext): Promise<Response> {
-    const readiness = maybeHandleDeployReadiness(request, env);
+    const readiness = await maybeHandleDeployReadiness(request, env);
     if (readiness) {
       const headers = new Headers(readiness.headers);
       applyCorsHeaders(headers, request, env);

--- a/packages/cloudflare-worker/src/security.test.ts
+++ b/packages/cloudflare-worker/src/security.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { hashPassword, verifyPassword } from "./security";
+
+describe("cloudflare password hashing", () => {
+  it("hashes and verifies", async () => {
+    const hash = await hashPassword("correct horse battery staple");
+    expect(hash.startsWith("pbkdf2$")).toBe(true);
+    await expect(verifyPassword("correct horse battery staple", hash)).resolves.toBe(true);
+    await expect(verifyPassword("nope", hash)).resolves.toBe(false);
+  });
+});

--- a/packages/cloudflare-worker/src/security.ts
+++ b/packages/cloudflare-worker/src/security.ts
@@ -1,0 +1,65 @@
+const encoder = new TextEncoder();
+
+function toHex(buffer: ArrayBuffer): string {
+  return Array.from(new Uint8Array(buffer)).map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) return new Uint8Array();
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) return new Uint8Array();
+    out[i] = byte;
+  }
+  return out;
+}
+
+function constantTimeEqual(a: string, b: string): boolean {
+  const aBytes = encoder.encode(a);
+  const bBytes = encoder.encode(b);
+  if (aBytes.length !== bBytes.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < aBytes.length; i += 1) mismatch |= aBytes[i] ^ bBytes[i];
+  return mismatch === 0;
+}
+
+export async function hashPassword(password: string): Promise<string> {
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const keyMaterial = await crypto.subtle.importKey("raw", encoder.encode(password), "PBKDF2", false, ["deriveBits"]);
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt,
+      iterations: 100000,
+    },
+    keyMaterial,
+    256
+  );
+  return `pbkdf2$100000$${toHex(salt.buffer)}$${toHex(bits)}`;
+}
+
+export async function verifyPassword(password: string, encodedHash: string | null): Promise<boolean> {
+  if (!encodedHash) return false;
+  const [algo, iterationsRaw, saltHex, hashHex] = encodedHash.split("$");
+  if (algo !== "pbkdf2") return false;
+  const iterations = Number.parseInt(iterationsRaw || "", 10);
+  if (!Number.isFinite(iterations) || iterations <= 0) return false;
+  const salt = fromHex(saltHex || "");
+  if (salt.length === 0) return false;
+
+  const keyMaterial = await crypto.subtle.importKey("raw", encoder.encode(password), "PBKDF2", false, ["deriveBits"]);
+  const bits = await crypto.subtle.deriveBits(
+    {
+      name: "PBKDF2",
+      hash: "SHA-256",
+      salt,
+      iterations,
+    },
+    keyMaterial,
+    256
+  );
+
+  return constantTimeEqual(toHex(bits), hashHex || "");
+}

--- a/packages/cloudflare-worker/src/ssr.test.ts
+++ b/packages/cloudflare-worker/src/ssr.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CloudflareStorage } from "./storage";
+
+const renderPage = vi.fn();
+
+vi.mock("vike/server", () => ({
+  renderPage,
+}));
+
+import { renderWorkerHtml } from "./ssr";
+
+describe("renderWorkerHtml", () => {
+  beforeEach(() => {
+    renderPage.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it("skips non-HTML requests", async () => {
+    const request = new Request("https://calendar.example/", {
+      method: "GET",
+      headers: { accept: "application/json" },
+    });
+
+    const response = await renderWorkerHtml(request, {} as never);
+    expect(response).toBeNull();
+    expect(renderPage).not.toHaveBeenCalled();
+  });
+
+  it("skips API namespace requests", async () => {
+    const request = new Request("https://calendar.example/api/v1/bootstrap", {
+      method: "GET",
+      headers: { accept: "text/html" },
+    });
+
+    const response = await renderWorkerHtml(request, {} as never);
+    expect(response).toBeNull();
+    expect(renderPage).not.toHaveBeenCalled();
+  });
+
+  it("adds anonymous edge-cache headers to SSR responses", async () => {
+    vi.spyOn(CloudflareStorage.prototype, "getSession").mockResolvedValue(null);
+    vi.spyOn(CloudflareStorage.prototype, "getAccountById").mockResolvedValue(null);
+    renderPage.mockResolvedValueOnce({
+      httpResponse: {
+        body: "<html>ok</html>",
+        statusCode: 200,
+        headers: [["content-type", "text/html"]],
+      },
+    });
+
+    const request = new Request("https://calendar.example/", {
+      method: "GET",
+      headers: { accept: "text/html" },
+    });
+
+    const response = await renderWorkerHtml(request, { SSR_CACHE_TAG_VERSION: "v2" } as never);
+    expect(response?.headers.get("Cache-Control")).toBe("public, max-age=0, s-maxage=15, stale-while-revalidate=30");
+    expect(response?.headers.get("X-SSR-Cache")).toBe("EDGE_HINT");
+    expect(response?.headers.get("Cache-Tag")).toBe("everycal-ssr,everycal-ssr-anon,everycal-ssr-v2");
+    expect(response?.headers.get("Vary")).toContain("Cache-Control");
+  });
+
+  it("bypasses anonymous edge cache when request asks for no-cache", async () => {
+    vi.spyOn(CloudflareStorage.prototype, "getSession").mockResolvedValue(null);
+    vi.spyOn(CloudflareStorage.prototype, "getAccountById").mockResolvedValue(null);
+    renderPage.mockResolvedValueOnce({
+      httpResponse: {
+        body: "<html>ok</html>",
+        statusCode: 200,
+        headers: [["content-type", "text/html"]],
+      },
+    });
+
+    const request = new Request("https://calendar.example/", {
+      method: "GET",
+      headers: { accept: "text/html", "cache-control": "no-cache" },
+    });
+
+    const response = await renderWorkerHtml(request, {} as never);
+    expect(response?.headers.get("X-SSR-Cache")).toBe("BYPASS_REQUEST");
+    expect(response?.headers.get("CDN-Cache-Control")).toBe("public, max-age=0, no-store");
+  });
+
+  it("supports rollout guardrail to disable anonymous edge cache", async () => {
+    vi.spyOn(CloudflareStorage.prototype, "getSession").mockResolvedValue(null);
+    vi.spyOn(CloudflareStorage.prototype, "getAccountById").mockResolvedValue(null);
+    renderPage.mockResolvedValueOnce({
+      httpResponse: {
+        body: "<html>ok</html>",
+        statusCode: 200,
+        headers: [["content-type", "text/html"]],
+      },
+    });
+
+    const request = new Request("https://calendar.example/", {
+      method: "GET",
+      headers: { accept: "text/html" },
+    });
+
+    const response = await renderWorkerHtml(request, { SSR_EDGE_CACHE_ENABLED: "false" } as never);
+    expect(response?.headers.get("X-SSR-Cache")).toBe("DISABLED");
+    expect(response?.headers.get("CDN-Cache-Control")).toBe("public, max-age=0, no-store");
+  });
+
+  it("adds authenticated no-store headers to SSR responses", async () => {
+    vi.spyOn(CloudflareStorage.prototype, "getSession").mockResolvedValue({
+      token: "t",
+      accountId: "acct-1",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+    });
+    vi.spyOn(CloudflareStorage.prototype, "getAccountById").mockResolvedValue({
+      id: "acct-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      passwordHash: "x",
+    });
+
+    renderPage.mockResolvedValueOnce({
+      httpResponse: {
+        body: "<html>private</html>",
+        statusCode: 200,
+        headers: [["content-type", "text/html"]],
+      },
+    });
+
+    const request = new Request("https://calendar.example/private", {
+      method: "GET",
+      headers: { accept: "text/html", cookie: "everycal_session=t" },
+    });
+
+    const response = await renderWorkerHtml(request, {} as never);
+    expect(response?.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(response?.headers.get("X-SSR-Cache")).toBe("BYPASS_AUTH");
+  });
+
+  it("restores internal API origin global after render", async () => {
+    const key = "__EVERYCAL_INTERNAL_API_ORIGIN";
+    (globalThis as Record<string, unknown>)[key] = "previous-origin";
+    vi.spyOn(CloudflareStorage.prototype, "getSession").mockResolvedValue(null);
+    vi.spyOn(CloudflareStorage.prototype, "getAccountById").mockResolvedValue(null);
+
+    renderPage.mockResolvedValueOnce({
+      httpResponse: {
+        body: "<html>ok</html>",
+        statusCode: 200,
+        headers: [["content-type", "text/html"]],
+      },
+    });
+
+    const request = new Request("https://calendar.example/", {
+      method: "GET",
+      headers: { accept: "text/html" },
+    });
+
+    await renderWorkerHtml(request, {} as never);
+
+    expect((globalThis as Record<string, unknown>)[key]).toBe("previous-origin");
+  });
+});

--- a/packages/cloudflare-worker/src/ssr.ts
+++ b/packages/cloudflare-worker/src/ssr.ts
@@ -1,0 +1,161 @@
+import { renderPage } from "vike/server";
+import type { CloudflareBindings } from "./storage";
+import { CloudflareStorage } from "./storage";
+
+const INTERNAL_API_ORIGIN_KEY = "__EVERYCAL_INTERNAL_API_ORIGIN";
+const SESSION_COOKIE_FALLBACK = "everycal_session";
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+function buildAnonymousSsrCacheControl(env: CloudflareBindings): string {
+  const sMaxAge = readPositiveInt(env.SSR_CACHE_MAX_AGE_SECONDS, 15);
+  const staleWhileRevalidate = readPositiveInt(env.SSR_CACHE_STALE_WHILE_REVALIDATE_SECONDS, 30);
+  return `public, max-age=0, s-maxage=${sMaxAge}, stale-while-revalidate=${staleWhileRevalidate}`;
+}
+
+function isEdgeCacheEnabled(env: CloudflareBindings): boolean {
+  return env.SSR_EDGE_CACHE_ENABLED !== "false";
+}
+
+function edgeCacheTag(env: CloudflareBindings): string {
+  const version = (env.SSR_CACHE_TAG_VERSION || "v1").trim() || "v1";
+  return `everycal-ssr,everycal-ssr-anon,everycal-ssr-${version}`;
+}
+
+function shouldBypassAnonymousEdgeCache(request: Request, env: CloudflareBindings): boolean {
+  const url = new URL(request.url);
+  if (url.searchParams.has("preview") || url.searchParams.has("nocache")) return true;
+
+  const cacheControl = (request.headers.get("cache-control") || "").toLowerCase();
+  const pragma = (request.headers.get("pragma") || "").toLowerCase();
+  if (cacheControl.includes("no-cache") || cacheControl.includes("no-store") || pragma.includes("no-cache")) return true;
+
+  const bypassHeaderName = (env.SSR_EDGE_CACHE_BYPASS_HEADER || "x-everycal-ssr-bypass").toLowerCase();
+  const bypassHeaderValue = request.headers.get(bypassHeaderName);
+  return typeof bypassHeaderValue === "string" && bypassHeaderValue.trim().length > 0;
+}
+
+function getCookie(headers: Headers, name: string): string | null {
+  const cookie = headers.get("cookie") || "";
+  const parts = cookie.split(";").map((v) => v.trim());
+  for (const part of parts) {
+    const idx = part.indexOf("=");
+    if (idx < 0) continue;
+    if (part.slice(0, idx) !== name) continue;
+    const encoded = part.slice(idx + 1);
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      return encoded;
+    }
+  }
+  return null;
+}
+
+async function resolveBootstrap(request: Request, env: CloudflareBindings) {
+  const storage = new CloudflareStorage(env);
+  const token = getCookie(request.headers, env.SESSION_COOKIE_NAME || SESSION_COOKIE_FALLBACK);
+  const session = token ? await storage.getSession(token) : null;
+  const account = session ? await storage.getAccountById(session.accountId) : null;
+
+  return {
+    locale: "en",
+    isAuthenticated: Boolean(account),
+    viewer: account
+      ? {
+          id: account.id,
+          username: account.username,
+          displayName: account.displayName,
+          avatarUrl: account.avatarUrl,
+          discoverable: false,
+          accountType: "person",
+          roles: [],
+        }
+      : null,
+  };
+}
+
+function shouldHandleWithSsr(request: Request): boolean {
+  if (request.method !== "GET") return false;
+
+  const accept = request.headers.get("accept") || "";
+  if (!accept.includes("text/html")) return false;
+
+  const url = new URL(request.url);
+  if (
+    url.pathname.startsWith("/api/") ||
+    url.pathname.startsWith("/uploads") ||
+    url.pathname.startsWith("/.well-known") ||
+    url.pathname.startsWith("/users") ||
+    url.pathname.startsWith("/events") ||
+    url.pathname.startsWith("/nodeinfo") ||
+    url.pathname === "/inbox" ||
+    url.pathname === "/healthz"
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function renderWorkerHtml(request: Request, env: CloudflareBindings): Promise<Response | null> {
+  if (!shouldHandleWithSsr(request)) return null;
+
+  const url = new URL(request.url);
+  const previousOrigin = (globalThis as Record<string, unknown>)[INTERNAL_API_ORIGIN_KEY];
+  (globalThis as Record<string, unknown>)[INTERNAL_API_ORIGIN_KEY] = `${url.protocol}//${url.host}`;
+
+  try {
+    const bootstrap = await resolveBootstrap(request, env);
+
+    const pageContext = await renderPage({
+      urlOriginal: request.url,
+      headersOriginal: Object.fromEntries(request.headers.entries()),
+      bootstrap,
+      initialData: null,
+    });
+
+    const { httpResponse } = pageContext;
+    if (!httpResponse) return null;
+
+    const headers = new Headers();
+    httpResponse.headers.forEach(([name, value]) => headers.set(name, value));
+    headers.set("Vary", "Cookie, Authorization, Accept-Language, Cache-Control, Pragma");
+
+    if (bootstrap.isAuthenticated) {
+      headers.set("Cache-Control", "private, no-store");
+      headers.set("CDN-Cache-Control", "private, no-store");
+      headers.set("X-SSR-Cache", "BYPASS_AUTH");
+    } else if (!isEdgeCacheEnabled(env)) {
+      headers.set("Cache-Control", "public, max-age=0, no-store");
+      headers.set("CDN-Cache-Control", "public, max-age=0, no-store");
+      headers.set("X-SSR-Cache", "DISABLED");
+    } else if (shouldBypassAnonymousEdgeCache(request, env)) {
+      headers.set("Cache-Control", "public, max-age=0, no-store");
+      headers.set("CDN-Cache-Control", "public, max-age=0, no-store");
+      headers.set("X-SSR-Cache", "BYPASS_REQUEST");
+    } else {
+      const cacheControl = buildAnonymousSsrCacheControl(env);
+      headers.set("Cache-Control", cacheControl);
+      headers.set("CDN-Cache-Control", cacheControl);
+      headers.set("Cache-Tag", edgeCacheTag(env));
+      headers.set("X-SSR-Cache", "EDGE_HINT");
+    }
+
+    return new Response(httpResponse.body, {
+      status: httpResponse.statusCode,
+      headers,
+    });
+  } finally {
+    if (typeof previousOrigin === "undefined") {
+      delete (globalThis as Record<string, unknown>)[INTERNAL_API_ORIGIN_KEY];
+    } else {
+      (globalThis as Record<string, unknown>)[INTERNAL_API_ORIGIN_KEY] = previousOrigin;
+    }
+  }
+}

--- a/packages/cloudflare-worker/src/storage.test.ts
+++ b/packages/cloudflare-worker/src/storage.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { CloudflareStorage } from "./storage";
+
+describe("CloudflareStorage", () => {
+  it("writes uploads to R2 and metadata to D1", async () => {
+    const run = vi.fn(async () => ({ success: true }));
+    const first = vi.fn(async () => null);
+    const all = vi.fn(async () => ({ results: [] }));
+    const bind = vi.fn(() => ({ run, first, all }));
+    const prepare = vi.fn(() => ({ bind }));
+    const put = vi.fn(async () => undefined);
+
+    const storage = new CloudflareStorage({
+      BASE_URL: "https://calendar.example",
+      DB: { prepare } as unknown as D1Database,
+      UPLOADS: { put } as unknown as R2Bucket,
+    });
+
+    const body = new TextEncoder().encode("hello").buffer;
+    const url = await storage.putUpload({ key: "avatar.png", contentType: "image/png", body });
+
+    expect(url).toBe("https://calendar.example/uploads/avatar.png");
+    expect(put).toHaveBeenCalledWith("avatar.png", body, { httpMetadata: { contentType: "image/png" } });
+    expect(prepare).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
+  });
+
+  it("follows and unfollows remote actors", async () => {
+    const run = vi.fn(async () => ({ success: true }));
+    const first = vi.fn(async () => null);
+    const all = vi.fn(async () => ({ results: [] }));
+    const bind = vi.fn(() => ({ run, first, all }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    const storage = new CloudflareStorage({
+      BASE_URL: "https://calendar.example",
+      DB: { prepare } as unknown as D1Database,
+      UPLOADS: { put: vi.fn() } as unknown as R2Bucket,
+    });
+
+    await storage.followRemoteActor("acct-1", {
+      uri: "https://remote.example/users/alice",
+      username: "alice",
+      displayName: "Alice",
+      domain: "remote.example",
+      inbox: "https://remote.example/inbox",
+      iconUrl: null,
+    });
+    await storage.unfollowRemoteActor("acct-1", "https://remote.example/users/alice");
+
+    expect(prepare).toHaveBeenCalled();
+    expect(run).toHaveBeenCalledTimes(2);
+  });
+
+  it("maps followed remote actors", async () => {
+    const run = vi.fn(async () => ({ success: true }));
+    const first = vi.fn(async () => null);
+    const all = vi.fn(async () => ({
+      results: [
+        {
+          uri: "https://remote.example/users/alice",
+          preferred_username: "alice",
+          display_name: "Alice",
+          domain: "remote.example",
+          inbox: "https://remote.example/inbox",
+          icon_url: "https://remote.example/alice.png",
+        },
+      ],
+    }));
+    const bind = vi.fn(() => ({ run, first, all }));
+    const prepare = vi.fn(() => ({ bind }));
+
+    const storage = new CloudflareStorage({
+      BASE_URL: "https://calendar.example",
+      DB: { prepare } as unknown as D1Database,
+      UPLOADS: { put: vi.fn() } as unknown as R2Bucket,
+    });
+
+    const actors = await storage.searchRemoteActors("alice");
+    expect(actors).toHaveLength(1);
+    expect(actors[0]?.username).toBe("alice");
+    expect(actors[0]?.iconUrl).toBe("https://remote.example/alice.png");
+  });
+});

--- a/packages/cloudflare-worker/src/storage.ts
+++ b/packages/cloudflare-worker/src/storage.ts
@@ -1,0 +1,413 @@
+import type { UnifiedStorage, UnifiedAccount, UnifiedEvent, UnifiedIdentity, UploadObject, SavedLocation, RemoteActorSummary, RemoteEventSummary } from "@everycal/runtime-core";
+
+export interface CloudflareBindings {
+  DB: D1Database;
+  UPLOADS: R2Bucket;
+  BASE_URL: string;
+  CORS_ORIGIN?: string;
+  SSR_CACHE_MAX_AGE_SECONDS?: string;
+  SSR_CACHE_STALE_WHILE_REVALIDATE_SECONDS?: string;
+  SSR_EDGE_CACHE_ENABLED?: string;
+  SSR_EDGE_CACHE_BYPASS_HEADER?: string;
+  SSR_CACHE_TAG_VERSION?: string;
+  SESSION_COOKIE_NAME?: string;
+  JOBS_QUEUE?: Queue;
+  JOBS_DLQ?: Queue;
+  ACTIVITYPUB_PRIVATE_KEY_PEM?: string;
+  REMINDERS_WEBHOOK_URL?: string;
+  SCRAPERS_WEBHOOK_URL?: string;
+  JOBS_WEBHOOK_TOKEN?: string;
+  REMINDERS_SERVICE?: Fetcher;
+  SCRAPERS_SERVICE?: Fetcher;
+  RATE_LIMITS_KV?: KVNamespace;
+  RATE_LIMITS_DO?: DurableObjectNamespace;
+}
+
+export class CloudflareStorage implements UnifiedStorage {
+  constructor(private readonly env: CloudflareBindings) {}
+
+  async getSession(token: string): Promise<{ token: string; accountId: string; expiresAt: string } | null> {
+    const row = await this.env.DB.prepare(
+      "SELECT token, account_id, expires_at FROM sessions WHERE token = ?1 AND expires_at > datetime('now')"
+    ).bind(token).first<{ token: string; account_id: string; expires_at: string }>();
+    return row ? { token: row.token, accountId: row.account_id, expiresAt: row.expires_at } : null;
+  }
+
+  async createSession(accountId: string): Promise<{ token: string; accountId: string; expiresAt: string }> {
+    const token = crypto.randomUUID();
+    await this.env.DB.prepare("INSERT INTO sessions (token, account_id, expires_at) VALUES (?1, ?2, datetime('now', '+14 day'))")
+      .bind(token, accountId)
+      .run();
+    const row = await this.env.DB.prepare("SELECT token, account_id, expires_at FROM sessions WHERE token = ?1")
+      .bind(token)
+      .first<{ token: string; account_id: string; expires_at: string }>();
+    if (!row) throw new Error("failed_to_create_session");
+    return { token: row.token, accountId: row.account_id, expiresAt: row.expires_at };
+  }
+
+  async deleteSession(token: string): Promise<void> {
+    await this.env.DB.prepare("DELETE FROM sessions WHERE token = ?1").bind(token).run();
+  }
+
+  async getAccountById(id: string): Promise<UnifiedAccount | null> {
+    const row = await this.env.DB.prepare(
+      "SELECT id, username, display_name, avatar_url, password_hash FROM accounts WHERE id = ?1"
+    ).bind(id).first<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>();
+    return row ? {
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    } : null;
+  }
+
+  async getAccountByUsername(username: string): Promise<UnifiedAccount | null> {
+    const row = await this.env.DB.prepare(
+      "SELECT id, username, display_name, avatar_url, password_hash FROM accounts WHERE username = ?1"
+    ).bind(username).first<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>();
+    return row ? {
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    } : null;
+  }
+
+  async createAccount(input: { username: string; displayName: string; passwordHash: string }): Promise<UnifiedAccount> {
+    const id = crypto.randomUUID();
+    await this.env.DB.prepare("INSERT INTO accounts (id, username, display_name, password_hash) VALUES (?1, ?2, ?3, ?4)")
+      .bind(id, input.username, input.displayName, input.passwordHash)
+      .run();
+    const account = await this.getAccountById(id);
+    if (!account) throw new Error("failed_to_create_account");
+    return account;
+  }
+
+  async listEventsForAccount(accountId: string): Promise<UnifiedEvent[]> {
+    const result = await this.env.DB.prepare(
+      "SELECT id, account_id, title, description, start_date, end_date, visibility FROM events WHERE account_id = ?1 ORDER BY start_date ASC"
+    ).bind(accountId).all<{ id: string; account_id: string; title: string; description: string | null; start_date: string; end_date: string | null; visibility: UnifiedEvent['visibility'] }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    }));
+  }
+
+  async createEvent(input: { accountId: string; title: string; description?: string; startDate: string; endDate?: string; visibility?: UnifiedEvent['visibility'] }): Promise<{ id: string }> {
+    const id = crypto.randomUUID();
+    await this.env.DB.prepare(
+      "INSERT INTO events (id, account_id, title, description, start_date, end_date, visibility) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
+    ).bind(id, input.accountId, input.title, input.description ?? null, input.startDate, input.endDate ?? null, input.visibility ?? "public").run();
+    return { id };
+  }
+
+  async getEventById(id: string): Promise<UnifiedEvent | null> {
+    const row = await this.env.DB.prepare(
+      "SELECT id, account_id, title, description, start_date, end_date, visibility FROM events WHERE id = ?1"
+    ).bind(id).first<{ id: string; account_id: string; title: string; description: string | null; start_date: string; end_date: string | null; visibility: UnifiedEvent['visibility'] }>();
+    return row ? {
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    } : null;
+  }
+
+  async listPublicEventsByUsername(username: string, limit: number): Promise<UnifiedEvent[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT e.id, e.account_id, e.title, e.description, e.start_date, e.end_date, e.visibility
+       FROM events e JOIN accounts a ON a.id = e.account_id
+       WHERE a.username = ?1 AND e.visibility IN ('public','unlisted')
+       ORDER BY e.start_date ASC
+       LIMIT ?2`
+    ).bind(username, limit).all<{ id: string; account_id: string; title: string; description: string | null; start_date: string; end_date: string | null; visibility: UnifiedEvent['visibility'] }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    }));
+  }
+
+  async createIdentity(ownerAccountId: string, input: { username: string; displayName: string }): Promise<UnifiedIdentity> {
+    const id = crypto.randomUUID();
+    await this.env.DB.prepare("INSERT INTO accounts (id, username, display_name, account_type) VALUES (?1, ?2, ?3, 'identity')")
+      .bind(id, input.username, input.displayName)
+      .run();
+    await this.env.DB.prepare(
+      "INSERT INTO identity_memberships (identity_account_id, member_account_id, role) VALUES (?1, ?2, 'owner')"
+    ).bind(id, ownerAccountId).run();
+    return { id, username: input.username, displayName: input.displayName, role: "owner" };
+  }
+
+  async listIdentitiesForMember(memberAccountId: string): Promise<UnifiedIdentity[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT a.id, a.username, a.display_name, im.role
+       FROM identity_memberships im JOIN accounts a ON a.id = im.identity_account_id
+       WHERE im.member_account_id = ?1`
+    ).bind(memberAccountId).all<{ id: string; username: string; display_name: string | null; role: "owner" | "editor" }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      role: row.role,
+    }));
+  }
+
+  async addRemoteFollow(accountId: string, actorUri: string, inbox: string): Promise<void> {
+    await this.env.DB.prepare(
+      "INSERT INTO remote_follows (account_id, follower_actor_uri, follower_inbox) VALUES (?1, ?2, ?3) ON CONFLICT(account_id, follower_actor_uri) DO UPDATE SET follower_inbox = excluded.follower_inbox"
+    ).bind(accountId, actorUri, inbox).run();
+  }
+
+  async removeRemoteFollow(accountId: string, actorUri: string): Promise<void> {
+    await this.env.DB.prepare("DELETE FROM remote_follows WHERE account_id = ?1 AND follower_actor_uri = ?2").bind(accountId, actorUri).run();
+  }
+
+
+  async listFollowersByUsername(username: string): Promise<UnifiedAccount[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT a.id, a.username, a.display_name, a.avatar_url, a.password_hash
+       FROM follows f
+       JOIN accounts target ON target.id = f.following_id
+       JOIN accounts a ON a.id = f.follower_id
+       WHERE target.username = ?1`
+    ).bind(username).all<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    }));
+  }
+
+  async listRemoteFollowerActorUrisByUsername(username: string): Promise<string[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT rf.follower_actor_uri
+       FROM remote_follows rf
+       JOIN accounts target ON target.id = rf.account_id
+       WHERE target.username = ?1`
+    ).bind(username).all<{ follower_actor_uri: string }>();
+    return (result.results ?? []).map((row) => row.follower_actor_uri);
+  }
+
+  async listFollowingByUsername(username: string): Promise<UnifiedAccount[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT a.id, a.username, a.display_name, a.avatar_url, a.password_hash
+       FROM follows f
+       JOIN accounts source ON source.id = f.follower_id
+       JOIN accounts a ON a.id = f.following_id
+       WHERE source.username = ?1`
+    ).bind(username).all<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    }));
+  }
+
+  async listSavedLocations(accountId: string): Promise<SavedLocation[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT id, name, address, latitude, longitude, used_at
+       FROM saved_locations
+       WHERE account_id = ?1
+       ORDER BY used_at DESC`
+    ).bind(accountId).all<{ id: number; name: string; address: string | null; latitude: number | null; longitude: number | null; used_at: string }>();
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      name: row.name,
+      address: row.address,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      usedAt: row.used_at,
+    }));
+  }
+
+  async saveLocation(accountId: string, loc: { name: string; address?: string; latitude?: number; longitude?: number }): Promise<void> {
+    await this.env.DB.prepare(
+      `INSERT INTO saved_locations (account_id, name, address, latitude, longitude, used_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))
+       ON CONFLICT(account_id, name, address)
+       DO UPDATE SET latitude = excluded.latitude, longitude = excluded.longitude, used_at = datetime('now')`
+    ).bind(accountId, loc.name.trim(), loc.address ?? null, loc.latitude ?? null, loc.longitude ?? null).run();
+  }
+
+  async deleteLocation(accountId: string, id: number): Promise<void> {
+    await this.env.DB.prepare("DELETE FROM saved_locations WHERE id = ?1 AND account_id = ?2").bind(id, accountId).run();
+  }
+
+
+  async listRemoteActors(params?: { domain?: string; limit?: number }): Promise<RemoteActorSummary[]> {
+    const limit = params?.limit ?? 20;
+    const domain = params?.domain;
+    const query = domain
+      ? `SELECT uri, preferred_username, display_name, domain, inbox, icon_url FROM remote_actors WHERE domain = ?1 ORDER BY last_fetched_at DESC LIMIT ?2`
+      : `SELECT uri, preferred_username, display_name, domain, inbox, icon_url FROM remote_actors ORDER BY last_fetched_at DESC LIMIT ?1`;
+    const result = domain
+      ? await this.env.DB.prepare(query).bind(domain, limit).all<{ uri: string; preferred_username: string; display_name: string | null; domain: string; inbox: string | null; icon_url: string | null }>()
+      : await this.env.DB.prepare(query).bind(limit).all<{ uri: string; preferred_username: string; display_name: string | null; domain: string; inbox: string | null; icon_url: string | null }>();
+    return (result.results ?? []).map((row) => ({
+      uri: row.uri,
+      username: row.preferred_username,
+      displayName: row.display_name,
+      domain: row.domain,
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    }));
+  }
+
+
+  async searchRemoteActors(query: string): Promise<RemoteActorSummary[]> {
+    const q = `%${query.toLowerCase()}%`;
+    const result = await this.env.DB.prepare(
+      `SELECT uri, preferred_username, display_name, domain, inbox, icon_url
+       FROM remote_actors
+       WHERE lower(preferred_username) LIKE ?1 OR lower(display_name) LIKE ?1 OR lower(uri) LIKE ?1
+       ORDER BY last_fetched_at DESC
+       LIMIT 20`
+    ).bind(q).all<{ uri: string; preferred_username: string; display_name: string | null; domain: string; inbox: string | null; icon_url: string | null }>();
+    return (result.results ?? []).map((row) => ({
+      uri: row.uri,
+      username: row.preferred_username,
+      displayName: row.display_name,
+      domain: row.domain,
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    }));
+  }
+
+  async listFollowedRemoteActors(accountId: string): Promise<RemoteActorSummary[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT ra.uri, ra.preferred_username, ra.display_name, ra.domain, rf.actor_inbox AS inbox, ra.icon_url
+       FROM remote_following rf
+       LEFT JOIN remote_actors ra ON ra.uri = rf.actor_uri
+       WHERE rf.account_id = ?1
+       ORDER BY rf.created_at DESC`
+    ).bind(accountId).all<{ uri: string | null; preferred_username: string | null; display_name: string | null; domain: string | null; inbox: string; icon_url: string | null }>();
+    return (result.results ?? []).map((row) => ({
+      uri: row.uri || "",
+      username: row.preferred_username || "",
+      displayName: row.display_name,
+      domain: row.domain || "",
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    })).filter((actor) => actor.uri.length > 0);
+  }
+
+
+  async upsertRemoteActor(actor: RemoteActorSummary & { inbox: string }): Promise<void> {
+    await this.env.DB.prepare(
+      `INSERT INTO remote_actors (uri, preferred_username, display_name, domain, inbox, icon_url, last_fetched_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+       ON CONFLICT(uri) DO UPDATE SET
+         preferred_username = excluded.preferred_username,
+         display_name = excluded.display_name,
+         domain = excluded.domain,
+         inbox = excluded.inbox,
+         icon_url = excluded.icon_url,
+         last_fetched_at = datetime('now')`
+    ).bind(actor.uri, actor.username, actor.displayName ?? null, actor.domain, actor.inbox, actor.iconUrl ?? null).run();
+  }
+
+  async upsertRemoteEvent(event: RemoteEventSummary): Promise<void> {
+    await this.env.DB.prepare(
+      `INSERT INTO remote_events (uri, actor_uri, title, description, start_date, end_date, fetched_at)
+       VALUES (?1, ?2, ?3, ?4, ?5, ?6, datetime('now'))
+       ON CONFLICT(uri) DO UPDATE SET
+         actor_uri = excluded.actor_uri,
+         title = excluded.title,
+         description = excluded.description,
+         start_date = excluded.start_date,
+         end_date = excluded.end_date,
+         fetched_at = datetime('now')`
+    ).bind(event.uri, event.actorUri, event.title, event.description ?? null, event.startDate, event.endDate ?? null).run();
+  }
+
+  async followRemoteActor(accountId: string, actor: RemoteActorSummary & { inbox: string }): Promise<void> {
+    await this.env.DB.prepare(
+      `INSERT INTO remote_following (account_id, actor_uri, actor_inbox)
+       VALUES (?1, ?2, ?3)
+       ON CONFLICT(account_id, actor_uri) DO UPDATE SET actor_inbox = excluded.actor_inbox`
+    ).bind(accountId, actor.uri, actor.inbox).run();
+  }
+
+  async unfollowRemoteActor(accountId: string, actorUri: string): Promise<void> {
+    await this.env.DB.prepare("DELETE FROM remote_following WHERE account_id = ?1 AND actor_uri = ?2").bind(accountId, actorUri).run();
+  }
+
+  async listRemoteEvents(params?: { actor?: string; from?: string; limit?: number; offset?: number }): Promise<RemoteEventSummary[]> {
+    const actor = params?.actor;
+    const from = params?.from;
+    const limit = params?.limit ?? 50;
+    const offset = params?.offset ?? 0;
+
+    const where: string[] = [];
+    const values: unknown[] = [];
+    if (actor) {
+      where.push(`actor_uri = ?${values.length + 1}`);
+      values.push(actor);
+    }
+    if (from) {
+      where.push(`start_date >= ?${values.length + 1}`);
+      values.push(from);
+    }
+    values.push(limit, offset);
+    const limIdx = values.length - 1;
+    const offIdx = values.length;
+    const query = `SELECT uri, actor_uri, title, description, start_date, end_date
+      FROM remote_events
+      ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY start_date ASC
+      LIMIT ?${limIdx} OFFSET ?${offIdx}`;
+
+    const result = await this.env.DB.prepare(query).bind(...values).all<{
+      uri: string;
+      actor_uri: string;
+      title: string;
+      description: string | null;
+      start_date: string;
+      end_date: string | null;
+    }>();
+
+    return (result.results ?? []).map((row) => ({
+      uri: row.uri,
+      actorUri: row.actor_uri,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+    }));
+  }
+
+  async putUpload(blob: { key: string; contentType: string; body: ArrayBuffer }): Promise<string> {
+    await this.env.UPLOADS.put(blob.key, blob.body, { httpMetadata: { contentType: blob.contentType } });
+    await this.env.DB.prepare(
+      "INSERT INTO uploads (id, object_key, content_type) VALUES (?1, ?2, ?3) ON CONFLICT(object_key) DO UPDATE SET content_type = excluded.content_type"
+    ).bind(blob.key, blob.key, blob.contentType).run();
+    return `${this.env.BASE_URL}/uploads/${blob.key}`;
+  }
+
+  async getUpload(key: string): Promise<UploadObject | null> {
+    const object = await this.env.UPLOADS.get(key);
+    if (!object) return null;
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    return { body: object.body || "", contentType: headers.get("content-type") || undefined };
+  }
+}

--- a/packages/cloudflare-worker/src/types.d.ts
+++ b/packages/cloudflare-worker/src/types.d.ts
@@ -1,0 +1,57 @@
+interface D1PreparedStatement {
+  bind(...values: unknown[]): D1PreparedStatement;
+  first<T = Record<string, unknown>>(): Promise<T | null>;
+  all<T = Record<string, unknown>>(): Promise<{ results?: T[] }>;
+  run(): Promise<unknown>;
+}
+
+interface D1Database {
+  prepare(query: string): D1PreparedStatement;
+}
+
+interface R2Bucket {
+  put(key: string, value: ArrayBuffer, options?: { httpMetadata?: { contentType?: string } }): Promise<void>;
+  get(key: string): Promise<R2ObjectBody | null>;
+}
+
+interface R2ObjectBody {
+  body: ReadableStream | null;
+  writeHttpMetadata(headers: Headers): void;
+}
+
+interface ScheduledController {}
+
+interface MessageBatch<T> {
+  messages: Array<{ body: T; attempts?: number; ack(): void; retry?(options?: { delaySeconds?: number }): void }>;
+}
+
+
+interface Queue {
+  send(message: unknown): Promise<void>;
+}
+
+
+interface ExecutionContext {}
+
+
+interface Fetcher {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+
+interface KVNamespace {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+}
+
+
+interface DurableObjectId {}
+
+interface DurableObjectStub {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+interface DurableObjectNamespace {
+  idFromName(name: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub;
+}

--- a/packages/cloudflare-worker/tsconfig.json
+++ b/packages/cloudflare-worker/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../runtime-core"
+    },
+    {
+      "path": "../core"
+    }
+  ]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,3 +16,5 @@ export {
 export { bootstrapViewerToUser, isAppBootstrap, isAppLocale } from "./bootstrap.js";
 export type { AppBootstrap, AppLocale, BootstrapUser, BootstrapViewer } from "./bootstrap.js";
 export type { SsrEventData, SsrInitialData, SsrProfileData } from "./ssr.js";
+
+export * from "./storage.js";

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -1,0 +1,38 @@
+export type RuntimeTarget = "node" | "cloudflare";
+
+export interface SessionRecord {
+  token: string;
+  accountId: string;
+  expiresAt: string;
+}
+
+export interface AccountRecord {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+}
+
+export interface EventRecord {
+  id: string;
+  accountId: string;
+  title: string;
+  description: string | null;
+  startDate: string;
+  endDate: string | null;
+  visibility: "public" | "unlisted" | "followers_only" | "private";
+}
+
+export interface UploadBlob {
+  key: string;
+  contentType: string;
+  body: ArrayBuffer;
+}
+
+export interface EveryCalStorage {
+  runtime: RuntimeTarget;
+  getSession(token: string): Promise<SessionRecord | null>;
+  getAccountById(id: string): Promise<AccountRecord | null>;
+  listPublicEventsByUsername(username: string, limit?: number): Promise<EventRecord[]>;
+  upsertUpload(blob: UploadBlob): Promise<string>;
+}

--- a/packages/runtime-core/package.json
+++ b/packages/runtime-core/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@everycal/runtime-core",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc -b --pretty false"
+  },
+  "dependencies": {
+    "@everycal/core": "workspace:*",
+    "hono": "^4.12.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/runtime-core/src/index.test.ts
+++ b/packages/runtime-core/src/index.test.ts
@@ -1,0 +1,376 @@
+import { describe, expect, it } from "vitest";
+import { createUnifiedApp, type UnifiedEvent, type UnifiedIdentity, type UnifiedStorage, type UploadObject } from "./index";
+
+class MemoryStorage implements UnifiedStorage {
+  private accounts = new Map<string, { id: string; username: string; displayName: string | null; avatarUrl: string | null; passwordHash: string | null }>();
+  private sessions = new Map<string, { token: string; accountId: string; expiresAt: string }>();
+  public remoteFollows = new Map<string, Set<string>>();
+  public localFollows = new Map<string, Set<string>>();
+  public remoteFollowersByUsername = new Map<string, Set<string>>();
+  public remoteFollowingByAccountId = new Map<string, Set<string>>();
+  public remoteActors = new Map<string, { uri: string; username: string; displayName: string | null; domain: string; inbox: string | null; iconUrl: string | null }>();
+  public remoteEvents = new Map<string, { uri: string; actorUri: string; title: string; description: string | null; startDate: string; endDate: string | null }>();
+
+  getAccountIdByUsername(username: string): string | null {
+    return Array.from(this.accounts.values()).find((a) => a.username === username)?.id ?? null;
+  }
+
+  async getSession(token: string) { return this.sessions.get(token) ?? null; }
+  async createSession(accountId: string) {
+    const s = { token: crypto.randomUUID(), accountId, expiresAt: new Date(Date.now() + 86400000).toISOString() };
+    this.sessions.set(s.token, s);
+    return s;
+  }
+  async deleteSession(token: string) { this.sessions.delete(token); }
+  async getAccountById(id: string) { return this.accounts.get(id) ?? null; }
+  async getAccountByUsername(username: string) { return Array.from(this.accounts.values()).find((a) => a.username === username) ?? null; }
+  async createAccount(input: { username: string; displayName: string; passwordHash: string }) {
+    const id = crypto.randomUUID();
+    const a = { id, username: input.username, displayName: input.displayName, avatarUrl: null, passwordHash: input.passwordHash };
+    this.accounts.set(id, a);
+    return a;
+  }
+  async listEventsForAccount(_accountId: string): Promise<UnifiedEvent[]> { return []; }
+  async createEvent(_input: { accountId: string; title: string; description?: string; startDate: string; endDate?: string; visibility?: UnifiedEvent["visibility"] }) { return { id: crypto.randomUUID() }; }
+  async getEventById(_id: string): Promise<UnifiedEvent | null> { return null; }
+  async listPublicEventsByUsername(_username: string, _limit: number): Promise<UnifiedEvent[]> { return []; }
+  async createIdentity(_ownerAccountId: string, input: { username: string; displayName: string }): Promise<UnifiedIdentity> { return { id: crypto.randomUUID(), username: input.username, displayName: input.displayName, role: "owner" }; }
+  async listIdentitiesForMember(_memberAccountId: string): Promise<UnifiedIdentity[]> { return []; }
+  async addRemoteFollow(accountId: string, actorUri: string, _inbox: string): Promise<void> {
+    if (!this.remoteFollows.has(accountId)) this.remoteFollows.set(accountId, new Set());
+    this.remoteFollows.get(accountId)?.add(actorUri);
+  }
+  async removeRemoteFollow(accountId: string, actorUri: string): Promise<void> {
+    this.remoteFollows.get(accountId)?.delete(actorUri);
+  }
+  async listFollowersByUsername(username: string) {
+    const targetId = this.getAccountIdByUsername(username);
+    if (!targetId) return [];
+    const followerIds = Array.from(this.localFollows.entries())
+      .filter(([, following]) => following.has(targetId))
+      .map(([followerId]) => followerId);
+    return followerIds
+      .map((id) => this.accounts.get(id))
+      .filter((value): value is NonNullable<typeof value> => Boolean(value));
+  }
+  async listRemoteFollowerActorUrisByUsername(username: string): Promise<string[]> {
+    return Array.from(this.remoteFollowersByUsername.get(username) ?? []);
+  }
+  async listFollowingByUsername(username: string) {
+    const accountId = this.getAccountIdByUsername(username);
+    if (!accountId) return [];
+    const followingIds = Array.from(this.localFollows.get(accountId) ?? []);
+    return followingIds
+      .map((id) => this.accounts.get(id))
+      .filter((value): value is NonNullable<typeof value> => Boolean(value));
+  }
+  async listSavedLocations(_accountId: string) { return []; }
+  async saveLocation(_accountId: string, _loc: { name: string; address?: string; latitude?: number; longitude?: number }) { return; }
+  async deleteLocation(_accountId: string, _id: number) { return; }
+  async listRemoteActors() { return Array.from(this.remoteActors.values()); }
+  async searchRemoteActors(query = "") {
+    const q = query.toLowerCase();
+    return Array.from(this.remoteActors.values()).filter((actor) => actor.uri.toLowerCase().includes(q) || actor.username.toLowerCase().includes(q));
+  }
+  async listFollowedRemoteActors(accountId: string) {
+    return Array.from(this.remoteFollowingByAccountId.get(accountId) ?? []).map((uri) => {
+      const existing = this.remoteActors.get(uri);
+      return existing ?? {
+        uri,
+        username: uri.split("/").pop() ?? "",
+        displayName: null,
+        domain: "remote.example",
+        inbox: null,
+        iconUrl: null,
+      };
+    });
+  }
+  async upsertRemoteActor(actor: { uri: string; username: string; displayName: string | null; domain: string; inbox: string; iconUrl?: string | null }) { this.remoteActors.set(actor.uri, { ...actor, inbox: actor.inbox, iconUrl: actor.iconUrl ?? null }); return; }
+  async upsertRemoteEvent(event: { uri: string; actorUri: string; title: string; description: string | null; startDate: string; endDate: string | null }) { this.remoteEvents.set(event.uri, event); return; }
+  async followRemoteActor(accountId: string, actor: { uri: string; username: string; displayName: string | null; domain: string; inbox: string; iconUrl?: string | null }) {
+    if (!this.remoteFollowingByAccountId.has(accountId)) this.remoteFollowingByAccountId.set(accountId, new Set());
+    this.remoteFollowingByAccountId.get(accountId)?.add(actor.uri);
+    this.remoteActors.set(actor.uri, { ...actor, inbox: actor.inbox, iconUrl: actor.iconUrl ?? null });
+    return;
+  }
+  async unfollowRemoteActor(accountId: string, actorUri: string) {
+    this.remoteFollowingByAccountId.get(accountId)?.delete(actorUri);
+    return;
+  }
+  async listRemoteEvents() { return []; }
+  async putUpload(blob: { key: string; contentType: string; body: ArrayBuffer }): Promise<string> { return `/uploads/${blob.key}`; }
+  async getUpload(_key: string): Promise<UploadObject | null> { return null; }
+}
+
+describe("createUnifiedApp", () => {
+  it("registers and returns bootstrap with auth", async () => {
+    const app = createUnifiedApp({
+      storage: new MemoryStorage(),
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+    });
+
+    const registerRes = await app.request("http://localhost/api/v1/auth/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ username: "alice", password: "password123" }),
+    });
+    expect(registerRes.status).toBe(201);
+    const cookie = registerRes.headers.get("set-cookie");
+    expect(cookie).toContain("everycal_session=");
+
+    const bootstrapRes = await app.request("http://localhost/api/v1/bootstrap", {
+      headers: { cookie: cookie || "" },
+    });
+    const bootstrap = await bootstrapRes.json();
+    expect(bootstrap.authenticated).toBe(true);
+  });
+
+
+
+
+  it("requires ActivityPub Accept header for actor/event endpoints", async () => {
+    const storage = new MemoryStorage();
+    await storage.createAccount({ username: "alice", displayName: "Alice", passwordHash: "hash:a" });
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+    });
+
+    const actorRes = await app.request("http://localhost/users/alice", {
+      headers: { accept: "text/html" },
+    });
+    expect(actorRes.status).toBe(406);
+
+    const eventRes = await app.request("http://localhost/events/any", {
+      headers: { accept: "application/json" },
+    });
+    expect(eventRes.status).toBe(406);
+  });
+
+  it("returns ActivityPub follower/following collections with totals", async () => {
+    const storage = new MemoryStorage();
+    await storage.createAccount({ username: "alice", displayName: "Alice", passwordHash: "hash:a" });
+    await storage.createAccount({ username: "bob", displayName: "Bob", passwordHash: "hash:b" });
+    await storage.createAccount({ username: "carol", displayName: "Carol", passwordHash: "hash:c" });
+
+    const aliceId = storage.getAccountIdByUsername("alice") as string;
+    const bobId = storage.getAccountIdByUsername("bob") as string;
+    const carolId = storage.getAccountIdByUsername("carol") as string;
+
+    storage.localFollows.set(bobId, new Set([aliceId]));
+    storage.localFollows.set(aliceId, new Set([carolId]));
+    storage.remoteFollowersByUsername.set("alice", new Set(["https://remote.example/users/zoe"]));
+    storage.remoteFollowingByAccountId.set(aliceId, new Set(["https://remote.example/users/erin"]));
+
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+    });
+
+    const followersRes = await app.request("http://localhost/users/alice/followers", {
+      headers: { accept: "application/activity+json" },
+    });
+    expect(followersRes.status).toBe(200);
+    expect(followersRes.headers.get("content-type") || "").toContain("application/activity+json");
+    const followersBody = await followersRes.json() as { totalItems: number; orderedItems: string[] };
+    expect(followersBody.totalItems).toBe(2);
+    expect(followersBody.orderedItems).toContain("https://example.com/users/bob");
+    expect(followersBody.orderedItems).toContain("https://remote.example/users/zoe");
+
+    const followingRes = await app.request("http://localhost/users/alice/following", {
+      headers: { accept: "application/activity+json" },
+    });
+    expect(followingRes.status).toBe(200);
+    expect(followingRes.headers.get("content-type") || "").toContain("application/activity+json");
+    const followingBody = await followingRes.json() as { totalItems: number; orderedItems: string[] };
+    expect(followingBody.totalItems).toBe(2);
+    expect(followingBody.orderedItems).toContain("https://example.com/users/carol");
+    expect(followingBody.orderedItems).toContain("https://remote.example/users/erin");
+  });
+
+
+
+  it("validates shared inbox requests with verifyInboxRequest hook", async () => {
+    const storage = new MemoryStorage();
+    await storage.createAccount({ username: "alice", displayName: "Alice", passwordHash: "hash:a" });
+
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+      verifyInboxRequest: async () => ({ ok: false, status: 401, error: "invalid_signature" }),
+    });
+
+    const res = await app.request("http://localhost/inbox", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "Follow",
+        actor: "https://remote.example/users/bob",
+        inbox: "https://remote.example/inbox",
+        object: "https://example.com/users/alice",
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("invalid_signature");
+  });
+
+
+  it("syncs actor and delivers follow/unfollow activities via hooks", async () => {
+    const storage = new MemoryStorage();
+    const account = await storage.createAccount({ username: "alice", displayName: "Alice", passwordHash: "hash:a" });
+    const delivered: Array<{ inbox: string; activity: Record<string, unknown> }> = [];
+
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+      deliverActivity: async ({ inbox, activity }) => {
+        delivered.push({ inbox, activity });
+        return { ok: true, status: 202 };
+      },
+      syncRemoteActorAndEvents: async (actorUri) => {
+        const actor = {
+          uri: actorUri,
+          username: "remote",
+          displayName: "Remote",
+          domain: "remote.example",
+          inbox: "https://remote.example/inbox",
+          iconUrl: null,
+        };
+        await storage.upsertRemoteActor(actor);
+        await storage.upsertRemoteEvent({
+          uri: `${actorUri}/events/1`,
+          actorUri,
+          title: "Imported Event",
+          description: null,
+          startDate: "2030-01-01T00:00:00.000Z",
+          endDate: null,
+        });
+        return { actor, eventsSynced: 1 };
+      },
+    });
+
+    const session = await storage.createSession(account.id);
+    const cookie = `everycal_session=${session.token}`;
+
+    const syncRes = await app.request("http://localhost/api/v1/federation/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify({ actorUri: "https://remote.example/users/bob" }),
+    });
+    expect(syncRes.status).toBe(200);
+
+    const followRes = await app.request("http://localhost/api/v1/federation/follow", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify({ actorUri: "https://remote.example/users/bob" }),
+    });
+    expect(followRes.status).toBe(200);
+
+    storage.remoteFollowingByAccountId.set(account.id, new Set(["https://remote.example/users/bob"]));
+    const unfollowRes = await app.request("http://localhost/api/v1/federation/unfollow", {
+      method: "POST",
+      headers: { "content-type": "application/json", cookie },
+      body: JSON.stringify({ actorUri: "https://remote.example/users/bob" }),
+    });
+    expect(unfollowRes.status).toBe(200);
+
+    expect(delivered.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("handles shared inbox Follow and Undo(Follow) for local target actor", async () => {
+    const storage = new MemoryStorage();
+    await storage.createAccount({ username: "alice", displayName: "Alice", passwordHash: "hash:a" });
+
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+    });
+
+    const accountId = storage.getAccountIdByUsername("alice") as string;
+
+    const followRes = await app.request("http://localhost/inbox", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "Follow",
+        actor: "https://remote.example/users/bob",
+        inbox: "https://remote.example/inbox",
+        object: "https://example.com/users/alice",
+      }),
+    });
+    expect(followRes.status).toBe(200);
+    expect(storage.remoteFollows.get(accountId)?.has("https://remote.example/users/bob")).toBe(true);
+
+    const undoRes = await app.request("http://localhost/inbox", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "Undo",
+        actor: "https://remote.example/users/bob",
+        object: {
+          type: "Follow",
+          actor: "https://remote.example/users/bob",
+          object: "https://example.com/users/alice",
+        },
+      }),
+    });
+    expect(undoRes.status).toBe(200);
+    expect(storage.remoteFollows.get(accountId)?.has("https://remote.example/users/bob")).toBe(false);
+  });
+
+  it("handles Follow and Undo(Follow) in user inbox", async () => {
+    const storage = new MemoryStorage();
+    const app = createUnifiedApp({
+      storage,
+      baseUrl: "https://example.com",
+      sessionCookieName: "everycal_session",
+      hashPassword: async (p) => `hash:${p}`,
+      verifyPassword: async (p, h) => h === `hash:${p}`,
+    });
+
+    await app.request("http://localhost/api/v1/auth/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ username: "alice", password: "password123" }),
+    });
+
+    const accountId = storage.getAccountIdByUsername("alice");
+    expect(accountId).toBeTruthy();
+
+    const followRes = await app.request("http://localhost/users/alice/inbox", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "Follow", actor: "https://remote.example/users/bob", inbox: "https://remote.example/inbox" }),
+    });
+    expect(followRes.status).toBe(200);
+    expect(storage.remoteFollows.get(accountId as string)?.has("https://remote.example/users/bob")).toBe(true);
+
+    const undoRes = await app.request("http://localhost/users/alice/inbox", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "Undo", object: { type: "Follow", actor: "https://remote.example/users/bob" } }),
+    });
+    expect(undoRes.status).toBe(200);
+    expect(storage.remoteFollows.get(accountId as string)?.has("https://remote.example/users/bob")).toBe(false);
+  });
+});

--- a/packages/runtime-core/src/index.ts
+++ b/packages/runtime-core/src/index.ts
@@ -1,0 +1,735 @@
+import { Hono } from "hono";
+import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { toActivityPubEvent, toICal, type EveryCalEvent } from "@everycal/core";
+
+export interface UnifiedAccount {
+  id: string;
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  passwordHash: string | null;
+}
+
+export interface UnifiedEvent {
+  id: string;
+  accountId: string;
+  title: string;
+  description: string | null;
+  startDate: string;
+  endDate: string | null;
+  visibility: "public" | "unlisted" | "followers_only" | "private";
+}
+
+export interface UnifiedIdentity {
+  id: string;
+  username: string;
+  displayName: string | null;
+  role: "owner" | "editor";
+}
+
+export interface UnifiedSession {
+  token: string;
+  accountId: string;
+  expiresAt: string;
+}
+
+export interface UploadObject {
+  body: BodyInit;
+  contentType?: string;
+}
+
+export interface SavedLocation {
+  id: number;
+  name: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  usedAt: string;
+}
+
+export interface RemoteActorSummary {
+  uri: string;
+  username: string;
+  displayName: string | null;
+  domain: string;
+  inbox: string | null;
+  iconUrl?: string | null;
+}
+
+export interface RemoteEventSummary {
+  uri: string;
+  actorUri: string;
+  title: string;
+  description: string | null;
+  startDate: string;
+  endDate: string | null;
+}
+
+export interface UnifiedStorage {
+  getSession(token: string): Promise<UnifiedSession | null>;
+  createSession(accountId: string): Promise<UnifiedSession>;
+  deleteSession(token: string): Promise<void>;
+  getAccountById(id: string): Promise<UnifiedAccount | null>;
+  getAccountByUsername(username: string): Promise<UnifiedAccount | null>;
+  createAccount(input: { username: string; displayName: string; passwordHash: string }): Promise<UnifiedAccount>;
+  listEventsForAccount(accountId: string): Promise<UnifiedEvent[]>;
+  createEvent(input: {
+    accountId: string;
+    title: string;
+    description?: string;
+    startDate: string;
+    endDate?: string;
+    visibility?: UnifiedEvent["visibility"];
+  }): Promise<{ id: string }>;
+  getEventById(id: string): Promise<UnifiedEvent | null>;
+  listPublicEventsByUsername(username: string, limit: number): Promise<UnifiedEvent[]>;
+  createIdentity(ownerAccountId: string, input: { username: string; displayName: string }): Promise<UnifiedIdentity>;
+  listIdentitiesForMember(memberAccountId: string): Promise<UnifiedIdentity[]>;
+  addRemoteFollow(accountId: string, actorUri: string, inbox: string): Promise<void>;
+  removeRemoteFollow(accountId: string, actorUri: string): Promise<void>;
+  listFollowersByUsername(username: string): Promise<UnifiedAccount[]>;
+  listRemoteFollowerActorUrisByUsername(username: string): Promise<string[]>;
+  listFollowingByUsername(username: string): Promise<UnifiedAccount[]>;
+  listSavedLocations(accountId: string): Promise<SavedLocation[]>;
+  saveLocation(accountId: string, loc: { name: string; address?: string; latitude?: number; longitude?: number }): Promise<void>;
+  deleteLocation(accountId: string, id: number): Promise<void>;
+  listRemoteActors(params?: { domain?: string; limit?: number }): Promise<RemoteActorSummary[]>;
+  searchRemoteActors(query: string): Promise<RemoteActorSummary[]>;
+  listFollowedRemoteActors(accountId: string): Promise<RemoteActorSummary[]>;
+  upsertRemoteActor(actor: RemoteActorSummary & { inbox: string }): Promise<void>;
+  upsertRemoteEvent(event: RemoteEventSummary): Promise<void>;
+  followRemoteActor(accountId: string, actor: RemoteActorSummary & { inbox: string }): Promise<void>;
+  unfollowRemoteActor(accountId: string, actorUri: string): Promise<void>;
+  listRemoteEvents(params?: { actor?: string; from?: string; limit?: number; offset?: number }): Promise<RemoteEventSummary[]>;
+  putUpload(blob: { key: string; contentType: string; body: ArrayBuffer }): Promise<string>;
+  getUpload(key: string): Promise<UploadObject | null>;
+}
+
+type InboxActivity = {
+  type?: string;
+  actor?: string;
+  inbox?: string;
+  object?: string | {
+    id?: string;
+    type?: string;
+    actor?: string;
+    object?: string | { id?: string };
+  };
+};
+
+export type InboxVerificationResult = { ok: true } | { ok: false; status?: number; error?: string };
+
+
+export type DeliveryResult = { ok: true; status?: number } | { ok: false; status?: number; error?: string };
+
+export type SyncResult = {
+  actor: (RemoteActorSummary & { inbox: string }) | null;
+  eventsSynced: number;
+};
+
+export interface UnifiedAppDeps {
+  storage: UnifiedStorage;
+  baseUrl: string;
+  sessionCookieName: string;
+  hashPassword(password: string): Promise<string>;
+  verifyPassword(password: string, encodedHash: string | null): Promise<boolean>;
+  verifyInboxRequest?(input: { request: Request; activity: InboxActivity }): Promise<InboxVerificationResult>;
+  deliverActivity?(input: { inbox: string; activity: Record<string, unknown>; actorKeyId: string }): Promise<DeliveryResult>;
+  syncRemoteActorAndEvents?(actorUri: string): Promise<SyncResult>;
+}
+
+type Variables = { accountId: string | null };
+
+const AP_CONTENT_TYPE = "application/activity+json; charset=utf-8";
+const AP_ACCEPT_TOKENS = ["application/activity+json", "application/ld+json"];
+
+function isActivityPubRequest(acceptHeader: string): boolean {
+  const accept = acceptHeader.toLowerCase();
+  return AP_ACCEPT_TOKENS.some((token) => accept.includes(token));
+}
+
+function normalizeHandle(input: string): string {
+  return input.trim().toLowerCase().replace(/^@+/, "");
+}
+
+
+function resolveLocalUsernameFromActorUri(actorUri: string, baseUrl: string): string | null {
+  const normalizedBase = baseUrl.replace(/\/$/, "");
+  if (!actorUri.startsWith(`${normalizedBase}/users/`)) return null;
+  const remainder = actorUri.slice(`${normalizedBase}/users/`.length);
+  const username = remainder.split("/")[0]?.trim();
+  return username ? normalizeHandle(username) : null;
+}
+
+function resolveFollowTargetUsername(activity: InboxActivity, baseUrl: string): string | null {
+  if (activity.type !== "Follow") return null;
+  const object = activity.object;
+  if (typeof object === "string") return resolveLocalUsernameFromActorUri(object, baseUrl);
+  if (object && typeof object.id === "string") return resolveLocalUsernameFromActorUri(object.id, baseUrl);
+  return null;
+}
+
+function resolveUndoTargetUsername(activity: InboxActivity, baseUrl: string): string | null {
+  if (activity.type !== "Undo") return null;
+  const undoObject = activity.object;
+  if (!undoObject || typeof undoObject === "string") return null;
+  if (undoObject.type !== "Follow") return null;
+  const followed = undoObject.object;
+  if (typeof followed === "string") return resolveLocalUsernameFromActorUri(followed, baseUrl);
+  if (followed && typeof followed.id === "string") return resolveLocalUsernameFromActorUri(followed.id, baseUrl);
+  return null;
+}
+
+export function createUnifiedApp(deps: UnifiedAppDeps): Hono<{ Variables: Variables }> {
+  const app = new Hono<{ Variables: Variables }>();
+
+  app.use("*", async (c, next) => {
+    const token = getCookie(c, deps.sessionCookieName);
+    if (!token) {
+      c.set("accountId", null);
+      await next();
+      return;
+    }
+    const session = await deps.storage.getSession(token);
+    c.set("accountId", session?.accountId ?? null);
+    await next();
+  });
+
+  app.get("/healthz", (c) => c.json({ status: "ok" }));
+
+  app.get("/api/v1/bootstrap", async (c) => {
+    const accountId = c.get("accountId");
+    const account = accountId ? await deps.storage.getAccountById(accountId) : null;
+    return c.json({ mode: "unified", authenticated: Boolean(account), account });
+  });
+
+  app.post("/api/v1/auth/register", async (c) => {
+    const body = await c.req.json<{ username: string; displayName?: string; password: string }>();
+    const username = normalizeHandle(body.username || "");
+    if (!/^[a-z0-9_]{3,32}$/.test(username)) return c.json({ error: "invalid_username" }, 400);
+    if (!body.password || body.password.length < 8) return c.json({ error: "password_too_short" }, 400);
+
+    const existing = await deps.storage.getAccountByUsername(username);
+    if (existing) return c.json({ error: "username_taken" }, 409);
+
+    const account = await deps.storage.createAccount({
+      username,
+      displayName: body.displayName?.trim() || username,
+      passwordHash: await deps.hashPassword(body.password),
+    });
+
+    const session = await deps.storage.createSession(account.id);
+    setCookie(c, deps.sessionCookieName, session.token, {
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+      maxAge: 60 * 60 * 24 * 14,
+    });
+
+    return c.json({ user: account, expiresAt: session.expiresAt }, 201);
+  });
+
+  app.post("/api/v1/auth/login", async (c) => {
+    const body = await c.req.json<{ username: string; password: string }>();
+    const account = await deps.storage.getAccountByUsername(normalizeHandle(body.username || ""));
+    if (!account) return c.json({ error: "invalid_credentials" }, 401);
+    const ok = await deps.verifyPassword(body.password || "", account.passwordHash);
+    if (!ok) return c.json({ error: "invalid_credentials" }, 401);
+    const session = await deps.storage.createSession(account.id);
+    setCookie(c, deps.sessionCookieName, session.token, {
+      path: "/",
+      httpOnly: true,
+      secure: true,
+      sameSite: "Lax",
+      maxAge: 60 * 60 * 24 * 14,
+    });
+    return c.json({
+      user: {
+        id: account.id,
+        username: account.username,
+        displayName: account.displayName,
+        avatarUrl: account.avatarUrl,
+      },
+      expiresAt: session.expiresAt,
+    });
+  });
+
+  app.post("/api/v1/auth/logout", async (c) => {
+    const token = getCookie(c, deps.sessionCookieName);
+    if (token) await deps.storage.deleteSession(token);
+    deleteCookie(c, deps.sessionCookieName, { path: "/" });
+    return c.json({ ok: true });
+  });
+
+  app.get("/api/v1/auth/me", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const account = await deps.storage.getAccountById(accountId);
+    if (!account) return c.json({ error: "unauthorized" }, 401);
+    return c.json({ user: account });
+  });
+
+  app.get("/api/v1/events", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    return c.json({ events: await deps.storage.listEventsForAccount(accountId) });
+  });
+
+  app.post("/api/v1/events", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+
+    const body = await c.req.json<{
+      title: string;
+      description?: string;
+      startDate: string;
+      endDate?: string;
+      visibility?: UnifiedEvent["visibility"];
+    }>();
+    if (!body.title || !body.startDate) return c.json({ error: "missing_required_fields" }, 400);
+
+    const created = await deps.storage.createEvent({
+      accountId,
+      title: body.title,
+      description: body.description,
+      startDate: body.startDate,
+      endDate: body.endDate,
+      visibility: body.visibility,
+    });
+    return c.json({ event: await deps.storage.getEventById(created.id) }, 201);
+  });
+
+  app.get("/api/v1/events/:username", async (c) => {
+    const events = await deps.storage.listPublicEventsByUsername(c.req.param("username"), 100);
+    return c.json({ events });
+  });
+
+  app.get("/api/v1/identities", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    return c.json({ identities: await deps.storage.listIdentitiesForMember(accountId) });
+  });
+
+  app.post("/api/v1/identities", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const body = await c.req.json<{ username: string; displayName?: string }>();
+    const username = normalizeHandle(body.username || "");
+    if (!/^[a-z0-9_]{3,32}$/.test(username)) return c.json({ error: "invalid_username" }, 400);
+    const identity = await deps.storage.createIdentity(accountId, {
+      username,
+      displayName: body.displayName || username,
+    });
+    return c.json({ identity }, 201);
+  });
+
+
+  app.get("/api/v1/users/:username/followers", async (c) => {
+    const users = await deps.storage.listFollowersByUsername(normalizeHandle(c.req.param("username")));
+    return c.json({ users: users.map((u) => ({ id: u.id, username: u.username, displayName: u.displayName, avatarUrl: u.avatarUrl })) });
+  });
+
+  app.get("/api/v1/users/:username/following", async (c) => {
+    const users = await deps.storage.listFollowingByUsername(normalizeHandle(c.req.param("username")));
+    return c.json({ users: users.map((u) => ({ id: u.id, username: u.username, displayName: u.displayName, avatarUrl: u.avatarUrl })) });
+  });
+
+  app.get("/api/v1/locations", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    return c.json(await deps.storage.listSavedLocations(accountId));
+  });
+
+  app.post("/api/v1/locations", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const body = await c.req.json<{ name: string; address?: string; latitude?: number; longitude?: number }>();
+    if (!body.name?.trim()) return c.json({ error: "name_required" }, 400);
+    await deps.storage.saveLocation(accountId, body);
+    return c.json({ ok: true });
+  });
+
+  app.delete("/api/v1/locations/:id", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const id = Number.parseInt(c.req.param("id"), 10);
+    if (!Number.isFinite(id)) return c.json({ error: "invalid_id" }, 400);
+    await deps.storage.deleteLocation(accountId, id);
+    return c.json({ ok: true });
+  });
+
+  app.get("/api/v1/feeds/:username.ics", async (c) => {
+    const username = c.req.param("username");
+    const events = await deps.storage.listPublicEventsByUsername(username, 200);
+    const vevents = events.map((event) => {
+      const normalized: EveryCalEvent = {
+        id: event.id,
+        title: event.title,
+        description: event.description ?? undefined,
+        startDate: event.startDate,
+        endDate: event.endDate ?? undefined,
+        allDay: false,
+        visibility: event.visibility,
+        createdAt: event.startDate,
+        updatedAt: event.startDate,
+        url: `${deps.baseUrl}/events/${event.id}`,
+      };
+      return toICal(normalized);
+    });
+
+    c.header("content-type", "text/calendar; charset=utf-8");
+    return c.body([
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      `PRODID:-//EveryCal//${username}//EN`,
+      `X-WR-CALNAME:${username}`,
+      ...vevents,
+      "END:VCALENDAR",
+    ].join("\r\n"));
+  });
+
+  app.get("/api/v1/feeds/:username.json", async (c) => {
+    return c.json({ events: await deps.storage.listPublicEventsByUsername(c.req.param("username"), 200) });
+  });
+
+
+
+  app.get("/api/v1/federation/search", async (c) => {
+    const q = (c.req.query("q") || "").trim();
+    if (q.length < 2) return c.json({ error: "query_too_short" }, 400);
+    const actors = await deps.storage.searchRemoteActors(q);
+    if (actors.length === 0) return c.json({ error: "actor_not_found" }, 404);
+    return c.json({ actor: actors[0] });
+  });
+
+  app.post("/api/v1/federation/follow", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const body = await c.req.json<{ actorUri?: string }>();
+    if (!body.actorUri) return c.json({ error: "actor_uri_required" }, 400);
+
+    if (deps.syncRemoteActorAndEvents) {
+      const synced = await deps.syncRemoteActorAndEvents(body.actorUri);
+      if (synced.actor) {
+        await deps.storage.upsertRemoteActor(synced.actor);
+      }
+    }
+
+    const actor = (await deps.storage.searchRemoteActors(body.actorUri)).find((a) => a.uri === body.actorUri)
+      ?? (await deps.storage.listRemoteActors({ limit: 1000 })).find((a) => a.uri === body.actorUri);
+    if (!actor || !actor.inbox) return c.json({ error: "actor_not_found" }, 404);
+    await deps.storage.followRemoteActor(accountId, { ...actor, inbox: actor.inbox });
+
+    let delivered = false;
+    if (deps.deliverActivity) {
+      const account = await deps.storage.getAccountById(accountId);
+      if (account) {
+        const actorUrl = `${deps.baseUrl}/users/${account.username}`;
+        const followActivity = {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          id: `${actorUrl}#follow-${Date.now()}`,
+          type: "Follow",
+          actor: actorUrl,
+          object: body.actorUri,
+        };
+        const delivery = await deps.deliverActivity({ inbox: actor.inbox, activity: followActivity, actorKeyId: `${actorUrl}#main-key` });
+        delivered = delivery.ok;
+      }
+    }
+
+    return c.json({ ok: true, delivered });
+  });
+
+  app.post("/api/v1/federation/unfollow", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const body = await c.req.json<{ actorUri?: string }>();
+    if (!body.actorUri) return c.json({ error: "actor_uri_required" }, 400);
+
+    const existing = (await deps.storage.listFollowedRemoteActors(accountId)).find((actor) => actor.uri === body.actorUri);
+
+    let delivered = false;
+    if (deps.deliverActivity && existing?.inbox) {
+      const account = await deps.storage.getAccountById(accountId);
+      if (account) {
+        const actorUrl = `${deps.baseUrl}/users/${account.username}`;
+        const followObject = {
+          id: `${actorUrl}#follow-${Date.now()}`,
+          type: "Follow",
+          actor: actorUrl,
+          object: body.actorUri,
+        };
+        const undoActivity = {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          id: `${actorUrl}#undo-${Date.now()}`,
+          type: "Undo",
+          actor: actorUrl,
+          object: followObject,
+        };
+        const delivery = await deps.deliverActivity({ inbox: existing.inbox, activity: undoActivity, actorKeyId: `${actorUrl}#main-key` });
+        delivered = delivery.ok;
+      }
+    }
+
+    await deps.storage.unfollowRemoteActor(accountId, body.actorUri);
+    return c.json({ ok: true, delivered });
+  });
+
+  app.get("/api/v1/federation/following", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    const actors = await deps.storage.listFollowedRemoteActors(accountId);
+    return c.json({ actors });
+  });
+
+  app.get("/api/v1/federation/actors", async (c) => {
+    const domain = c.req.query("domain") || undefined;
+    const limit = Number.parseInt(c.req.query("limit") || "20", 10);
+    const actors = await deps.storage.listRemoteActors({ domain, limit: Number.isFinite(limit) ? limit : 20 });
+    return c.json({ actors });
+  });
+
+  app.get("/api/v1/federation/remote-events", async (c) => {
+    const actor = c.req.query("actor") || undefined;
+    const from = c.req.query("from") || undefined;
+    const limit = Number.parseInt(c.req.query("limit") || "50", 10);
+    const offset = Number.parseInt(c.req.query("offset") || "0", 10);
+    const events = await deps.storage.listRemoteEvents({
+      actor,
+      from,
+      limit: Number.isFinite(limit) ? limit : 50,
+      offset: Number.isFinite(offset) ? offset : 0,
+    });
+    return c.json({ events });
+  });
+
+  app.post("/api/v1/federation/sync", async (c) => {
+    const accountId = c.get("accountId");
+    if (!accountId) return c.json({ error: "unauthorized" }, 401);
+    if (!deps.syncRemoteActorAndEvents) return c.json({ error: "sync_not_supported" }, 501);
+    const body = await c.req.json<{ actorUri?: string }>();
+    if (!body.actorUri) return c.json({ error: "actor_uri_required" }, 400);
+    const result = await deps.syncRemoteActorAndEvents(body.actorUri);
+    if (result.actor) await deps.storage.upsertRemoteActor(result.actor);
+    return c.json({ ok: true, actor: result.actor, eventsSynced: result.eventsSynced });
+  });
+
+  app.put("/api/v1/uploads/:key", async (c) => {
+    const key = c.req.param("key");
+    const contentType = c.req.header("content-type") || "application/octet-stream";
+    const url = await deps.storage.putUpload({ key, contentType, body: await c.req.arrayBuffer() });
+    return c.json({ url });
+  });
+
+  app.get("/uploads/:key", async (c) => {
+    const object = await deps.storage.getUpload(c.req.param("key"));
+    if (!object) return c.notFound();
+    if (object.contentType) c.header("Content-Type", object.contentType);
+    return c.body(object.body);
+  });
+
+
+  app.get("/.well-known/nodeinfo", (c) => {
+    return c.json({
+      links: [
+        { rel: "http://nodeinfo.diaspora.software/ns/schema/2.0", href: `${deps.baseUrl}/nodeinfo/2.0` },
+        { rel: "http://nodeinfo.diaspora.software/ns/schema/2.1", href: `${deps.baseUrl}/nodeinfo/2.1` },
+      ],
+    });
+  });
+
+  app.get("/nodeinfo/:version", (c) => {
+    const version = c.req.param("version");
+    if (version !== "2.0" && version !== "2.1") return c.notFound();
+    return c.json({
+      version,
+      software: { name: "everycal", version: "0.1.0" },
+      protocols: ["activitypub"],
+      services: { inbound: [], outbound: [] },
+      openRegistrations: true,
+      usage: { users: { total: 0, activeHalfyear: 0, activeMonth: 0 }, localPosts: 0, localComments: 0 },
+      metadata: { runtime: "unified" },
+    });
+  });
+
+  app.get("/.well-known/webfinger", async (c) => {
+    const resource = c.req.query("resource") || "";
+    const match = resource.match(/^acct:([^@]+)@/);
+    if (!match) return c.json({ error: "invalid_resource" }, 400);
+    const username = normalizeHandle(match[1]);
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    return c.json({
+      subject: resource,
+      links: [{ rel: "self", type: "application/activity+json", href: `${deps.baseUrl}/users/${username}` }],
+    });
+  });
+
+  app.get("/users/:username", async (c) => {
+    if (!isActivityPubRequest(c.req.header("accept") || "")) {
+      return c.json({ error: "accept_activity_json" }, 406);
+    }
+    const username = normalizeHandle(c.req.param("username"));
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    const actorUrl = `${deps.baseUrl}/users/${username}`;
+    return c.json({
+      "@context": "https://www.w3.org/ns/activitystreams",
+      id: actorUrl,
+      type: "Person",
+      preferredUsername: username,
+      name: account.displayName || username,
+      inbox: `${actorUrl}/inbox`,
+      outbox: `${actorUrl}/outbox`,
+      followers: `${actorUrl}/followers`,
+      following: `${actorUrl}/following`,
+    }, 200, { "Content-Type": AP_CONTENT_TYPE });
+  });
+
+  app.get("/users/:username/outbox", async (c) => {
+    if (!isActivityPubRequest(c.req.header("accept") || "")) {
+      return c.json({ error: "accept_activity_json" }, 406);
+    }
+    const username = normalizeHandle(c.req.param("username"));
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    const events = await deps.storage.listPublicEventsByUsername(username, 40);
+    return c.json({
+      "@context": "https://www.w3.org/ns/activitystreams",
+      type: "OrderedCollection",
+      totalItems: events.length,
+      orderedItems: events.map((event) => ({
+        id: `${deps.baseUrl}/activities/create-${event.id}`,
+        type: "Create",
+        actor: `${deps.baseUrl}/users/${username}`,
+        object: toActivityPubEvent({
+          id: `${deps.baseUrl}/events/${event.id}`,
+          title: event.title,
+          description: event.description || "",
+          startDate: event.startDate,
+          endDate: event.endDate || undefined,
+          allDay: false,
+          visibility: event.visibility,
+          createdAt: event.startDate,
+          updatedAt: event.startDate,
+          url: `${deps.baseUrl}/events/${event.id}`,
+        }),
+      })),
+    }, 200, { "Content-Type": AP_CONTENT_TYPE });
+  });
+
+
+  app.get("/users/:username/followers", async (c) => {
+    if (!isActivityPubRequest(c.req.header("accept") || "")) {
+      return c.json({ error: "accept_activity_json" }, 406);
+    }
+    const username = normalizeHandle(c.req.param("username"));
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    const followers = await deps.storage.listFollowersByUsername(username);
+    const remoteFollowerActorUris = await deps.storage.listRemoteFollowerActorUrisByUsername(username);
+    const orderedItems = Array.from(new Set([
+      ...followers.map((follower) => `${deps.baseUrl}/users/${follower.username}`),
+      ...remoteFollowerActorUris,
+    ]));
+    return c.json({
+      "@context": "https://www.w3.org/ns/activitystreams",
+      id: `${deps.baseUrl}/users/${username}/followers`,
+      type: "OrderedCollection",
+      totalItems: orderedItems.length,
+      orderedItems,
+    }, 200, { "Content-Type": AP_CONTENT_TYPE });
+  });
+
+  app.get("/users/:username/following", async (c) => {
+    if (!isActivityPubRequest(c.req.header("accept") || "")) {
+      return c.json({ error: "accept_activity_json" }, 406);
+    }
+    const username = normalizeHandle(c.req.param("username"));
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    const following = await deps.storage.listFollowingByUsername(username);
+    const remoteFollowing = await deps.storage.listFollowedRemoteActors(account.id);
+    const orderedItems = Array.from(new Set([
+      ...following.map((followed) => `${deps.baseUrl}/users/${followed.username}`),
+      ...remoteFollowing.map((actor) => actor.uri),
+    ]));
+    return c.json({
+      "@context": "https://www.w3.org/ns/activitystreams",
+      id: `${deps.baseUrl}/users/${username}/following`,
+      type: "OrderedCollection",
+      totalItems: orderedItems.length,
+      orderedItems,
+    }, 200, { "Content-Type": AP_CONTENT_TYPE });
+  });
+
+  app.post("/users/:username/inbox", async (c) => {
+    const username = normalizeHandle(c.req.param("username"));
+    const account = await deps.storage.getAccountByUsername(username);
+    if (!account) return c.notFound();
+    const body = await c.req.json<InboxActivity>();
+    if (body.type === "Follow" && body.actor && body.inbox) {
+      await deps.storage.addRemoteFollow(account.id, body.actor, body.inbox);
+      return c.json({ ok: true, accepted: "follow" });
+    }
+    if (body.type === "Undo" && body.object && typeof body.object !== "string" && body.object.type === "Follow" && body.object.actor) {
+      await deps.storage.removeRemoteFollow(account.id, body.object.actor);
+      return c.json({ ok: true, accepted: "undo-follow" });
+    }
+    return c.json({ ok: true });
+  });
+
+  app.get("/events/:id", async (c) => {
+    if (!isActivityPubRequest(c.req.header("accept") || "")) {
+      return c.json({ error: "accept_activity_json" }, 406);
+    }
+    const event = await deps.storage.getEventById(c.req.param("id"));
+    if (!event) return c.notFound();
+    return c.json(toActivityPubEvent({
+      id: `${deps.baseUrl}/events/${event.id}`,
+      title: event.title,
+      description: event.description || "",
+      startDate: event.startDate,
+      endDate: event.endDate || undefined,
+      allDay: false,
+      visibility: event.visibility,
+      createdAt: event.startDate,
+      updatedAt: event.startDate,
+      url: `${deps.baseUrl}/events/${event.id}`,
+    }), 200, { "Content-Type": AP_CONTENT_TYPE });
+  });
+
+  app.post("/inbox", async (c) => {
+    const body = await c.req.json<InboxActivity>();
+
+    if (deps.verifyInboxRequest) {
+      const verification = await deps.verifyInboxRequest({ request: c.req.raw, activity: body });
+      if (!verification.ok) {
+        return c.json({ error: verification.error || "invalid_signature" }, verification.status || 401);
+      }
+    }
+
+    const followTargetUsername = resolveFollowTargetUsername(body, deps.baseUrl);
+    if (followTargetUsername && body.actor && body.inbox) {
+      const account = await deps.storage.getAccountByUsername(followTargetUsername);
+      if (account) {
+        await deps.storage.addRemoteFollow(account.id, body.actor, body.inbox);
+        return c.json({ ok: true, accepted: "shared-follow" });
+      }
+    }
+
+    const undoTargetUsername = resolveUndoTargetUsername(body, deps.baseUrl);
+    if (undoTargetUsername && body.actor) {
+      const account = await deps.storage.getAccountByUsername(undoTargetUsername);
+      if (account) {
+        await deps.storage.removeRemoteFollow(account.id, body.actor);
+        return c.json({ ok: true, accepted: "shared-undo-follow" });
+      }
+    }
+
+    return c.json({ ok: true });
+  });
+
+  return app;
+}

--- a/packages/runtime-core/tsconfig.json
+++ b/packages/runtime-core/tsconfig.json
@@ -12,11 +12,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
     "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "composite": true
   },
   "include": [
     "src"
@@ -27,7 +26,6 @@
     }
   ],
   "exclude": [
-    "src/unified-index.ts",
-    "src/storage/node-storage.ts"
+    "src/**/*.test.ts"
   ]
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -10,7 +10,9 @@
     "dev": "cross-env NODE_ENV=development node --watch-path=src --import tsx src/index.ts",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "lint": "tsc -b --pretty false"
+    "lint": "tsc -b --pretty false",
+    "dev:unified": "cross-env NODE_ENV=development node --watch-path=src --import tsx src/unified-index.ts",
+    "start:unified": "node dist/unified-index.js"
   },
   "dependencies": {
     "@everycal/core": "workspace:*",
@@ -25,7 +27,8 @@
     "nodemailer": "^7.0.11",
     "sanitize-html": "^2.17.0",
     "sharp": "^0.34.5",
-    "vike": "^0.4.255"
+    "vike": "^0.4.255",
+    "@everycal/runtime-core": "workspace:*"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",

--- a/packages/server/src/storage/node-storage.ts
+++ b/packages/server/src/storage/node-storage.ts
@@ -1,0 +1,375 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { AccountRecord, EveryCalStorage, EventRecord, SessionRecord, UploadBlob } from "@everycal/core";
+import type { UnifiedAccount, UnifiedEvent, UnifiedIdentity, UnifiedStorage, UploadObject, SavedLocation, RemoteActorSummary, RemoteEventSummary } from "@everycal/runtime-core";
+import type { DB } from "../db.js";
+
+export class NodeStorage implements EveryCalStorage, UnifiedStorage {
+  runtime = "node" as const;
+
+  constructor(
+    private readonly db: DB,
+    private readonly uploadDir: string
+  ) {}
+
+  async getSession(token: string): Promise<SessionRecord | null> {
+    const row = this.db
+      .prepare("SELECT token, account_id, expires_at FROM sessions WHERE token = ? AND expires_at > datetime('now')")
+      .get(token) as { token: string; account_id: string; expires_at: string } | undefined;
+    return row ? { token: row.token, accountId: row.account_id, expiresAt: row.expires_at } : null;
+  }
+
+  async createSession(accountId: string): Promise<SessionRecord> {
+    const token = crypto.randomUUID();
+    this.db.prepare("INSERT INTO sessions (token, account_id, expires_at) VALUES (?, ?, datetime('now', '+14 day'))").run(token, accountId);
+    const row = this.db.prepare("SELECT token, account_id, expires_at FROM sessions WHERE token = ?").get(token) as {
+      token: string;
+      account_id: string;
+      expires_at: string;
+    } | undefined;
+    if (!row) throw new Error("failed_to_create_session");
+    return { token: row.token, accountId: row.account_id, expiresAt: row.expires_at };
+  }
+
+  async deleteSession(token: string): Promise<void> {
+    this.db.prepare("DELETE FROM sessions WHERE token = ?").run(token);
+  }
+
+  async getAccountById(id: string): Promise<AccountRecord | null> {
+    const row = this.db
+      .prepare("SELECT id, username, display_name, avatar_url, password_hash FROM accounts WHERE id = ?")
+      .get(id) as { id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null } | undefined;
+    return row ? {
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    } as UnifiedAccount : null;
+  }
+
+  async getAccountByUsername(username: string): Promise<UnifiedAccount | null> {
+    const row = this.db
+      .prepare("SELECT id, username, display_name, avatar_url, password_hash FROM accounts WHERE username = ?")
+      .get(username) as { id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null } | undefined;
+    return row ? {
+      id: row.id,
+      username: row.username,
+      displayName: row.display_name,
+      avatarUrl: row.avatar_url,
+      passwordHash: row.password_hash,
+    } : null;
+  }
+
+  async createAccount(input: { username: string; displayName: string; passwordHash: string }): Promise<UnifiedAccount> {
+    const id = crypto.randomUUID();
+    this.db.prepare("INSERT INTO accounts (id, username, display_name, password_hash) VALUES (?, ?, ?, ?)")
+      .run(id, input.username, input.displayName, input.passwordHash);
+    const account = await this.getAccountById(id);
+    if (!account) throw new Error("failed_to_create_account");
+    return account as UnifiedAccount;
+  }
+
+  async listPublicEventsByUsername(username: string, limit = 50): Promise<EventRecord[]> {
+    const rows = this.db
+      .prepare(
+        `SELECT e.id, e.account_id, e.title, e.description, e.start_date, e.end_date, e.visibility
+         FROM events e JOIN accounts a ON a.id = e.account_id
+         WHERE a.username = ? AND e.visibility IN ('public','unlisted')
+         ORDER BY e.start_date ASC LIMIT ?`
+      )
+      .all(username, limit) as Array<{
+        id: string;
+        account_id: string;
+        title: string;
+        description: string | null;
+        start_date: string;
+        end_date: string | null;
+        visibility: UnifiedEvent["visibility"];
+      }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    }));
+  }
+
+  async listEventsForAccount(accountId: string): Promise<UnifiedEvent[]> {
+    const rows = this.db
+      .prepare("SELECT id, account_id, title, description, start_date, end_date, visibility FROM events WHERE account_id = ? ORDER BY start_date ASC")
+      .all(accountId) as Array<{ id: string; account_id: string; title: string; description: string | null; start_date: string; end_date: string | null; visibility: UnifiedEvent['visibility'] }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    }));
+  }
+
+  async createEvent(input: { accountId: string; title: string; description?: string; startDate: string; endDate?: string; visibility?: UnifiedEvent['visibility'] }): Promise<{ id: string }> {
+    const id = crypto.randomUUID();
+    this.db.prepare(
+      "INSERT INTO events (id, account_id, title, description, start_date, end_date, visibility) VALUES (?, ?, ?, ?, ?, ?, ?)"
+    ).run(id, input.accountId, input.title, input.description ?? null, input.startDate, input.endDate ?? null, input.visibility ?? "public");
+    return { id };
+  }
+
+  async getEventById(id: string): Promise<UnifiedEvent | null> {
+    const row = this.db.prepare(
+      "SELECT id, account_id, title, description, start_date, end_date, visibility FROM events WHERE id = ?"
+    ).get(id) as { id: string; account_id: string; title: string; description: string | null; start_date: string; end_date: string | null; visibility: UnifiedEvent['visibility'] } | undefined;
+    return row ? {
+      id: row.id,
+      accountId: row.account_id,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+      visibility: row.visibility,
+    } : null;
+  }
+
+  async createIdentity(ownerAccountId: string, input: { username: string; displayName: string }): Promise<UnifiedIdentity> {
+    const id = crypto.randomUUID();
+    this.db.prepare("INSERT INTO accounts (id, username, display_name, account_type) VALUES (?, ?, ?, 'identity')")
+      .run(id, input.username, input.displayName);
+    this.db.prepare("INSERT INTO identity_memberships (identity_account_id, member_account_id, role) VALUES (?, ?, 'owner')")
+      .run(id, ownerAccountId);
+    return { id, username: input.username, displayName: input.displayName, role: "owner" };
+  }
+
+  async listIdentitiesForMember(memberAccountId: string): Promise<UnifiedIdentity[]> {
+    const rows = this.db.prepare(
+      `SELECT a.id, a.username, a.display_name, im.role
+       FROM identity_memberships im JOIN accounts a ON a.id = im.identity_account_id
+       WHERE im.member_account_id = ?`
+    ).all(memberAccountId) as Array<{ id: string; username: string; display_name: string | null; role: "owner" | "editor" }>;
+    return rows.map((row) => ({ id: row.id, username: row.username, displayName: row.display_name, role: row.role }));
+  }
+
+  async addRemoteFollow(accountId: string, actorUri: string, inbox: string): Promise<void> {
+    this.db.prepare(
+      "INSERT INTO remote_follows (account_id, follower_actor_uri, follower_inbox) VALUES (?, ?, ?) ON CONFLICT(account_id, follower_actor_uri) DO UPDATE SET follower_inbox = excluded.follower_inbox"
+    ).run(accountId, actorUri, inbox);
+  }
+
+  async removeRemoteFollow(accountId: string, actorUri: string): Promise<void> {
+    this.db.prepare("DELETE FROM remote_follows WHERE account_id = ? AND follower_actor_uri = ?").run(accountId, actorUri);
+  }
+
+
+  async listFollowersByUsername(username: string): Promise<UnifiedAccount[]> {
+    const rows = this.db.prepare(
+      `SELECT a.id, a.username, a.display_name, a.avatar_url, a.password_hash
+       FROM follows f
+       JOIN accounts target ON target.id = f.following_id
+       JOIN accounts a ON a.id = f.follower_id
+       WHERE target.username = ?`
+    ).all(username) as Array<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>;
+    return rows.map((row) => ({ id: row.id, username: row.username, displayName: row.display_name, avatarUrl: row.avatar_url, passwordHash: row.password_hash }));
+  }
+
+  async listRemoteFollowerActorUrisByUsername(username: string): Promise<string[]> {
+    const rows = this.db.prepare(
+      `SELECT rf.follower_actor_uri
+       FROM remote_follows rf
+       JOIN accounts target ON target.id = rf.account_id
+       WHERE target.username = ?`
+    ).all(username) as Array<{ follower_actor_uri: string }>;
+    return rows.map((row) => row.follower_actor_uri);
+  }
+
+  async listFollowingByUsername(username: string): Promise<UnifiedAccount[]> {
+    const rows = this.db.prepare(
+      `SELECT a.id, a.username, a.display_name, a.avatar_url, a.password_hash
+       FROM follows f
+       JOIN accounts source ON source.id = f.follower_id
+       JOIN accounts a ON a.id = f.following_id
+       WHERE source.username = ?`
+    ).all(username) as Array<{ id: string; username: string; display_name: string | null; avatar_url: string | null; password_hash: string | null }>;
+    return rows.map((row) => ({ id: row.id, username: row.username, displayName: row.display_name, avatarUrl: row.avatar_url, passwordHash: row.password_hash }));
+  }
+
+  async listSavedLocations(accountId: string): Promise<SavedLocation[]> {
+    const rows = this.db.prepare(
+      `SELECT id, name, address, latitude, longitude, used_at
+       FROM saved_locations
+       WHERE account_id = ?
+       ORDER BY used_at DESC`
+    ).all(accountId) as Array<{ id: number; name: string; address: string | null; latitude: number | null; longitude: number | null; used_at: string }>;
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      address: row.address,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      usedAt: row.used_at,
+    }));
+  }
+
+  async saveLocation(accountId: string, loc: { name: string; address?: string; latitude?: number; longitude?: number }): Promise<void> {
+    this.db.prepare(
+      `INSERT INTO saved_locations (account_id, name, address, latitude, longitude, used_at)
+       VALUES (?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(account_id, name, address)
+       DO UPDATE SET latitude = excluded.latitude, longitude = excluded.longitude, used_at = datetime('now')`
+    ).run(accountId, loc.name.trim(), loc.address ?? null, loc.latitude ?? null, loc.longitude ?? null);
+  }
+
+  async deleteLocation(accountId: string, id: number): Promise<void> {
+    this.db.prepare("DELETE FROM saved_locations WHERE id = ? AND account_id = ?").run(id, accountId);
+  }
+
+  async upsertUpload(blob: UploadBlob): Promise<string> {
+    return this.putUpload(blob);
+  }
+
+
+  async listRemoteActors(params?: { domain?: string; limit?: number }): Promise<RemoteActorSummary[]> {
+    const limit = params?.limit ?? 20;
+    const rows = params?.domain
+      ? this.db.prepare("SELECT uri, preferred_username, display_name, domain, inbox, icon_url FROM remote_actors WHERE domain = ? ORDER BY last_fetched_at DESC LIMIT ?").all(params.domain, limit)
+      : this.db.prepare("SELECT uri, preferred_username, display_name, domain, inbox, icon_url FROM remote_actors ORDER BY last_fetched_at DESC LIMIT ?").all(limit);
+    return (rows as Array<{ uri: string; preferred_username: string; display_name: string | null; domain: string; inbox: string | null }>).map((row) => ({
+      uri: row.uri,
+      username: row.preferred_username,
+      displayName: row.display_name,
+      domain: row.domain,
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    }));
+  }
+
+
+  async searchRemoteActors(query: string): Promise<RemoteActorSummary[]> {
+    const rows = this.db.prepare(
+      `SELECT uri, preferred_username, display_name, domain, inbox, icon_url
+       FROM remote_actors
+       WHERE lower(preferred_username) LIKE lower(?) OR lower(display_name) LIKE lower(?) OR lower(uri) LIKE lower(?)
+       ORDER BY last_fetched_at DESC
+       LIMIT 20`
+    ).all(`%${query}%`, `%${query}%`, `%${query}%`) as Array<{ uri: string; preferred_username: string; display_name: string | null; domain: string; inbox: string | null; icon_url: string | null }>;
+    return rows.map((row) => ({
+      uri: row.uri,
+      username: row.preferred_username,
+      displayName: row.display_name,
+      domain: row.domain,
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    }));
+  }
+
+  async listFollowedRemoteActors(accountId: string): Promise<RemoteActorSummary[]> {
+    const rows = this.db.prepare(
+      `SELECT ra.uri, ra.preferred_username, ra.display_name, ra.domain, rf.actor_inbox AS inbox, ra.icon_url
+       FROM remote_following rf
+       LEFT JOIN remote_actors ra ON ra.uri = rf.actor_uri
+       WHERE rf.account_id = ?
+       ORDER BY rf.created_at DESC`
+    ).all(accountId) as Array<{ uri: string | null; preferred_username: string | null; display_name: string | null; domain: string | null; inbox: string; icon_url: string | null }>;
+    return rows.filter((row) => !!row.uri).map((row) => ({
+      uri: row.uri as string,
+      username: row.preferred_username || "",
+      displayName: row.display_name,
+      domain: row.domain || "",
+      inbox: row.inbox,
+      iconUrl: row.icon_url,
+    }));
+  }
+
+
+  async upsertRemoteActor(actor: RemoteActorSummary & { inbox: string }): Promise<void> {
+    this.db.prepare(
+      `INSERT INTO remote_actors (uri, preferred_username, display_name, domain, inbox, icon_url, last_fetched_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(uri) DO UPDATE SET
+         preferred_username = excluded.preferred_username,
+         display_name = excluded.display_name,
+         domain = excluded.domain,
+         inbox = excluded.inbox,
+         icon_url = excluded.icon_url,
+         last_fetched_at = datetime('now')`
+    ).run(actor.uri, actor.username, actor.displayName ?? null, actor.domain, actor.inbox, actor.iconUrl ?? null);
+  }
+
+  async upsertRemoteEvent(event: RemoteEventSummary): Promise<void> {
+    this.db.prepare(
+      `INSERT INTO remote_events (uri, actor_uri, title, description, start_date, end_date, fetched_at)
+       VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+       ON CONFLICT(uri) DO UPDATE SET
+         actor_uri = excluded.actor_uri,
+         title = excluded.title,
+         description = excluded.description,
+         start_date = excluded.start_date,
+         end_date = excluded.end_date,
+         fetched_at = datetime('now')`
+    ).run(event.uri, event.actorUri, event.title, event.description ?? null, event.startDate, event.endDate ?? null);
+  }
+
+  async followRemoteActor(accountId: string, actor: RemoteActorSummary & { inbox: string }): Promise<void> {
+    this.db.prepare(
+      `INSERT INTO remote_following (account_id, actor_uri, actor_inbox)
+       VALUES (?, ?, ?)
+       ON CONFLICT(account_id, actor_uri) DO UPDATE SET actor_inbox = excluded.actor_inbox`
+    ).run(accountId, actor.uri, actor.inbox);
+  }
+
+  async unfollowRemoteActor(accountId: string, actorUri: string): Promise<void> {
+    this.db.prepare("DELETE FROM remote_following WHERE account_id = ? AND actor_uri = ?").run(accountId, actorUri);
+  }
+
+  async listRemoteEvents(params?: { actor?: string; from?: string; limit?: number; offset?: number }): Promise<RemoteEventSummary[]> {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (params?.actor) {
+      where.push("actor_uri = ?");
+      args.push(params.actor);
+    }
+    if (params?.from) {
+      where.push("start_date >= ?");
+      args.push(params.from);
+    }
+    const limit = params?.limit ?? 50;
+    const offset = params?.offset ?? 0;
+    const sql = `SELECT uri, actor_uri, title, description, start_date, end_date
+      FROM remote_events
+      ${where.length ? `WHERE ${where.join(' AND ')}` : ''}
+      ORDER BY start_date ASC
+      LIMIT ? OFFSET ?`;
+    const rows = this.db.prepare(sql).all(...args, limit, offset) as Array<{ uri: string; actor_uri: string; title: string; description: string | null; start_date: string; end_date: string | null }>;
+    return rows.map((row) => ({
+      uri: row.uri,
+      actorUri: row.actor_uri,
+      title: row.title,
+      description: row.description,
+      startDate: row.start_date,
+      endDate: row.end_date,
+    }));
+  }
+
+  async putUpload(blob: { key: string; contentType: string; body: ArrayBuffer }): Promise<string> {
+    const filePath = join(this.uploadDir, blob.key);
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(filePath, Buffer.from(blob.body));
+    return `/uploads/${blob.key}`;
+  }
+
+  async getUpload(key: string): Promise<UploadObject | null> {
+    try {
+      const filePath = join(this.uploadDir, key);
+      const data = await readFile(filePath);
+      return { body: data };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/server/src/unified-index.ts
+++ b/packages/server/src/unified-index.ts
@@ -1,0 +1,34 @@
+import { config } from "dotenv";
+import { createServer } from "node:http";
+import { resolve } from "node:path";
+import { createUnifiedApp } from "@everycal/runtime-core";
+import bcrypt from "bcrypt";
+import { getRequestListener } from "@hono/node-server";
+import { initDatabase } from "./db.js";
+import { DATABASE_PATH, UPLOAD_DIR } from "./lib/paths.js";
+import { NodeStorage } from "./storage/node-storage.js";
+
+config({ path: resolve(process.cwd(), "../../.env"), quiet: true });
+config({ quiet: true });
+
+const db = initDatabase(DATABASE_PATH);
+const storage = new NodeStorage(db, UPLOAD_DIR);
+
+const app = createUnifiedApp({
+  storage,
+  baseUrl: process.env.BASE_URL || "http://localhost:3000",
+  sessionCookieName: "everycal_session",
+  hashPassword: (password: string) => bcrypt.hash(password, 10),
+  verifyPassword: (password: string, hash: string | null) => {
+    if (!hash) return Promise.resolve(false);
+    return bcrypt.compare(password, hash);
+  },
+});
+
+const port = parseInt(process.env.PORT || "3000", 10);
+console.log(`🗓️  EveryCal unified server starting on http://localhost:${port}`);
+
+const listener = getRequestListener(app.fetch);
+createServer((req, res) => {
+  void listener(req, res);
+}).listen(port);

--- a/packages/web/functions/.well-known/[[path]].ts
+++ b/packages/web/functions/.well-known/[[path]].ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "../_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env);
+};

--- a/packages/web/functions/_lib/proxy.ts
+++ b/packages/web/functions/_lib/proxy.ts
@@ -1,0 +1,22 @@
+export async function proxyToApi(request: Request, env: { API_ORIGIN?: string }, pathOverride?: string): Promise<Response> {
+  const apiOrigin = env.API_ORIGIN || env.VITE_API_ORIGIN;
+  if (!apiOrigin) {
+    return new Response(JSON.stringify({ error: "API_ORIGIN is not configured" }), {
+      status: 500,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  const reqUrl = new URL(request.url);
+  const upstreamUrl = new URL(pathOverride || reqUrl.pathname + reqUrl.search, apiOrigin);
+  const headers = new Headers(request.headers);
+  headers.set("x-forwarded-host", reqUrl.host);
+  headers.set("x-forwarded-proto", reqUrl.protocol.replace(":", ""));
+
+  return fetch(upstreamUrl.toString(), {
+    method: request.method,
+    headers,
+    body: request.body,
+    redirect: "manual",
+  });
+}

--- a/packages/web/functions/api/[[path]].ts
+++ b/packages/web/functions/api/[[path]].ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "../_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env);
+};

--- a/packages/web/functions/events/[[path]].ts
+++ b/packages/web/functions/events/[[path]].ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "../_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env);
+};

--- a/packages/web/functions/inbox.ts
+++ b/packages/web/functions/inbox.ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "./_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env, "/inbox");
+};

--- a/packages/web/functions/nodeinfo/[[path]].ts
+++ b/packages/web/functions/nodeinfo/[[path]].ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "../_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env);
+};

--- a/packages/web/functions/types.d.ts
+++ b/packages/web/functions/types.d.ts
@@ -1,0 +1,4 @@
+type PagesFunction<E = Record<string, unknown>> = (context: {
+  request: Request;
+  env: E;
+}) => Response | Promise<Response>;

--- a/packages/web/functions/users/[[path]].ts
+++ b/packages/web/functions/users/[[path]].ts
@@ -1,0 +1,5 @@
+import { proxyToApi } from "../_lib/proxy";
+
+export const onRequest: PagesFunction<{ API_ORIGIN?: string; VITE_API_ORIGIN?: string }> = async (context) => {
+  return proxyToApi(context.request, context.env);
+};

--- a/packages/web/wrangler.toml
+++ b/packages/web/wrangler.toml
@@ -1,0 +1,7 @@
+name = "everycal-web"
+compatibility_date = "2026-03-01"
+pages_build_output_dir = "dist/client"
+
+[vars]
+API_ORIGIN = "https://api.example.com"
+VITE_API_ORIGIN = "https://api.example.com"

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -147,6 +147,9 @@ async function runCommandCapture(cmd, args, options = {}) {
       if (code === 0) resolve({ stdout, stderr });
       else reject(new Error(`${cmd} ${args.join(" ")} exited with code ${code}\n${stderr || stdout}`));
     });
+    child.on("error", (error) => {
+      reject(new Error(`${cmd} ${args.join(" ")} failed to start: ${error.message}`));
+    });
   });
 }
 
@@ -161,8 +164,16 @@ function parseMaybeJsonOutput(stdout) {
   return JSON.parse(jsonCandidate);
 }
 
-async function runWranglerJson(args) {
-  const { stdout } = await runCommandCapture("wrangler", [...args, "--json"]);
+function wranglerEnv(accountId) {
+  if (!accountId) return process.env;
+  return {
+    ...process.env,
+    CLOUDFLARE_ACCOUNT_ID: accountId,
+  };
+}
+
+async function runWranglerJson(args, options = {}) {
+  const { stdout } = await runCommandCapture("wrangler", [...args, "--json"], { env: wranglerEnv(options.accountId) });
   const parsed = parseMaybeJsonOutput(stdout);
   if (parsed === null) throw new Error(`Expected JSON output from wrangler ${args.join(" ")}`);
   return parsed;
@@ -195,11 +206,18 @@ async function resolveAccountId(token, preferredAccountId) {
 }
 
 async function resolveAccountIdFromWrangler(preferredAccountId) {
-  if (preferredAccountId) return preferredAccountId;
   const whoami = await runWranglerJson(["whoami"]);
-  const account = Array.isArray(whoami?.accounts) ? whoami.accounts[0] : null;
-  if (!account?.id) throw new Error("Unable to resolve account id from Wrangler OAuth session. Run `wrangler login` or provide --account-id.");
-  return account.id;
+  const accounts = Array.isArray(whoami?.accounts) ? whoami.accounts : [];
+  if (preferredAccountId) {
+    const matched = accounts.find((account) => account?.id === preferredAccountId);
+    if (!matched) {
+      throw new Error(`Account id ${preferredAccountId} not found in Wrangler OAuth session. Run 'wrangler whoami' and choose a listed account id.`);
+    }
+    return preferredAccountId;
+  }
+  const first = accounts[0];
+  if (!first?.id) throw new Error("Unable to resolve account id from Wrangler OAuth session. Run `wrangler login` or provide --account-id.");
+  return first.id;
 }
 
 async function ensureD1Database(accountId, name, token) {
@@ -246,45 +264,41 @@ async function ensureQueue(accountId, queueName, token) {
   return { id: created.queue_id, created: true };
 }
 
-function buildAccountArgs(accountId) {
-  return accountId ? ["--account-id", accountId] : [];
-}
-
 async function ensureD1DatabaseWithWrangler(accountId, name) {
-  const list = await runWranglerJson(["d1", "list", ...buildAccountArgs(accountId)]);
+  const list = await runWranglerJson(["d1", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
   if (existing?.uuid) return { id: existing.uuid, created: false };
-  const created = await runWranglerJson(["d1", "create", name, ...buildAccountArgs(accountId)]);
+  const created = await runWranglerJson(["d1", "create", name], { accountId });
   const createdId = created?.uuid || created?.database_id;
   if (!createdId) throw new Error("Unable to parse D1 id from wrangler d1 create output.");
   return { id: createdId, created: true };
 }
 
 async function ensureKvNamespaceWithWrangler(accountId, title) {
-  const list = await runWranglerJson(["kv", "namespace", "list", ...buildAccountArgs(accountId)]);
+  const list = await runWranglerJson(["kv", "namespace", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.title === title) : null;
   if (existing?.id) return { id: existing.id, created: false };
 
   const placeholderBinding = "RATE_LIMITS_KV";
-  const created = await runWranglerJson(["kv", "namespace", "create", placeholderBinding, ...buildAccountArgs(accountId), "--title", title]);
+  const created = await runWranglerJson(["kv", "namespace", "create", placeholderBinding, "--title", title], { accountId });
   const createdId = created?.id;
   if (!createdId) throw new Error("Unable to parse KV namespace id from wrangler kv namespace create output.");
   return { id: createdId, created: true };
 }
 
 async function ensureR2BucketWithWrangler(accountId, name) {
-  const list = await runWranglerJson(["r2", "bucket", "list", ...buildAccountArgs(accountId)]);
+  const list = await runWranglerJson(["r2", "bucket", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
   if (existing?.name) return { name: existing.name, created: false };
-  await runWranglerJson(["r2", "bucket", "create", name, ...buildAccountArgs(accountId)]);
+  await runWranglerJson(["r2", "bucket", "create", name], { accountId });
   return { name, created: true };
 }
 
 async function ensureQueueWithWrangler(accountId, queueName) {
-  const list = await runWranglerJson(["queues", "list", ...buildAccountArgs(accountId)]);
+  const list = await runWranglerJson(["queues", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.queue_name === queueName || item.queueName === queueName) : null;
   if (existing?.queue_id || existing?.queueId) return { id: existing.queue_id || existing.queueId, created: false };
-  const created = await runWranglerJson(["queues", "create", queueName, ...buildAccountArgs(accountId)]);
+  const created = await runWranglerJson(["queues", "create", queueName], { accountId });
   return { id: created?.queue_id || created?.queueId || "", created: true };
 }
 
@@ -298,6 +312,9 @@ async function runCommand(cmd, args, options = {}) {
     child.on("exit", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`${cmd} ${args.join(" ")} exited with code ${code}`));
+    });
+    child.on("error", (error) => {
+      reject(new Error(`${cmd} ${args.join(" ")} failed to start: ${error.message}`));
     });
   });
 }

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -179,6 +179,10 @@ async function runWranglerJson(args, options = {}) {
   return parsed;
 }
 
+async function runWrangler(args, options = {}) {
+  return await runCommandCapture("wrangler", args, { env: wranglerEnv(options.accountId) });
+}
+
 async function cfFetch(path, init, token) {
   const res = await fetch(`${CF_API_BASE}${path}`, {
     ...init,
@@ -268,7 +272,9 @@ async function ensureD1DatabaseWithWrangler(accountId, name) {
   const list = await runWranglerJson(["d1", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
   if (existing?.uuid) return { id: existing.uuid, created: false };
-  const created = await runWranglerJson(["d1", "create", name], { accountId });
+  await runWrangler(["d1", "create", name], { accountId });
+  const refreshed = await runWranglerJson(["d1", "list"], { accountId });
+  const created = Array.isArray(refreshed) ? refreshed.find((item) => item.name === name) : null;
   const createdId = created?.uuid || created?.database_id;
   if (!createdId) throw new Error("Unable to parse D1 id from wrangler d1 create output.");
   return { id: createdId, created: true };
@@ -280,7 +286,9 @@ async function ensureKvNamespaceWithWrangler(accountId, title) {
   if (existing?.id) return { id: existing.id, created: false };
 
   const placeholderBinding = "RATE_LIMITS_KV";
-  const created = await runWranglerJson(["kv", "namespace", "create", placeholderBinding, "--title", title], { accountId });
+  await runWrangler(["kv", "namespace", "create", placeholderBinding, "--title", title], { accountId });
+  const refreshed = await runWranglerJson(["kv", "namespace", "list"], { accountId });
+  const created = Array.isArray(refreshed) ? refreshed.find((item) => item.title === title) : null;
   const createdId = created?.id;
   if (!createdId) throw new Error("Unable to parse KV namespace id from wrangler kv namespace create output.");
   return { id: createdId, created: true };
@@ -290,7 +298,7 @@ async function ensureR2BucketWithWrangler(accountId, name) {
   const list = await runWranglerJson(["r2", "bucket", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
   if (existing?.name) return { name: existing.name, created: false };
-  await runWranglerJson(["r2", "bucket", "create", name], { accountId });
+  await runWrangler(["r2", "bucket", "create", name], { accountId });
   return { name, created: true };
 }
 
@@ -298,7 +306,9 @@ async function ensureQueueWithWrangler(accountId, queueName) {
   const list = await runWranglerJson(["queues", "list"], { accountId });
   const existing = Array.isArray(list) ? list.find((item) => item.queue_name === queueName || item.queueName === queueName) : null;
   if (existing?.queue_id || existing?.queueId) return { id: existing.queue_id || existing.queueId, created: false };
-  const created = await runWranglerJson(["queues", "create", queueName], { accountId });
+  await runWrangler(["queues", "create", queueName], { accountId });
+  const refreshed = await runWranglerJson(["queues", "list"], { accountId });
+  const created = Array.isArray(refreshed) ? refreshed.find((item) => item.queue_name === queueName || item.queueName === queueName) : null;
   return { id: created?.queue_id || created?.queueId || "", created: true };
 }
 

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -4,6 +4,8 @@ import { mkdir, readFile, writeFile, access, copyFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { generateKeyPairSync, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
+import { lookup } from "node:dns/promises";
+import net from "node:net";
 
 const CF_API_BASE = "https://api.cloudflare.com/client/v4";
 const COMPATIBILITY_DATE = "2026-03-01";
@@ -62,6 +64,68 @@ async function resolveOrCreateSecretMaterial(path, createValue, rotate) {
   const value = createValue();
   await writeFile(path, `${value}\n`);
   return { value, reused: false };
+}
+
+function isValidEmail(value) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function normalizeSmtpConfig(args) {
+  const config = {
+    host: (args["smtp-host"] ? String(args["smtp-host"]) : (process.env.SMTP_HOST || "")).trim(),
+    port: (args["smtp-port"] ? String(args["smtp-port"]) : (process.env.SMTP_PORT || "")).trim(),
+    from: (args["smtp-from"] ? String(args["smtp-from"]) : (process.env.SMTP_FROM || "")).trim(),
+    secure: (args["smtp-secure"] ? String(args["smtp-secure"]) : (process.env.SMTP_SECURE || "false")).trim(),
+    user: (args["smtp-user"] ? String(args["smtp-user"]) : (process.env.SMTP_USER || "")).trim(),
+    pass: (args["smtp-pass"] ? String(args["smtp-pass"]) : (process.env.SMTP_PASS || "")).trim(),
+  };
+  return config;
+}
+
+async function verifySmtpReachability(host, port, timeoutMs = 4000) {
+  await lookup(host);
+  await new Promise((resolve, reject) => {
+    const socket = net.createConnection({ host, port, timeout: timeoutMs }, () => {
+      socket.end();
+      resolve(undefined);
+    });
+    socket.on("error", reject);
+    socket.on("timeout", () => {
+      socket.destroy();
+      reject(new Error("smtp_timeout"));
+    });
+  });
+}
+
+async function validateSmtpConfig(config, options) {
+  const messages = [];
+  const configured = Boolean(config.host && config.port && config.from);
+  if (!configured) {
+    if (options.allowNoSmtp) {
+      return { configured: false, valid: true, messages: ["SMTP optional mode enabled; skipping SMTP validation."] };
+    }
+    throw new Error("SMTP is required for production bootstrap. Provide --smtp-host, --smtp-port, --smtp-from (and optional auth). Use --allow-no-smtp only for non-production/testing.");
+  }
+
+  const port = Number.parseInt(config.port, 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid SMTP port: ${config.port}`);
+  }
+  if (!isValidEmail(config.from)) {
+    throw new Error(`Invalid SMTP from address: ${config.from}`);
+  }
+  if (!["true", "false"].includes(config.secure.toLowerCase())) {
+    throw new Error("SMTP secure flag must be true or false.");
+  }
+
+  if (!options.skipSmtpConnectionCheck) {
+    await verifySmtpReachability(config.host, port);
+    messages.push("SMTP DNS + TCP reachability check passed.");
+  } else {
+    messages.push("SMTP connection check skipped by flag.");
+  }
+
+  return { configured: true, valid: true, messages };
 }
 
 async function cfFetch(path, init, token) {
@@ -330,6 +394,9 @@ async function main() {
   const shouldWriteTrackedConfigs = Boolean(args["write-tracked-configs"]);
   const remindersWebhookUrl = args["reminders-webhook-url"] ? String(args["reminders-webhook-url"]) : "";
   const scrapersWebhookUrl = args["scrapers-webhook-url"] ? String(args["scrapers-webhook-url"]) : "";
+  const allowNoSmtp = Boolean(args["allow-no-smtp"]);
+  const skipSmtpConnectionCheck = Boolean(args["skip-smtp-connection-check"]);
+  const smtpConfig = normalizeSmtpConfig(args);
 
   const d1Name = `${projectSlug}-${env}`;
   const kvTitle = `${projectSlug}-${env}-rate-limits`;
@@ -338,9 +405,13 @@ async function main() {
   const remindersService = `${projectSlug}-reminders-${env}`;
   const scrapersService = `${projectSlug}-scrapers-${env}`;
 
+  const smtpValidation = dryRun
+    ? { configured: Boolean(smtpConfig.host && smtpConfig.port && smtpConfig.from), valid: true, messages: ["Plan mode: SMTP validation deferred to apply mode."] }
+    : await validateSmtpConfig(smtpConfig, { allowNoSmtp, skipSmtpConnectionCheck });
+
   const summary = {
     mode: dryRun ? "plan" : "apply",
-    input: { domain, apiHost, env, projectSlug, pagesProject, remindersWebhookUrl, scrapersWebhookUrl },
+    input: { domain, apiHost, env, projectSlug, pagesProject, remindersWebhookUrl, scrapersWebhookUrl, smtp: { host: smtpConfig.host, port: smtpConfig.port, from: smtpConfig.from, secure: smtpConfig.secure, hasAuth: Boolean(smtpConfig.user && smtpConfig.pass) } },
     derived: {
       webOrigin,
       apiOrigin,
@@ -362,6 +433,8 @@ async function main() {
       shouldWriteTrackedConfigs,
       remindersWebhookConfigured: Boolean(remindersWebhookUrl),
       scrapersWebhookConfigured: Boolean(scrapersWebhookUrl),
+      smtpConfigured: smtpValidation.configured,
+      smtpValidationMessages: smtpValidation.messages,
     },
   };
 
@@ -369,6 +442,10 @@ async function main() {
     console.log(JSON.stringify(summary, null, 2));
     console.log("\nPlan mode only. Re-run with --apply to provision resources and write generated config files.");
     return;
+  }
+
+  if (smtpValidation.configured) {
+    console.log(`[bootstrap] SMTP validated for ${smtpConfig.host}:${smtpConfig.port} (${smtpConfig.from}).`);
   }
 
   const token = must(process.env.CLOUDFLARE_API_TOKEN, "Missing CLOUDFLARE_API_TOKEN for --apply mode.");
@@ -435,6 +512,14 @@ async function main() {
       federationKeyReused: privateKey.reused,
       jobsWebhookTokenReused: jobsToken.reused,
     },
+    smtp: {
+      ...smtpValidation,
+      host: smtpConfig.host,
+      port: smtpConfig.port,
+      from: smtpConfig.from,
+      secure: smtpConfig.secure,
+      hasAuth: Boolean(smtpConfig.user && smtpConfig.pass),
+    },
   };
 
   const receiptPath = `.generated/cf-bootstrap-receipt.${env}.json`;
@@ -454,6 +539,16 @@ async function main() {
     console.log("\nSetting Worker secrets...");
     await putWranglerSecret("ACTIVITYPUB_PRIVATE_KEY_PEM", privateKey.value, workerConfigPath);
     await putWranglerSecret("JOBS_WEBHOOK_TOKEN", jobsToken.value, workerConfigPath);
+    if (smtpValidation.configured) {
+      await putWranglerSecret("SMTP_HOST", smtpConfig.host, workerConfigPath);
+      await putWranglerSecret("SMTP_PORT", smtpConfig.port, workerConfigPath);
+      await putWranglerSecret("SMTP_FROM", smtpConfig.from, workerConfigPath);
+      await putWranglerSecret("SMTP_SECURE", smtpConfig.secure, workerConfigPath);
+      if (smtpConfig.user && smtpConfig.pass) {
+        await putWranglerSecret("SMTP_USER", smtpConfig.user, workerConfigPath);
+        await putWranglerSecret("SMTP_PASS", smtpConfig.pass, workerConfigPath);
+      }
+    }
   }
 
   if (shouldProvisionCompanionWorkers && (!remindersWebhookUrl || !scrapersWebhookUrl)) {
@@ -470,6 +565,22 @@ async function main() {
       if (shouldSetSecrets) {
         await putWorkerNamedSecret(remindersService, "JOBS_WEBHOOK_TOKEN", jobsToken.value);
         await putWorkerNamedSecret(scrapersService, "JOBS_WEBHOOK_TOKEN", jobsToken.value);
+        if (smtpValidation.configured) {
+          await putWorkerNamedSecret(remindersService, "SMTP_HOST", smtpConfig.host);
+          await putWorkerNamedSecret(remindersService, "SMTP_PORT", smtpConfig.port);
+          await putWorkerNamedSecret(remindersService, "SMTP_FROM", smtpConfig.from);
+          await putWorkerNamedSecret(remindersService, "SMTP_SECURE", smtpConfig.secure);
+          await putWorkerNamedSecret(scrapersService, "SMTP_HOST", smtpConfig.host);
+          await putWorkerNamedSecret(scrapersService, "SMTP_PORT", smtpConfig.port);
+          await putWorkerNamedSecret(scrapersService, "SMTP_FROM", smtpConfig.from);
+          await putWorkerNamedSecret(scrapersService, "SMTP_SECURE", smtpConfig.secure);
+          if (smtpConfig.user && smtpConfig.pass) {
+            await putWorkerNamedSecret(remindersService, "SMTP_USER", smtpConfig.user);
+            await putWorkerNamedSecret(remindersService, "SMTP_PASS", smtpConfig.pass);
+            await putWorkerNamedSecret(scrapersService, "SMTP_USER", smtpConfig.user);
+            await putWorkerNamedSecret(scrapersService, "SMTP_PASS", smtpConfig.pass);
+          }
+        }
       }
     }
 

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -152,13 +152,52 @@ async function putWranglerSecret(name, value, workerConfigPath) {
   await runCommand("wrangler", ["secret", "put", name, "--config", workerConfigPath], { stdinText: `${value}\n` });
 }
 
+async function putWorkerNamedSecret(workerName, secretName, value) {
+  await runCommand("wrangler", ["secret", "put", secretName, "--name", workerName], { stdinText: `${value}\n` });
+}
+
 function renderCompanionWorkerSource(jobType) {
   return `export default {
-  async fetch(request) {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (request.method === "GET" && url.pathname === "/healthz") {
+      const ok = Boolean(env.TARGET_WEBHOOK_URL && String(env.TARGET_WEBHOOK_URL).trim());
+      return new Response(JSON.stringify({ ok, mode: "webhook-forward" }), {
+        status: ok ? 200 : 503,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
     if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
-    const payload = await request.text();
-    console.log("[${jobType}] received job payload", payload.slice(0, 1000));
-    return new Response(JSON.stringify({ ok: true, worker: "${jobType}" }), {
+    if (url.pathname !== "/jobs/${jobType}") return new Response("Not Found", { status: 404 });
+
+    const target = env.TARGET_WEBHOOK_URL ? String(env.TARGET_WEBHOOK_URL).trim() : "";
+    if (!target) {
+      return new Response(JSON.stringify({ error: "missing_target_webhook_url" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    const raw = await request.text();
+    const headers = { "content-type": "application/json" };
+    if (env.JOBS_WEBHOOK_TOKEN) headers.authorization = "Bearer " + env.JOBS_WEBHOOK_TOKEN;
+
+    const parsed = raw ? JSON.parse(raw) : {};
+    const res = await fetch(target, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ ...parsed, source: "cloudflare-companion-${jobType}" }),
+    });
+
+    if (!res.ok) {
+      return new Response(JSON.stringify({ error: "executor_failed", status: res.status }), {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    return new Response(JSON.stringify({ ok: true, worker: jobType }), {
       status: 202,
       headers: { "content-type": "application/json" },
     });
@@ -258,15 +297,17 @@ async function verifyRemoteReadiness(apiOrigin) {
   }
 }
 
-async function deployCompanionWorker(name, scriptPath) {
-  await runCommand("wrangler", [
+async function deployCompanionWorker(name, scriptPath, webhookUrl) {
+  const args = [
     "deploy",
     scriptPath,
     "--name",
     name,
     "--compatibility-date",
     COMPATIBILITY_DATE,
-  ]);
+  ];
+  if (webhookUrl) args.push("--var", `TARGET_WEBHOOK_URL:${webhookUrl}`);
+  await runCommand("wrangler", args);
 }
 
 async function main() {
@@ -287,6 +328,8 @@ async function main() {
   const shouldProvisionCompanionWorkers = !args["skip-companion-workers"];
   const shouldRotateKeys = Boolean(args["rotate-keys"]);
   const shouldWriteTrackedConfigs = Boolean(args["write-tracked-configs"]);
+  const remindersWebhookUrl = args["reminders-webhook-url"] ? String(args["reminders-webhook-url"]) : "";
+  const scrapersWebhookUrl = args["scrapers-webhook-url"] ? String(args["scrapers-webhook-url"]) : "";
 
   const d1Name = `${projectSlug}-${env}`;
   const kvTitle = `${projectSlug}-${env}-rate-limits`;
@@ -297,7 +340,7 @@ async function main() {
 
   const summary = {
     mode: dryRun ? "plan" : "apply",
-    input: { domain, apiHost, env, projectSlug, pagesProject },
+    input: { domain, apiHost, env, projectSlug, pagesProject, remindersWebhookUrl, scrapersWebhookUrl },
     derived: {
       webOrigin,
       apiOrigin,
@@ -317,6 +360,8 @@ async function main() {
       shouldProvisionCompanionWorkers,
       shouldRotateKeys,
       shouldWriteTrackedConfigs,
+      remindersWebhookConfigured: Boolean(remindersWebhookUrl),
+      scrapersWebhookConfigured: Boolean(scrapersWebhookUrl),
     },
   };
 
@@ -411,11 +456,21 @@ async function main() {
     await putWranglerSecret("JOBS_WEBHOOK_TOKEN", jobsToken.value, workerConfigPath);
   }
 
+  if (shouldProvisionCompanionWorkers && (!remindersWebhookUrl || !scrapersWebhookUrl)) {
+    console.warn("\n[bootstrap] Companion workers are deployed without one or more TARGET_WEBHOOK_URL values.");
+    console.warn("[bootstrap] Set --reminders-webhook-url/--scrapers-webhook-url for behavioral executor readiness.");
+  }
+
   if (shouldDeploy) {
     if (shouldProvisionCompanionWorkers) {
       console.log("\nDeploying companion service workers (reminders/scrapers)...");
-      await deployCompanionWorker(remindersService, remindersCompanionPath);
-      await deployCompanionWorker(scrapersService, scrapersCompanionPath);
+      await deployCompanionWorker(remindersService, remindersCompanionPath, remindersWebhookUrl);
+      await deployCompanionWorker(scrapersService, scrapersCompanionPath, scrapersWebhookUrl);
+
+      if (shouldSetSecrets) {
+        await putWorkerNamedSecret(remindersService, "JOBS_WEBHOOK_TOKEN", jobsToken.value);
+        await putWorkerNamedSecret(scrapersService, "JOBS_WEBHOOK_TOKEN", jobsToken.value);
+      }
     }
 
     console.log("\nDeploying EveryCal Worker + Pages...");
@@ -441,8 +496,8 @@ async function main() {
   if (!shouldDeploy) {
     console.log("- Deploy manually:");
     if (shouldProvisionCompanionWorkers) {
-      console.log(`  wrangler deploy ${remindersCompanionPath} --name ${remindersService} --compatibility-date ${COMPATIBILITY_DATE}`);
-      console.log(`  wrangler deploy ${scrapersCompanionPath} --name ${scrapersService} --compatibility-date ${COMPATIBILITY_DATE}`);
+      console.log(`  wrangler deploy ${remindersCompanionPath} --name ${remindersService} --compatibility-date ${COMPATIBILITY_DATE} --var TARGET_WEBHOOK_URL:${remindersWebhookUrl || "<set reminders webhook url>"}`);
+      console.log(`  wrangler deploy ${scrapersCompanionPath} --name ${scrapersService} --compatibility-date ${COMPATIBILITY_DATE} --var TARGET_WEBHOOK_URL:${scrapersWebhookUrl || "<set scrapers webhook url>"}`);
     }
     console.log(`  wrangler d1 migrations apply ${d1Name} --config ${workerConfigPath}`);
     console.log(`  wrangler deploy --config ${workerConfigPath}`);

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -128,6 +128,46 @@ async function validateSmtpConfig(config, options) {
   return { configured: true, valid: true, messages };
 }
 
+async function runCommandCapture(cmd, args, options = {}) {
+  return await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["pipe", "pipe", "pipe"], ...options });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    if (options.stdinText) {
+      child.stdin.write(options.stdinText);
+      child.stdin.end();
+    }
+    child.on("exit", (code) => {
+      if (code === 0) resolve({ stdout, stderr });
+      else reject(new Error(`${cmd} ${args.join(" ")} exited with code ${code}\n${stderr || stdout}`));
+    });
+  });
+}
+
+function parseMaybeJsonOutput(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+  const firstArray = trimmed.indexOf("[");
+  const firstObject = trimmed.indexOf("{");
+  const start = firstArray === -1 ? firstObject : (firstObject === -1 ? firstArray : Math.min(firstArray, firstObject));
+  if (start === -1) return null;
+  const jsonCandidate = trimmed.slice(start);
+  return JSON.parse(jsonCandidate);
+}
+
+async function runWranglerJson(args) {
+  const { stdout } = await runCommandCapture("wrangler", [...args, "--json"]);
+  const parsed = parseMaybeJsonOutput(stdout);
+  if (parsed === null) throw new Error(`Expected JSON output from wrangler ${args.join(" ")}`);
+  return parsed;
+}
+
 async function cfFetch(path, init, token) {
   const res = await fetch(`${CF_API_BASE}${path}`, {
     ...init,
@@ -152,6 +192,14 @@ async function resolveAccountId(token, preferredAccountId) {
   const first = Array.isArray(memberships) ? memberships[0] : null;
   if (!first?.account?.id) throw new Error("Unable to resolve account id from token. Provide --account-id.");
   return first.account.id;
+}
+
+async function resolveAccountIdFromWrangler(preferredAccountId) {
+  if (preferredAccountId) return preferredAccountId;
+  const whoami = await runWranglerJson(["whoami"]);
+  const account = Array.isArray(whoami?.accounts) ? whoami.accounts[0] : null;
+  if (!account?.id) throw new Error("Unable to resolve account id from Wrangler OAuth session. Run `wrangler login` or provide --account-id.");
+  return account.id;
 }
 
 async function ensureD1Database(accountId, name, token) {
@@ -196,6 +244,48 @@ async function ensureQueue(accountId, queueName, token) {
     body: JSON.stringify({ queue_name: queueName }),
   }, token);
   return { id: created.queue_id, created: true };
+}
+
+function buildAccountArgs(accountId) {
+  return accountId ? ["--account-id", accountId] : [];
+}
+
+async function ensureD1DatabaseWithWrangler(accountId, name) {
+  const list = await runWranglerJson(["d1", "list", ...buildAccountArgs(accountId)]);
+  const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
+  if (existing?.uuid) return { id: existing.uuid, created: false };
+  const created = await runWranglerJson(["d1", "create", name, ...buildAccountArgs(accountId)]);
+  const createdId = created?.uuid || created?.database_id;
+  if (!createdId) throw new Error("Unable to parse D1 id from wrangler d1 create output.");
+  return { id: createdId, created: true };
+}
+
+async function ensureKvNamespaceWithWrangler(accountId, title) {
+  const list = await runWranglerJson(["kv", "namespace", "list", ...buildAccountArgs(accountId)]);
+  const existing = Array.isArray(list) ? list.find((item) => item.title === title) : null;
+  if (existing?.id) return { id: existing.id, created: false };
+
+  const placeholderBinding = "RATE_LIMITS_KV";
+  const created = await runWranglerJson(["kv", "namespace", "create", placeholderBinding, ...buildAccountArgs(accountId), "--title", title]);
+  const createdId = created?.id;
+  if (!createdId) throw new Error("Unable to parse KV namespace id from wrangler kv namespace create output.");
+  return { id: createdId, created: true };
+}
+
+async function ensureR2BucketWithWrangler(accountId, name) {
+  const list = await runWranglerJson(["r2", "bucket", "list", ...buildAccountArgs(accountId)]);
+  const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
+  if (existing?.name) return { name: existing.name, created: false };
+  await runWranglerJson(["r2", "bucket", "create", name, ...buildAccountArgs(accountId)]);
+  return { name, created: true };
+}
+
+async function ensureQueueWithWrangler(accountId, queueName) {
+  const list = await runWranglerJson(["queues", "list", ...buildAccountArgs(accountId)]);
+  const existing = Array.isArray(list) ? list.find((item) => item.queue_name === queueName || item.queueName === queueName) : null;
+  if (existing?.queue_id || existing?.queueId) return { id: existing.queue_id || existing.queueId, created: false };
+  const created = await runWranglerJson(["queues", "create", queueName, ...buildAccountArgs(accountId)]);
+  return { id: created?.queue_id || created?.queueId || "", created: true };
 }
 
 async function runCommand(cmd, args, options = {}) {
@@ -411,7 +501,7 @@ async function main() {
 
   const summary = {
     mode: dryRun ? "plan" : "apply",
-    input: { domain, apiHost, env, projectSlug, pagesProject, remindersWebhookUrl, scrapersWebhookUrl, smtp: { host: smtpConfig.host, port: smtpConfig.port, from: smtpConfig.from, secure: smtpConfig.secure, hasAuth: Boolean(smtpConfig.user && smtpConfig.pass) } },
+    input: { domain, apiHost, env, projectSlug, pagesProject, authMode: String(args.auth || process.env.CF_BOOTSTRAP_AUTH || "oauth").toLowerCase(), remindersWebhookUrl, scrapersWebhookUrl, smtp: { host: smtpConfig.host, port: smtpConfig.port, from: smtpConfig.from, secure: smtpConfig.secure, hasAuth: Boolean(smtpConfig.user && smtpConfig.pass) } },
     derived: {
       webOrigin,
       apiOrigin,
@@ -448,13 +538,28 @@ async function main() {
     console.log(`[bootstrap] SMTP validated for ${smtpConfig.host}:${smtpConfig.port} (${smtpConfig.from}).`);
   }
 
-  const token = must(process.env.CLOUDFLARE_API_TOKEN, "Missing CLOUDFLARE_API_TOKEN for --apply mode.");
-  const accountId = await resolveAccountId(token, args["account-id"] ? String(args["account-id"]) : undefined);
+  const preferredAccountId = args["account-id"] ? String(args["account-id"]) : undefined;
+  const authMode = String(args.auth || process.env.CF_BOOTSTRAP_AUTH || "oauth").toLowerCase();
+  let accountId;
+  let d1;
+  let kv;
+  let r2;
+  let queue;
 
-  const d1 = await ensureD1Database(accountId, d1Name, token);
-  const kv = await ensureKvNamespace(accountId, kvTitle, token);
-  const r2 = await ensureR2Bucket(accountId, r2Bucket, token);
-  await ensureQueue(accountId, queueName, token);
+  if (authMode === "api-token") {
+    const token = must(process.env.CLOUDFLARE_API_TOKEN, "Missing CLOUDFLARE_API_TOKEN for --auth api-token mode.");
+    accountId = await resolveAccountId(token, preferredAccountId);
+    d1 = await ensureD1Database(accountId, d1Name, token);
+    kv = await ensureKvNamespace(accountId, kvTitle, token);
+    r2 = await ensureR2Bucket(accountId, r2Bucket, token);
+    queue = await ensureQueue(accountId, queueName, token);
+  } else {
+    accountId = await resolveAccountIdFromWrangler(preferredAccountId);
+    d1 = await ensureD1DatabaseWithWrangler(accountId, d1Name);
+    kv = await ensureKvNamespaceWithWrangler(accountId, kvTitle);
+    r2 = await ensureR2BucketWithWrangler(accountId, r2Bucket);
+    queue = await ensureQueueWithWrangler(accountId, queueName);
+  }
 
   await mkdir(".generated", { recursive: true });
 
@@ -496,7 +601,7 @@ async function main() {
       d1: { ...d1, name: d1Name },
       kv: { ...kv, title: kvTitle },
       r2: { ...r2 },
-      queue: { name: queueName },
+      queue: { ...queue, name: queueName },
       companionServices: {
         reminders: { name: remindersService, scriptPath: remindersCompanionPath },
         scrapers: { name: scrapersService, scriptPath: scrapersCompanionPath },

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile, access, copyFile } from "node:fs/promises";
+import { constants } from "node:fs";
 import { generateKeyPairSync, randomBytes } from "node:crypto";
 import { spawn } from "node:child_process";
 
 const CF_API_BASE = "https://api.cloudflare.com/client/v4";
+const COMPATIBILITY_DATE = "2026-03-01";
 
 function parseArgs(argv) {
   const args = {};
@@ -39,6 +41,27 @@ function generateFederationPrivateKeyPem() {
     publicKeyEncoding: { type: "spki", format: "pem" },
   });
   return privateKey;
+}
+
+async function fileExists(path) {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveOrCreateSecretMaterial(path, createValue, rotate) {
+  if (!rotate && await fileExists(path)) {
+    const existing = await readFile(path, "utf8");
+    const normalized = existing.trim();
+    if (normalized) return { value: normalized, reused: true };
+  }
+
+  const value = createValue();
+  await writeFile(path, `${value}\n`);
+  return { value, reused: false };
 }
 
 async function cfFetch(path, init, token) {
@@ -129,10 +152,25 @@ async function putWranglerSecret(name, value, workerConfigPath) {
   await runCommand("wrangler", ["secret", "put", name, "--config", workerConfigPath], { stdinText: `${value}\n` });
 }
 
+function renderCompanionWorkerSource(jobType) {
+  return `export default {
+  async fetch(request) {
+    if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 });
+    const payload = await request.text();
+    console.log("[${jobType}] received job payload", payload.slice(0, 1000));
+    return new Response(JSON.stringify({ ok: true, worker: "${jobType}" }), {
+      status: 202,
+      headers: { "content-type": "application/json" },
+    });
+  },
+};
+`;
+}
+
 function renderWorkerConfig(input) {
   return `name = "${input.workerName}"
 main = "packages/cloudflare-worker/src/index.ts"
-compatibility_date = "2026-03-01"
+compatibility_date = "${COMPATIBILITY_DATE}"
 workers_dev = true
 
 [[d1_databases]]
@@ -194,7 +232,7 @@ enabled = true
 
 function renderPagesConfig(apiOrigin) {
   return `name = "everycal-web"
-compatibility_date = "2026-03-01"
+compatibility_date = "${COMPATIBILITY_DATE}"
 pages_build_output_dir = "dist/client"
 
 [vars]
@@ -220,6 +258,17 @@ async function verifyRemoteReadiness(apiOrigin) {
   }
 }
 
+async function deployCompanionWorker(name, scriptPath) {
+  await runCommand("wrangler", [
+    "deploy",
+    scriptPath,
+    "--name",
+    name,
+    "--compatibility-date",
+    COMPATIBILITY_DATE,
+  ]);
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const domain = must(args.domain, "Missing required --domain (example: --domain calendar.example.com)");
@@ -235,6 +284,9 @@ async function main() {
   const shouldSetSecrets = !args["skip-secrets"];
   const shouldVerifyGenerated = !args["skip-config-check"];
   const shouldVerifyRemote = shouldDeploy && !args["skip-remote-verify"];
+  const shouldProvisionCompanionWorkers = !args["skip-companion-workers"];
+  const shouldRotateKeys = Boolean(args["rotate-keys"]);
+  const shouldWriteTrackedConfigs = Boolean(args["write-tracked-configs"]);
 
   const d1Name = `${projectSlug}-${env}`;
   const kvTitle = `${projectSlug}-${env}-rate-limits`;
@@ -246,7 +298,26 @@ async function main() {
   const summary = {
     mode: dryRun ? "plan" : "apply",
     input: { domain, apiHost, env, projectSlug, pagesProject },
-    derived: { webOrigin, apiOrigin, workerName, d1Name, kvTitle, r2Bucket, queueName, remindersService, scrapersService },
+    derived: {
+      webOrigin,
+      apiOrigin,
+      workerName,
+      d1Name,
+      kvTitle,
+      r2Bucket,
+      queueName,
+      remindersService,
+      scrapersService,
+    },
+    execution: {
+      shouldSetSecrets,
+      shouldDeploy,
+      shouldVerifyGenerated,
+      shouldVerifyRemote,
+      shouldProvisionCompanionWorkers,
+      shouldRotateKeys,
+      shouldWriteTrackedConfigs,
+    },
   };
 
   if (dryRun) {
@@ -263,10 +334,12 @@ async function main() {
   const r2 = await ensureR2Bucket(accountId, r2Bucket, token);
   await ensureQueue(accountId, queueName, token);
 
-  const activityPubPrivateKeyPem = generateFederationPrivateKeyPem();
-  const jobsWebhookToken = randomBytes(24).toString("hex");
-
   await mkdir(".generated", { recursive: true });
+
+  const privateKeyPath = `.generated/activitypub-private-key.${env}.pem`;
+  const jobsTokenPath = `.generated/jobs-webhook-token.${env}.txt`;
+  const privateKey = await resolveOrCreateSecretMaterial(privateKeyPath, generateFederationPrivateKeyPem, shouldRotateKeys);
+  const jobsToken = await resolveOrCreateSecretMaterial(jobsTokenPath, () => randomBytes(24).toString("hex"), shouldRotateKeys);
 
   const workerConfigPath = `.generated/wrangler.${env}.toml`;
   const pagesConfigPath = `.generated/packages.web.wrangler.${env}.toml`;
@@ -284,10 +357,15 @@ async function main() {
   }));
   await writeFile(pagesConfigPath, renderPagesConfig(apiOrigin));
 
-  const privateKeyPath = `.generated/activitypub-private-key.${env}.pem`;
-  const jobsTokenPath = `.generated/jobs-webhook-token.${env}.txt`;
-  await writeFile(privateKeyPath, activityPubPrivateKeyPem);
-  await writeFile(jobsTokenPath, `${jobsWebhookToken}\n`);
+  if (shouldWriteTrackedConfigs) {
+    await copyFile(workerConfigPath, "wrangler.toml");
+    await copyFile(pagesConfigPath, "packages/web/wrangler.toml");
+  }
+
+  const remindersCompanionPath = `.generated/companion-${remindersService}.mjs`;
+  const scrapersCompanionPath = `.generated/companion-${scrapersService}.mjs`;
+  await writeFile(remindersCompanionPath, renderCompanionWorkerSource("reminders"));
+  await writeFile(scrapersCompanionPath, renderCompanionWorkerSource("scrapers"));
 
   const receipt = {
     ...summary,
@@ -297,6 +375,10 @@ async function main() {
       kv: { ...kv, title: kvTitle },
       r2: { ...r2 },
       queue: { name: queueName },
+      companionServices: {
+        reminders: { name: remindersService, scriptPath: remindersCompanionPath },
+        scrapers: { name: scrapersService, scriptPath: scrapersCompanionPath },
+      },
     },
     generated: {
       workerConfigPath,
@@ -304,11 +386,9 @@ async function main() {
       activityPubPrivateKeyPemPath: privateKeyPath,
       jobsWebhookTokenPath: jobsTokenPath,
     },
-    execution: {
-      shouldSetSecrets,
-      shouldDeploy,
-      shouldVerifyGenerated,
-      shouldVerifyRemote,
+    secretReuse: {
+      federationKeyReused: privateKey.reused,
+      jobsWebhookTokenReused: jobsToken.reused,
     },
   };
 
@@ -327,12 +407,18 @@ async function main() {
 
   if (shouldSetSecrets) {
     console.log("\nSetting Worker secrets...");
-    await putWranglerSecret("ACTIVITYPUB_PRIVATE_KEY_PEM", activityPubPrivateKeyPem, workerConfigPath);
-    await putWranglerSecret("JOBS_WEBHOOK_TOKEN", jobsWebhookToken, workerConfigPath);
+    await putWranglerSecret("ACTIVITYPUB_PRIVATE_KEY_PEM", privateKey.value, workerConfigPath);
+    await putWranglerSecret("JOBS_WEBHOOK_TOKEN", jobsToken.value, workerConfigPath);
   }
 
   if (shouldDeploy) {
-    console.log("\nDeploying Worker + Pages...");
+    if (shouldProvisionCompanionWorkers) {
+      console.log("\nDeploying companion service workers (reminders/scrapers)...");
+      await deployCompanionWorker(remindersService, remindersCompanionPath);
+      await deployCompanionWorker(scrapersService, scrapersCompanionPath);
+    }
+
+    console.log("\nDeploying EveryCal Worker + Pages...");
     await runCommand("wrangler", ["d1", "migrations", "apply", d1Name, "--config", workerConfigPath]);
     await runCommand("wrangler", ["deploy", "--config", workerConfigPath]);
     await runCommand("pnpm", ["cf:pages:build"]);
@@ -348,19 +434,23 @@ async function main() {
   console.log("\nNext steps:");
   console.log(`- Review ${receiptPath} for created resource IDs and generated artifacts.`);
   if (!shouldSetSecrets) {
-    console.log(`- Set secrets manually:`);
+    console.log("- Set secrets manually:");
     console.log(`  wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config ${workerConfigPath} < ${privateKeyPath}`);
     console.log(`  wrangler secret put JOBS_WEBHOOK_TOKEN --config ${workerConfigPath} < ${jobsTokenPath}`);
   }
   if (!shouldDeploy) {
-    console.log(`- Deploy manually:`);
+    console.log("- Deploy manually:");
+    if (shouldProvisionCompanionWorkers) {
+      console.log(`  wrangler deploy ${remindersCompanionPath} --name ${remindersService} --compatibility-date ${COMPATIBILITY_DATE}`);
+      console.log(`  wrangler deploy ${scrapersCompanionPath} --name ${scrapersService} --compatibility-date ${COMPATIBILITY_DATE}`);
+    }
     console.log(`  wrangler d1 migrations apply ${d1Name} --config ${workerConfigPath}`);
     console.log(`  wrangler deploy --config ${workerConfigPath}`);
-    console.log(`  pnpm cf:pages:build`);
+    console.log("  pnpm cf:pages:build");
     console.log(`  wrangler pages deploy packages/web/dist/client --project-name ${pagesProject} --config ${pagesConfigPath}`);
   }
   if (!shouldVerifyRemote) {
-    console.log(`- Verify runtime readiness:`);
+    console.log("- Verify runtime readiness:");
     console.log(`  curl -fsS ${apiOrigin}/api/v1/system/deploy-readiness`);
   }
 }

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { generateKeyPairSync, randomBytes } from "node:crypto";
+import { spawn } from "node:child_process";
+
+const CF_API_BASE = "https://api.cloudflare.com/client/v4";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
+function must(value, message) {
+  if (!value) throw new Error(message);
+  return value;
+}
+
+function slugify(value) {
+  return value.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+function generateFederationPrivateKeyPem() {
+  const { privateKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  return privateKey;
+}
+
+async function cfFetch(path, init, token) {
+  const res = await fetch(`${CF_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      ...(init?.headers || {}),
+    },
+  });
+
+  const payload = await res.json().catch(() => ({}));
+  if (!res.ok || payload?.success === false) {
+    const err = JSON.stringify(payload?.errors || payload || {}, null, 2);
+    throw new Error(`Cloudflare API ${path} failed (${res.status}): ${err}`);
+  }
+  return payload.result;
+}
+
+async function resolveAccountId(token, preferredAccountId) {
+  if (preferredAccountId) return preferredAccountId;
+  const memberships = await cfFetch("/memberships", { method: "GET" }, token);
+  const first = Array.isArray(memberships) ? memberships[0] : null;
+  if (!first?.account?.id) throw new Error("Unable to resolve account id from token. Provide --account-id.");
+  return first.account.id;
+}
+
+async function ensureD1Database(accountId, name, token) {
+  const list = await cfFetch(`/accounts/${accountId}/d1/database`, { method: "GET" }, token);
+  const existing = Array.isArray(list) ? list.find((item) => item.name === name) : null;
+  if (existing?.uuid) return { id: existing.uuid, created: false };
+  const created = await cfFetch(`/accounts/${accountId}/d1/database`, {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  }, token);
+  return { id: created.uuid, created: true };
+}
+
+async function ensureKvNamespace(accountId, title, token) {
+  const list = await cfFetch(`/accounts/${accountId}/storage/kv/namespaces?per_page=100`, { method: "GET" }, token);
+  const existing = Array.isArray(list) ? list.find((item) => item.title === title) : null;
+  if (existing?.id) return { id: existing.id, created: false };
+  const created = await cfFetch(`/accounts/${accountId}/storage/kv/namespaces`, {
+    method: "POST",
+    body: JSON.stringify({ title }),
+  }, token);
+  return { id: created.id, created: true };
+}
+
+async function ensureR2Bucket(accountId, name, token) {
+  const list = await cfFetch(`/accounts/${accountId}/r2/buckets`, { method: "GET" }, token);
+  const existing = Array.isArray(list?.buckets) ? list.buckets.find((item) => item.name === name) : null;
+  if (existing?.name) return { name: existing.name, created: false };
+  await cfFetch(`/accounts/${accountId}/r2/buckets`, {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  }, token);
+  return { name, created: true };
+}
+
+async function ensureQueue(accountId, queueName, token) {
+  const list = await cfFetch(`/accounts/${accountId}/queues`, { method: "GET" }, token);
+  const existing = Array.isArray(list) ? list.find((item) => item.queue_name === queueName) : null;
+  if (existing?.queue_id) return { id: existing.queue_id, created: false };
+  const created = await cfFetch(`/accounts/${accountId}/queues`, {
+    method: "POST",
+    body: JSON.stringify({ queue_name: queueName }),
+  }, token);
+  return { id: created.queue_id, created: true };
+}
+
+async function runCommand(cmd, args, options = {}) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["pipe", "inherit", "inherit"], ...options });
+    if (options.stdinText) {
+      child.stdin.write(options.stdinText);
+      child.stdin.end();
+    }
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+function renderWorkerConfig(input) {
+  return `name = "everycal"
+main = "packages/cloudflare-worker/src/index.ts"
+compatibility_date = "2026-03-01"
+workers_dev = true
+
+[[d1_databases]]
+binding = "DB"
+database_name = "${input.d1Name}"
+database_id = "${input.d1Id}"
+migrations_dir = "packages/cloudflare-worker/migrations"
+
+[[r2_buckets]]
+binding = "UPLOADS"
+bucket_name = "${input.r2Bucket}"
+
+[[queues.producers]]
+binding = "JOBS_QUEUE"
+queue = "${input.queueName}"
+
+[[queues.consumers]]
+queue = "${input.queueName}"
+max_batch_size = 10
+max_batch_timeout = 10
+
+[[kv_namespaces]]
+binding = "RATE_LIMITS_KV"
+id = "${input.kvId}"
+
+[[durable_objects.bindings]]
+name = "RATE_LIMITS_DO"
+class_name = "RateLimitCoordinator"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["RateLimitCoordinator"]
+
+[[services]]
+binding = "REMINDERS_SERVICE"
+service = "${input.remindersService}"
+
+[[services]]
+binding = "SCRAPERS_SERVICE"
+service = "${input.scrapersService}"
+
+[triggers]
+crons = ["0 * * * *"]
+
+[vars]
+BASE_URL = "${input.apiOrigin}"
+SESSION_COOKIE_NAME = "everycal_session"
+CORS_ORIGIN = "${input.webOrigin}"
+SSR_CACHE_MAX_AGE_SECONDS = "15"
+SSR_CACHE_STALE_WHILE_REVALIDATE_SECONDS = "30"
+SSR_EDGE_CACHE_ENABLED = "true"
+SSR_EDGE_CACHE_BYPASS_HEADER = "x-everycal-ssr-bypass"
+SSR_CACHE_TAG_VERSION = "v1"
+
+[observability]
+enabled = true
+`;
+}
+
+function renderPagesConfig(apiOrigin) {
+  return `name = "everycal-web"
+compatibility_date = "2026-03-01"
+pages_build_output_dir = "dist/client"
+
+[vars]
+API_ORIGIN = "${apiOrigin}"
+VITE_API_ORIGIN = "${apiOrigin}"
+`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const domain = must(args.domain, "Missing required --domain (example: --domain calendar.example.com)");
+  const env = String(args.env || "prod");
+  const projectSlug = slugify(String(args.project || "everycal"));
+  const apiHost = String(args["api-host"] || `api.${domain}`);
+  const webOrigin = `https://${domain}`;
+  const apiOrigin = `https://${apiHost}`;
+  const dryRun = !args.apply;
+
+  const d1Name = `${projectSlug}-${env}`;
+  const kvTitle = `${projectSlug}-${env}-rate-limits`;
+  const r2Bucket = `${projectSlug}-${env}-uploads`;
+  const queueName = `${projectSlug}-${env}-jobs`;
+  const remindersService = `${projectSlug}-reminders-${env}`;
+  const scrapersService = `${projectSlug}-scrapers-${env}`;
+
+  const summary = {
+    mode: dryRun ? "plan" : "apply",
+    input: { domain, apiHost, env, projectSlug },
+    derived: { webOrigin, apiOrigin, d1Name, kvTitle, r2Bucket, queueName, remindersService, scrapersService },
+  };
+
+  if (dryRun) {
+    console.log(JSON.stringify(summary, null, 2));
+    console.log("\nPlan mode only. Re-run with --apply to provision resources and write generated config files.");
+    return;
+  }
+
+  const token = must(process.env.CLOUDFLARE_API_TOKEN, "Missing CLOUDFLARE_API_TOKEN for --apply mode.");
+  const accountId = await resolveAccountId(token, args["account-id"] ? String(args["account-id"]) : undefined);
+
+  const d1 = await ensureD1Database(accountId, d1Name, token);
+  const kv = await ensureKvNamespace(accountId, kvTitle, token);
+  const r2 = await ensureR2Bucket(accountId, r2Bucket, token);
+  await ensureQueue(accountId, queueName, token);
+
+  const activityPubPrivateKeyPem = generateFederationPrivateKeyPem();
+  const jobsWebhookToken = randomBytes(24).toString("hex");
+
+  await mkdir(".generated", { recursive: true });
+
+  const workerConfigPath = `.generated/wrangler.${env}.toml`;
+  const pagesConfigPath = `.generated/packages.web.wrangler.${env}.toml`;
+  await writeFile(workerConfigPath, renderWorkerConfig({
+    d1Name,
+    d1Id: d1.id,
+    r2Bucket: r2.name,
+    queueName,
+    kvId: kv.id,
+    remindersService,
+    scrapersService,
+    webOrigin,
+    apiOrigin,
+  }));
+  await writeFile(pagesConfigPath, renderPagesConfig(apiOrigin));
+
+  const receipt = {
+    ...summary,
+    accountId,
+    resources: {
+      d1: { ...d1, name: d1Name },
+      kv: { ...kv, title: kvTitle },
+      r2: { ...r2 },
+      queue: { name: queueName },
+    },
+    generated: {
+      workerConfigPath,
+      pagesConfigPath,
+      activityPubPrivateKeyPemPath: `.generated/activitypub-private-key.${env}.pem`,
+      jobsWebhookTokenPath: `.generated/jobs-webhook-token.${env}.txt`,
+    },
+  };
+
+  await writeFile(`.generated/activitypub-private-key.${env}.pem`, activityPubPrivateKeyPem);
+  await writeFile(`.generated/jobs-webhook-token.${env}.txt`, `${jobsWebhookToken}\n`);
+  await writeFile(`.generated/cf-bootstrap-receipt.${env}.json`, JSON.stringify(receipt, null, 2));
+
+  console.log("Created resources and generated config files:");
+  console.log(`- ${workerConfigPath}`);
+  console.log(`- ${pagesConfigPath}`);
+  console.log(`- .generated/cf-bootstrap-receipt.${env}.json`);
+
+  if (args.deploy) {
+    await runCommand("wrangler", ["d1", "migrations", "apply", d1Name, "--config", workerConfigPath]);
+    await runCommand("wrangler", ["deploy", "--config", workerConfigPath]);
+    await runCommand("pnpm", ["cf:pages:build"]);
+    await runCommand("wrangler", ["pages", "deploy", "packages/web/dist/client", "--project-name", "everycal-web", "--config", pagesConfigPath]);
+  }
+
+  console.log("\nNext steps:");
+  console.log(`1) wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config ${workerConfigPath} < .generated/activitypub-private-key.${env}.pem`);
+  console.log(`2) wrangler secret put JOBS_WEBHOOK_TOKEN --config ${workerConfigPath} < .generated/jobs-webhook-token.${env}.txt`);
+  console.log(`3) pnpm cf:check:strict (after copying generated config into tracked wrangler files or using equivalent check script wiring)`);
+  console.log(`4) GET ${apiOrigin}/api/v1/system/deploy-readiness should return { ok: true }`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -173,10 +173,26 @@ function wranglerEnv(accountId) {
 }
 
 async function runWranglerJson(args, options = {}) {
-  const { stdout } = await runCommandCapture("wrangler", [...args, "--json"], { env: wranglerEnv(options.accountId) });
-  const parsed = parseMaybeJsonOutput(stdout);
-  if (parsed === null) throw new Error(`Expected JSON output from wrangler ${args.join(" ")}`);
-  return parsed;
+  try {
+    const { stdout } = await runCommandCapture("wrangler", [...args, "--json"], { env: wranglerEnv(options.accountId) });
+    const parsed = parseMaybeJsonOutput(stdout);
+    if (parsed === null) throw new Error(`Expected JSON output from wrangler ${args.join(" ")}`);
+    return parsed;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.includes("Unknown argument: json") && !message.includes("Unknown arguments: json")) {
+      throw error;
+    }
+
+    const fallback = await runCommandCapture("wrangler", args, { env: wranglerEnv(options.accountId) });
+    const parsed = parseMaybeJsonOutput(fallback.stdout) ?? parseMaybeJsonOutput(fallback.stderr);
+    if (parsed !== null) return parsed;
+
+    throw new Error(
+      `Wrangler command '${args.join(" ")}' does not support --json and did not emit machine-readable output. ` +
+      "Upgrade Wrangler (recommended) or run bootstrap with --auth api-token."
+    );
+  }
 }
 
 async function runWrangler(args, options = {}) {

--- a/scripts/cf-bootstrap.mjs
+++ b/scripts/cf-bootstrap.mjs
@@ -125,8 +125,12 @@ async function runCommand(cmd, args, options = {}) {
   });
 }
 
+async function putWranglerSecret(name, value, workerConfigPath) {
+  await runCommand("wrangler", ["secret", "put", name, "--config", workerConfigPath], { stdinText: `${value}\n` });
+}
+
 function renderWorkerConfig(input) {
-  return `name = "everycal"
+  return `name = "${input.workerName}"
 main = "packages/cloudflare-worker/src/index.ts"
 compatibility_date = "2026-03-01"
 workers_dev = true
@@ -199,15 +203,38 @@ VITE_API_ORIGIN = "${apiOrigin}"
 `;
 }
 
+async function verifyGeneratedConfig(workerConfigPath, pagesConfigPath) {
+  await runCommand("node", [
+    "scripts/cf-deploy-readiness.mjs",
+    "--worker-config", workerConfigPath,
+    "--pages-config", pagesConfigPath,
+  ]);
+}
+
+async function verifyRemoteReadiness(apiOrigin) {
+  const url = `${apiOrigin}/api/v1/system/deploy-readiness`;
+  const res = await fetch(url);
+  const payload = await res.json().catch(() => ({}));
+  if (!res.ok || payload?.ok !== true) {
+    throw new Error(`Remote readiness check failed at ${url}: ${JSON.stringify(payload)}`);
+  }
+}
+
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const domain = must(args.domain, "Missing required --domain (example: --domain calendar.example.com)");
   const env = String(args.env || "prod");
   const projectSlug = slugify(String(args.project || "everycal"));
+  const workerName = `${projectSlug}-${env}`;
+  const pagesProject = String(args["pages-project"] || "everycal-web");
   const apiHost = String(args["api-host"] || `api.${domain}`);
   const webOrigin = `https://${domain}`;
   const apiOrigin = `https://${apiHost}`;
   const dryRun = !args.apply;
+  const shouldDeploy = Boolean(args.deploy);
+  const shouldSetSecrets = !args["skip-secrets"];
+  const shouldVerifyGenerated = !args["skip-config-check"];
+  const shouldVerifyRemote = shouldDeploy && !args["skip-remote-verify"];
 
   const d1Name = `${projectSlug}-${env}`;
   const kvTitle = `${projectSlug}-${env}-rate-limits`;
@@ -218,8 +245,8 @@ async function main() {
 
   const summary = {
     mode: dryRun ? "plan" : "apply",
-    input: { domain, apiHost, env, projectSlug },
-    derived: { webOrigin, apiOrigin, d1Name, kvTitle, r2Bucket, queueName, remindersService, scrapersService },
+    input: { domain, apiHost, env, projectSlug, pagesProject },
+    derived: { webOrigin, apiOrigin, workerName, d1Name, kvTitle, r2Bucket, queueName, remindersService, scrapersService },
   };
 
   if (dryRun) {
@@ -244,6 +271,7 @@ async function main() {
   const workerConfigPath = `.generated/wrangler.${env}.toml`;
   const pagesConfigPath = `.generated/packages.web.wrangler.${env}.toml`;
   await writeFile(workerConfigPath, renderWorkerConfig({
+    workerName,
     d1Name,
     d1Id: d1.id,
     r2Bucket: r2.name,
@@ -255,6 +283,11 @@ async function main() {
     apiOrigin,
   }));
   await writeFile(pagesConfigPath, renderPagesConfig(apiOrigin));
+
+  const privateKeyPath = `.generated/activitypub-private-key.${env}.pem`;
+  const jobsTokenPath = `.generated/jobs-webhook-token.${env}.txt`;
+  await writeFile(privateKeyPath, activityPubPrivateKeyPem);
+  await writeFile(jobsTokenPath, `${jobsWebhookToken}\n`);
 
   const receipt = {
     ...summary,
@@ -268,32 +301,68 @@ async function main() {
     generated: {
       workerConfigPath,
       pagesConfigPath,
-      activityPubPrivateKeyPemPath: `.generated/activitypub-private-key.${env}.pem`,
-      jobsWebhookTokenPath: `.generated/jobs-webhook-token.${env}.txt`,
+      activityPubPrivateKeyPemPath: privateKeyPath,
+      jobsWebhookTokenPath: jobsTokenPath,
+    },
+    execution: {
+      shouldSetSecrets,
+      shouldDeploy,
+      shouldVerifyGenerated,
+      shouldVerifyRemote,
     },
   };
 
-  await writeFile(`.generated/activitypub-private-key.${env}.pem`, activityPubPrivateKeyPem);
-  await writeFile(`.generated/jobs-webhook-token.${env}.txt`, `${jobsWebhookToken}\n`);
-  await writeFile(`.generated/cf-bootstrap-receipt.${env}.json`, JSON.stringify(receipt, null, 2));
+  const receiptPath = `.generated/cf-bootstrap-receipt.${env}.json`;
+  await writeFile(receiptPath, JSON.stringify(receipt, null, 2));
 
   console.log("Created resources and generated config files:");
   console.log(`- ${workerConfigPath}`);
   console.log(`- ${pagesConfigPath}`);
-  console.log(`- .generated/cf-bootstrap-receipt.${env}.json`);
+  console.log(`- ${receiptPath}`);
 
-  if (args.deploy) {
+  if (shouldVerifyGenerated) {
+    console.log("\nRunning strict generated-config readiness checks...");
+    await verifyGeneratedConfig(workerConfigPath, pagesConfigPath);
+  }
+
+  if (shouldSetSecrets) {
+    console.log("\nSetting Worker secrets...");
+    await putWranglerSecret("ACTIVITYPUB_PRIVATE_KEY_PEM", activityPubPrivateKeyPem, workerConfigPath);
+    await putWranglerSecret("JOBS_WEBHOOK_TOKEN", jobsWebhookToken, workerConfigPath);
+  }
+
+  if (shouldDeploy) {
+    console.log("\nDeploying Worker + Pages...");
     await runCommand("wrangler", ["d1", "migrations", "apply", d1Name, "--config", workerConfigPath]);
     await runCommand("wrangler", ["deploy", "--config", workerConfigPath]);
     await runCommand("pnpm", ["cf:pages:build"]);
-    await runCommand("wrangler", ["pages", "deploy", "packages/web/dist/client", "--project-name", "everycal-web", "--config", pagesConfigPath]);
+    await runCommand("wrangler", ["pages", "deploy", "packages/web/dist/client", "--project-name", pagesProject, "--config", pagesConfigPath]);
+
+    if (shouldVerifyRemote) {
+      console.log("\nVerifying remote runtime readiness endpoint...");
+      await verifyRemoteReadiness(apiOrigin);
+      console.log("Remote readiness check passed.");
+    }
   }
 
   console.log("\nNext steps:");
-  console.log(`1) wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config ${workerConfigPath} < .generated/activitypub-private-key.${env}.pem`);
-  console.log(`2) wrangler secret put JOBS_WEBHOOK_TOKEN --config ${workerConfigPath} < .generated/jobs-webhook-token.${env}.txt`);
-  console.log(`3) pnpm cf:check:strict (after copying generated config into tracked wrangler files or using equivalent check script wiring)`);
-  console.log(`4) GET ${apiOrigin}/api/v1/system/deploy-readiness should return { ok: true }`);
+  console.log(`- Review ${receiptPath} for created resource IDs and generated artifacts.`);
+  if (!shouldSetSecrets) {
+    console.log(`- Set secrets manually:`);
+    console.log(`  wrangler secret put ACTIVITYPUB_PRIVATE_KEY_PEM --config ${workerConfigPath} < ${privateKeyPath}`);
+    console.log(`  wrangler secret put JOBS_WEBHOOK_TOKEN --config ${workerConfigPath} < ${jobsTokenPath}`);
+  }
+  if (!shouldDeploy) {
+    console.log(`- Deploy manually:`);
+    console.log(`  wrangler d1 migrations apply ${d1Name} --config ${workerConfigPath}`);
+    console.log(`  wrangler deploy --config ${workerConfigPath}`);
+    console.log(`  pnpm cf:pages:build`);
+    console.log(`  wrangler pages deploy packages/web/dist/client --project-name ${pagesProject} --config ${pagesConfigPath}`);
+  }
+  if (!shouldVerifyRemote) {
+    console.log(`- Verify runtime readiness:`);
+    console.log(`  curl -fsS ${apiOrigin}/api/v1/system/deploy-readiness`);
+  }
 }
 
 main().catch((err) => {

--- a/scripts/cf-deploy-readiness.mjs
+++ b/scripts/cf-deploy-readiness.mjs
@@ -2,6 +2,23 @@
 
 import { readFile } from "node:fs/promises";
 
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
 function getTomlValue(text, key) {
   const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = text.match(new RegExp(`^\\s*${escaped}\\s*=\\s*"([^"]*)"`, "m"));
@@ -23,8 +40,11 @@ function isPlaceholderLike(value) {
 }
 
 async function main() {
-  const workerToml = await readFile(new URL("../wrangler.toml", import.meta.url), "utf8");
-  const pagesToml = await readFile(new URL("../packages/web/wrangler.toml", import.meta.url), "utf8");
+  const args = parseArgs(process.argv.slice(2));
+  const workerConfigPath = args["worker-config"] ? String(args["worker-config"]) : new URL("../wrangler.toml", import.meta.url);
+  const pagesConfigPath = args["pages-config"] ? String(args["pages-config"]) : new URL("../packages/web/wrangler.toml", import.meta.url);
+  const workerToml = await readFile(workerConfigPath, "utf8");
+  const pagesToml = await readFile(pagesConfigPath, "utf8");
 
   const checks = [
     {
@@ -75,7 +95,7 @@ async function main() {
   ];
 
   const failing = checks.filter((check) => !check.ok);
-  const warnOnly = process.argv.includes("--warn");
+  const warnOnly = Boolean(args.warn);
 
   console.log("Cloudflare deploy readiness checks");
   for (const check of checks) {

--- a/scripts/cf-deploy-readiness.mjs
+++ b/scripts/cf-deploy-readiness.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+
+function getTomlValue(text, key) {
+  const escaped = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = text.match(new RegExp(`^\\s*${escaped}\\s*=\\s*"([^"]*)"`, "m"));
+  return match ? match[1] : null;
+}
+
+function hasBinding(text, bindingName) {
+  return new RegExp(`binding\\s*=\\s*"${bindingName}"`, "m").test(text);
+}
+
+function isPlaceholderLike(value) {
+  if (!value) return true;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return true;
+  return normalized.includes("replace_with")
+    || normalized.includes("example.com")
+    || normalized.includes("example.workers.dev")
+    || normalized.includes("example.pages.dev");
+}
+
+async function main() {
+  const workerToml = await readFile(new URL("../wrangler.toml", import.meta.url), "utf8");
+  const pagesToml = await readFile(new URL("../packages/web/wrangler.toml", import.meta.url), "utf8");
+
+  const checks = [
+    {
+      id: "worker.database_id",
+      ok: !isPlaceholderLike(getTomlValue(workerToml, "database_id")),
+      detail: "wrangler.toml should use a real D1 database_id.",
+    },
+    {
+      id: "worker.rate_limits_kv_id",
+      ok: !isPlaceholderLike(getTomlValue(workerToml, "id")),
+      detail: "wrangler.toml should use a real KV namespace id for RATE_LIMITS_KV (or remove that binding).",
+    },
+    {
+      id: "worker.base_url",
+      ok: !isPlaceholderLike(getTomlValue(workerToml, "BASE_URL")),
+      detail: "wrangler.toml BASE_URL should point at your deployed API/Worker URL.",
+    },
+    {
+      id: "worker.cors_origin",
+      ok: !isPlaceholderLike(getTomlValue(workerToml, "CORS_ORIGIN")),
+      detail: "wrangler.toml CORS_ORIGIN should point at your deployed web origin.",
+    },
+    {
+      id: "pages.api_origin",
+      ok: !isPlaceholderLike(getTomlValue(pagesToml, "API_ORIGIN")),
+      detail: "packages/web/wrangler.toml API_ORIGIN should point at your deployed Worker API origin.",
+    },
+    {
+      id: "pages.vite_api_origin",
+      ok: !isPlaceholderLike(getTomlValue(pagesToml, "VITE_API_ORIGIN")),
+      detail: "packages/web/wrangler.toml VITE_API_ORIGIN should point at your deployed Worker API origin.",
+    },
+    {
+      id: "worker.jobs_queue_binding",
+      ok: hasBinding(workerToml, "JOBS_QUEUE"),
+      detail: "wrangler.toml should define JOBS_QUEUE producer binding.",
+    },
+    {
+      id: "worker.reminders_executor_binding",
+      ok: hasBinding(workerToml, "REMINDERS_SERVICE"),
+      detail: "wrangler.toml should define REMINDERS_SERVICE or you must provide REMINDERS_WEBHOOK_URL secret at runtime.",
+    },
+    {
+      id: "worker.scrapers_executor_binding",
+      ok: hasBinding(workerToml, "SCRAPERS_SERVICE"),
+      detail: "wrangler.toml should define SCRAPERS_SERVICE or you must provide SCRAPERS_WEBHOOK_URL secret at runtime.",
+    },
+  ];
+
+  const failing = checks.filter((check) => !check.ok);
+  const warnOnly = process.argv.includes("--warn");
+
+  console.log("Cloudflare deploy readiness checks");
+  for (const check of checks) {
+    const marker = check.ok ? "✓" : warnOnly ? "!" : "✗";
+    console.log(`${marker} ${check.id} - ${check.detail}`);
+  }
+
+  if (failing.length > 0 && !warnOnly) {
+    console.error(`\nFailed ${failing.length}/${checks.length} checks.`);
+    process.exit(1);
+  }
+
+  if (failing.length > 0) {
+    console.warn(`\nWarning: ${failing.length}/${checks.length} checks need real deployment values.`);
+    return;
+  }
+
+  console.log(`\nAll ${checks.length} checks passed.`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/cf-go-live-gate.mjs
+++ b/scripts/cf-go-live-gate.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith("--")) continue;
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith("--")) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
+async function run(cmd, args) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("exit", (code) => (code === 0 ? resolve(undefined) : reject(new Error(`${cmd} exited with ${code}`))));
+  });
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  const payload = await res.json().catch(() => ({}));
+  return { res, payload };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const env = String(args.env || "prod");
+  const apiOrigin = args["api-origin"] ? String(args["api-origin"]) : "";
+  if (!apiOrigin) throw new Error("Missing --api-origin for go-live gate checks.");
+
+  const workerConfig = args["worker-config"] ? String(args["worker-config"]) : `.generated/wrangler.${env}.toml`;
+  const pagesConfig = args["pages-config"] ? String(args["pages-config"]) : `.generated/packages.web.wrangler.${env}.toml`;
+  const receiptPath = args.receipt ? String(args.receipt) : `.generated/cf-bootstrap-receipt.${env}.json`;
+
+  await run("node", [
+    "scripts/cf-deploy-readiness.mjs",
+    "--worker-config", workerConfig,
+    "--pages-config", pagesConfig,
+  ]);
+
+  const receipt = JSON.parse(await readFile(receiptPath, "utf8"));
+  if (!receipt.smtp?.configured || !receipt.smtp?.valid) {
+    throw new Error("SMTP validation missing or failed in bootstrap receipt.");
+  }
+
+  const readiness = await fetchJson(`${apiOrigin}/api/v1/system/deploy-readiness`);
+  if (!readiness.res.ok || readiness.payload?.ok !== true) {
+    throw new Error(`Runtime readiness failed: ${JSON.stringify(readiness.payload)}`);
+  }
+
+  const behavioralFailures = (readiness.payload?.checks || []).filter((check) => check.level === "behavior" && !check.ok);
+  if (behavioralFailures.length > 0) {
+    throw new Error(`Behavioral readiness checks failed: ${JSON.stringify(behavioralFailures)}`);
+  }
+
+  const health = await fetchJson(`${apiOrigin}/healthz`);
+  if (!health.res.ok || health.payload?.status !== "ok") {
+    throw new Error(`Health endpoint failed: ${JSON.stringify(health.payload)}`);
+  }
+
+  const bootstrap = await fetchJson(`${apiOrigin}/api/v1/bootstrap`);
+  if (!bootstrap.res.ok || bootstrap.payload?.mode !== "unified") {
+    throw new Error(`Bootstrap contract check failed: ${JSON.stringify(bootstrap.payload)}`);
+  }
+
+  console.log("\nGo-live gate passed: config + smtp + readiness + smoke checks are green.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,62 @@
+name = "everycal"
+main = "packages/cloudflare-worker/src/index.ts"
+compatibility_date = "2026-03-01"
+workers_dev = true
+
+[[d1_databases]]
+binding = "DB"
+database_name = "everycal"
+database_id = "REPLACE_WITH_REAL_D1_DATABASE_ID"
+migrations_dir = "packages/cloudflare-worker/migrations"
+
+[[r2_buckets]]
+binding = "UPLOADS"
+bucket_name = "everycal-uploads"
+
+[[queues.producers]]
+binding = "JOBS_QUEUE"
+queue = "everycal-jobs"
+
+[[queues.consumers]]
+queue = "everycal-jobs"
+max_batch_size = 10
+max_batch_timeout = 10
+
+# Optional distributed/global rate-limit backing store
+[[kv_namespaces]]
+binding = "RATE_LIMITS_KV"
+id = "REPLACE_WITH_RATE_LIMITS_KV_ID"
+
+
+[[durable_objects.bindings]]
+name = "RATE_LIMITS_DO"
+class_name = "RateLimitCoordinator"
+
+[[migrations]]
+tag = "v1"
+new_classes = ["RateLimitCoordinator"]
+
+# Optional native queue consumer targets (service bindings)
+[[services]]
+binding = "REMINDERS_SERVICE"
+service = "everycal-reminders"
+
+[[services]]
+binding = "SCRAPERS_SERVICE"
+service = "everycal-scrapers"
+
+[triggers]
+crons = ["0 * * * *"]
+
+[vars]
+BASE_URL = "https://example.workers.dev"
+SESSION_COOKIE_NAME = "everycal_session"
+CORS_ORIGIN = "https://example.pages.dev"
+SSR_CACHE_MAX_AGE_SECONDS = "15"
+SSR_CACHE_STALE_WHILE_REVALIDATE_SECONDS = "30"
+SSR_EDGE_CACHE_ENABLED = "true"
+SSR_EDGE_CACHE_BYPASS_HEADER = "x-everycal-ssr-bypass"
+SSR_CACHE_TAG_VERSION = "v1"
+
+[observability]
+enabled = true


### PR DESCRIPTION
### Motivation

- Provide an additive Cloudflare-native deployment option (Pages + Workers + D1 + R2 + Queues + Cron) while preserving existing Node/Docker runtimes. 
- Share core HTTP/API logic across runtimes via a new unified runtime package to avoid divergent implementations and simplify parity tests. 
- Add deploy/readiness checks and CI parity gates to prevent regressions between runtimes.

### Description

- Introduces a new runtime package `@everycal/runtime-core` that implements a unified Hono-based app with the shared API surface and pluggable hooks (`verifyInboxRequest`, `deliverActivity`, `syncRemoteActorAndEvents`).
- Adds a Cloudflare platform package `@everycal/cloudflare-worker` that includes: federation helpers (`federation.ts`), SSR adapter (`ssr.ts`), Cloudflare storage adapter (`storage.ts`), security helpers (`security.ts`), worker entry (`index.ts`), D1 migrations (`migrations/0001_init.sql`), and Pages proxy functions under `packages/web/functions` to route Pages -> Worker API.
- Adds Node-side unified entry and storage: `packages/server/src/unified-index.ts` and `packages/server/src/storage/node-storage.ts` to run the same unified app on Node for migration/testing, and updates `packages/server/package.json` scripts (`dev:unified`, `start:unified`) and references to `@everycal/runtime-core`.
- Adds runtime/core storage typings and shared helpers: `packages/core/src/storage.ts` and re-exports in `packages/core/src/index.ts`.
- Adds test suites for runtime-core and cloudflare-worker (`*.test.ts`) exercising federation, SSR, queue handling, storage adapter behavior, and password hashing.
- Adds Cloudflare deployment support files: `wrangler.toml`, `packages/web/wrangler.toml`, `scripts/cf-deploy-readiness.mjs`, and `packages/cloudflare-worker/tsconfig.json`.
- Adds CI parity workflow `.github/workflows/parity-gates.yml` that runs `pnpm cf:check` and parity tests for `@everycal/runtime-core` and `@everycal/cloudflare-worker` on PRs and pushes to `main`.
- Updates repository README and adds `docs/deployment.md` to document the three deployment paths and migration/operational notes.

### Testing

- Ran Cloudflare config readiness checks with `pnpm cf:check` which completed successfully (warn-free in strict environments when configured). 
- Executed unit tests for the unified runtime and worker packages with `pnpm --filter @everycal/runtime-core test` and `pnpm --filter @everycal/cloudflare-worker test`, and all tests passed. 
- Confirmed CI parity workflow was added as `.github/workflows/parity-gates.yml` to run the above checks automatically on PRs and `main` pushes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8822cea548321a60c592d404b367d)