### PR TITLE
Add GEHT-DOCH Tribe scraper and shared Tribe helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
       "minimatch": ">=10.2.3",
       "webpack-dev-server": ">=5.2.1",
       "ajv": ">=8.18.0",
-      "@eslint/eslintrc>ajv": ">=6.14.0",
-      "eslint>ajv": ">=6.14.0",
+      "@eslint/eslintrc>ajv": "^6.12.6",
+      "eslint>ajv": "^6.12.6",
       "qs": ">=6.14.2",
       "basic-ftp": ">=5.2.2",
       "wait-on>axios": ">=1.15.0",
@@ -32,7 +32,8 @@
       "serialize-javascript": ">=7.0.3",
       "svgo": ">=3.3.3",
       "immutable": ">=5.1.5",
-      "picomatch": ">=4.0.4"
+      "picomatch": ">=4.0.4",
+      "schema-utils@3>ajv": "^6.12.6"
     }
   },
   "scripts": {

--- a/packages/core/src/activitypub.test.ts
+++ b/packages/core/src/activitypub.test.ts
@@ -66,6 +66,18 @@ describe("toActivityPubEvent", () => {
     expect(ap.startTime).toBe("2026-03-01");
     expect(ap.endTime).toBe("2026-03-02");
   });
+
+  it("normalizes tags to valid hashtag names", () => {
+    const ap = toActivityPubEvent(
+      baseEvent({
+        tags: ["community walk", "#already-tagged", "two   spaces", "   "],
+      })
+    );
+
+    const names = (ap.tag || []).map((t) => t.name);
+    expect(names).toEqual(["#community-walk", "#already-tagged", "#two-spaces"]);
+    for (const name of names) expect(name).not.toMatch(/\s/);
+  });
 });
 
 describe("fromActivityPubEvent", () => {

--- a/packages/core/src/activitypub.ts
+++ b/packages/core/src/activitypub.ts
@@ -53,7 +53,7 @@ interface APTag {
 
 const PUBLIC = "https://www.w3.org/ns/activitystreams#Public";
 
-function normalizeHashtagName(tag: string): string | undefined {
+export function normalizeHashtagName(tag: string): string | undefined {
   const base = tag.replace(/^#/, "").trim();
   if (!base) return undefined;
   return base.replace(/\s+/g, "-").replace(/-+/g, "-");

--- a/packages/core/src/activitypub.ts
+++ b/packages/core/src/activitypub.ts
@@ -53,6 +53,12 @@ interface APTag {
 
 const PUBLIC = "https://www.w3.org/ns/activitystreams#Public";
 
+function normalizeHashtagName(tag: string): string | undefined {
+  const base = tag.replace(/^#/, "").trim();
+  if (!base) return undefined;
+  return base.replace(/\s+/g, "-").replace(/-+/g, "-");
+}
+
 function visibilityToAddressing(
   visibility: EventVisibility,
   organizer?: string
@@ -137,10 +143,15 @@ export function toActivityPubEvent(event: EveryCalEvent): APEvent {
   }
 
   if (event.tags && event.tags.length > 0) {
-    ap.tag = event.tags.map((t) => ({
-      type: "Hashtag" as const,
-      name: t.startsWith("#") ? t : `#${t}`,
-    }));
+    const normalizedTags = event.tags
+      .map(normalizeHashtagName)
+      .filter((t): t is string => Boolean(t));
+    if (normalizedTags.length > 0) {
+      ap.tag = normalizedTags.map((t) => ({
+        type: "Hashtag" as const,
+        name: `#${t}`,
+      }));
+    }
   }
 
   return ap;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,7 +3,7 @@
  */
 
 export { EveryCalEvent, EventVisibility, EVENT_VISIBILITIES, isValidVisibility, EventLocation, EventImage, ImageAttribution, TimezoneQuality } from "./event.js";
-export { toActivityPubEvent, fromActivityPubEvent } from "./activitypub.js";
+export { toActivityPubEvent, fromActivityPubEvent, normalizeHashtagName } from "./activitypub.js";
 export { toICal, toICalendar, fromICal } from "./ical.js";
 export { SAFE_HTML_TAGS, SAFE_HTML_ATTRS, SAFE_HTML_ATTR_LIST, SAFE_HTML_SCHEMES } from "./sanitize.js";
 export {

--- a/packages/scrapers/src/lib/tribe.test.ts
+++ b/packages/scrapers/src/lib/tribe.test.ts
@@ -54,6 +54,38 @@ describe("fetchTribeEvents", () => {
     );
   });
 
+  it("rejects invalid pagination URLs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          events: [{ id: 1, title: "Page one" }],
+          next_rest_url: "https://flex.at:bad-port/wp-json/tribe/events/v1/events?page=2",
+        })
+      )
+    );
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Invalid Tribe pagination URL"
+    );
+  });
+
+  it("rejects non-http pagination protocols", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          events: [{ id: 1, title: "Page one" }],
+          next_rest_url: "javascript:alert(1)",
+        })
+      )
+    );
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Unsafe Tribe pagination protocol"
+    );
+  });
+
   it("detects circular pagination URLs", async () => {
     const fetchMock = vi
       .fn()
@@ -94,5 +126,37 @@ describe("fetchTribeEvents", () => {
       "Tribe pagination exceeded 100 pages"
     );
     expect(fetchMock).toHaveBeenCalledTimes(100);
+  });
+
+  it("rejects Tribe error payload shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          code: "rest_forbidden",
+          message: "You cannot view this resource.",
+          data: { status: 403 },
+        })
+      )
+    );
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Tribe API returned error payload: rest_forbidden: You cannot view this resource."
+    );
+  });
+
+  it("rejects non-array events payload", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          events: { id: 1 },
+        })
+      )
+    );
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Invalid Tribe API payload: expected events array"
+    );
   });
 });

--- a/packages/scrapers/src/lib/tribe.test.ts
+++ b/packages/scrapers/src/lib/tribe.test.ts
@@ -8,6 +8,13 @@ function mockJsonResponse(payload: unknown) {
   } as const;
 }
 
+function mockHttpErrorResponse(status: number) {
+  return {
+    ok: false,
+    status,
+  } as const;
+}
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.clearAllMocks();
@@ -51,6 +58,14 @@ describe("fetchTribeEvents", () => {
 
     await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
       "Unsafe Tribe pagination origin"
+    );
+  });
+
+  it("includes request URL in HTTP error messages", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockHttpErrorResponse(503)));
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Failed to fetch Tribe events API (503) for https://flex.at/wp-json/tribe/events/v1/events?page=1 (seed origin: https://flex.at)"
     );
   });
 

--- a/packages/scrapers/src/lib/tribe.test.ts
+++ b/packages/scrapers/src/lib/tribe.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchTribeEvents } from "./tribe.js";
+
+function mockJsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as const;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("fetchTribeEvents", () => {
+  it("follows same-origin pagination URLs", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          events: [{ id: 1, title: "Page one" }],
+          next_rest_url: "/wp-json/tribe/events/v1/events?page=2",
+        })
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          events: [{ id: 2, title: "Page two" }],
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const events = await fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1");
+
+    expect(events.map((event) => event.id)).toEqual([1, 2]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://flex.at/wp-json/tribe/events/v1/events?page=2");
+  });
+
+  it("rejects cross-origin pagination URLs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          events: [{ id: 1, title: "Page one" }],
+          next_rest_url: "https://evil.example/collect",
+        })
+      )
+    );
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Unsafe Tribe pagination origin"
+    );
+  });
+
+  it("detects circular pagination URLs", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          events: [{ id: 1, title: "Page one" }],
+          next_rest_url: "https://flex.at/wp-json/tribe/events/v1/events?page=2",
+        })
+      )
+      .mockResolvedValueOnce(
+        mockJsonResponse({
+          events: [{ id: 2, title: "Page two" }],
+          next_rest_url: "https://flex.at/wp-json/tribe/events/v1/events?page=1",
+        })
+      );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Tribe pagination cycle detected"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("limits the number of pagination requests", async () => {
+    const fetchMock = vi.fn().mockImplementation(async (input: string | URL) => {
+      const requestUrl = new URL(String(input));
+      const page = Number(requestUrl.searchParams.get("page") || "1");
+      return mockJsonResponse({
+        events: [{ id: page, title: `Page ${page}` }],
+        next_rest_url: `https://flex.at/wp-json/tribe/events/v1/events?page=${page + 1}`,
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchTribeEvents("https://flex.at/wp-json/tribe/events/v1/events?page=1")).rejects.toThrow(
+      "Tribe pagination exceeded 100 pages"
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(100);
+  });
+});

--- a/packages/scrapers/src/lib/tribe.ts
+++ b/packages/scrapers/src/lib/tribe.ts
@@ -37,22 +37,62 @@ interface TribeEventsResponse {
   next_rest_url?: string;
 }
 
+const MAX_TRIBE_PAGES = 100;
+
 export async function fetchTribeEvents(url: string): Promise<TribeEvent[]> {
   const events: TribeEvent[] = [];
-  let nextUrl = url;
+  const seedUrl = new URL(url);
+  let nextUrl: URL | undefined = seedUrl;
+  let pageCount = 0;
+  const visitedUrls = new Set<string>();
 
   while (nextUrl) {
-    const response = await fetch(nextUrl);
+    pageCount += 1;
+    if (pageCount > MAX_TRIBE_PAGES) {
+      throw new Error(`Tribe pagination exceeded ${MAX_TRIBE_PAGES} pages`);
+    }
+
+    const currentUrl = nextUrl.toString();
+    if (visitedUrls.has(currentUrl)) {
+      throw new Error(`Tribe pagination cycle detected for URL: ${currentUrl}`);
+    }
+    visitedUrls.add(currentUrl);
+
+    const response = await fetch(currentUrl);
     if (!response.ok) {
       throw new Error(`Failed to fetch Tribe events API: ${response.status}`);
     }
 
     const payload = (await response.json()) as TribeEventsResponse;
-    events.push(...(payload.events || []));
-    nextUrl = payload.next_rest_url || "";
+    if (Array.isArray(payload.events)) {
+      events.push(...payload.events);
+    }
+    nextUrl = getSafeNextUrl(payload.next_rest_url, seedUrl);
   }
 
   return events;
+}
+
+function getSafeNextUrl(nextRestUrl: string | undefined, seedUrl: URL): URL | undefined {
+  if (!nextRestUrl) {
+    return undefined;
+  }
+
+  let candidate: URL;
+  try {
+    candidate = new URL(nextRestUrl, seedUrl);
+  } catch {
+    throw new Error(`Invalid Tribe pagination URL: ${nextRestUrl}`);
+  }
+
+  if (candidate.protocol !== "http:" && candidate.protocol !== "https:") {
+    throw new Error(`Unsafe Tribe pagination protocol: ${candidate.protocol}`);
+  }
+  if (candidate.origin !== seedUrl.origin) {
+    throw new Error(`Unsafe Tribe pagination origin: ${candidate.origin}`);
+  }
+
+  return candidate;
 }
 
 export function fromTribeEvent(

--- a/packages/scrapers/src/lib/tribe.ts
+++ b/packages/scrapers/src/lib/tribe.ts
@@ -60,7 +60,9 @@ export async function fetchTribeEvents(url: string): Promise<TribeEvent[]> {
 
     const response = await fetch(currentUrl);
     if (!response.ok) {
-      throw new Error(`Failed to fetch Tribe events API: ${response.status}`);
+      throw new Error(
+        `Failed to fetch Tribe events API (${response.status}) for ${currentUrl} (seed origin: ${seedUrl.origin})`
+      );
     }
 
     const payload = parseTribeEventsResponse(await response.json());

--- a/packages/scrapers/src/lib/tribe.ts
+++ b/packages/scrapers/src/lib/tribe.ts
@@ -63,14 +63,42 @@ export async function fetchTribeEvents(url: string): Promise<TribeEvent[]> {
       throw new Error(`Failed to fetch Tribe events API: ${response.status}`);
     }
 
-    const payload = (await response.json()) as TribeEventsResponse;
-    if (Array.isArray(payload.events)) {
-      events.push(...payload.events);
-    }
+    const payload = parseTribeEventsResponse(await response.json());
+    events.push(...payload.events);
     nextUrl = getSafeNextUrl(payload.next_rest_url, seedUrl);
   }
 
   return events;
+}
+
+function parseTribeEventsResponse(payload: unknown): TribeEventsResponse {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Invalid Tribe API payload: expected object");
+  }
+
+  const candidate = payload as {
+    events?: unknown;
+    next_rest_url?: unknown;
+    code?: unknown;
+    message?: unknown;
+  };
+
+  if (typeof candidate.code === "string") {
+    const message = typeof candidate.message === "string" ? candidate.message : "Unknown error";
+    throw new Error(`Tribe API returned error payload: ${candidate.code}: ${message}`);
+  }
+
+  if (candidate.events !== undefined && !Array.isArray(candidate.events)) {
+    throw new Error("Invalid Tribe API payload: expected events array");
+  }
+  if (candidate.next_rest_url !== undefined && typeof candidate.next_rest_url !== "string") {
+    throw new Error("Invalid Tribe API payload: expected next_rest_url string");
+  }
+
+  return {
+    events: (candidate.events ?? []) as TribeEvent[],
+    next_rest_url: candidate.next_rest_url,
+  };
 }
 
 function getSafeNextUrl(nextRestUrl: string | undefined, seedUrl: URL): URL | undefined {

--- a/packages/scrapers/src/lib/tribe.ts
+++ b/packages/scrapers/src/lib/tribe.ts
@@ -1,0 +1,108 @@
+import type { EveryCalEvent } from "@everycal/core";
+import { normalizeEventDateTime, normalizeUtcDateTime } from "./datetime.js";
+
+export interface TribeCategory {
+  name: string;
+}
+
+export interface TribeImage {
+  url?: string;
+  alt?: string;
+}
+
+export interface TribeVenue {
+  venue?: string;
+  address?: string;
+  city?: string;
+  zip?: string;
+}
+
+export interface TribeEvent {
+  id: number;
+  title?: string;
+  description?: string;
+  url?: string;
+  image?: TribeImage;
+  categories?: TribeCategory[];
+  venue?: TribeVenue;
+  utc_start_date?: string;
+  utc_end_date?: string;
+  start_date?: string;
+  end_date?: string;
+  all_day?: boolean;
+}
+
+interface TribeEventsResponse {
+  events: TribeEvent[];
+  next_rest_url?: string;
+}
+
+export async function fetchTribeEvents(url: string): Promise<TribeEvent[]> {
+  const events: TribeEvent[] = [];
+  let nextUrl = url;
+
+  while (nextUrl) {
+    const response = await fetch(nextUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch Tribe events API: ${response.status}`);
+    }
+
+    const payload = (await response.json()) as TribeEventsResponse;
+    events.push(...(payload.events || []));
+    nextUrl = payload.next_rest_url || "";
+  }
+
+  return events;
+}
+
+export function fromTribeEvent(
+  raw: TribeEvent,
+  idPrefix: string,
+): Partial<EveryCalEvent> {
+  const startDate = raw.utc_start_date
+    ? normalizeUtcDateTime(raw.utc_start_date)
+    : normalizeEventDateTime(raw.start_date);
+  const endDate = raw.utc_end_date
+    ? normalizeUtcDateTime(raw.utc_end_date)
+    : normalizeEventDateTime(raw.end_date);
+
+  const event: Partial<EveryCalEvent> = {
+    id: `${idPrefix}-${raw.id}`,
+    title: raw.title,
+    description: raw.description || undefined,
+    startDate,
+    endDate,
+    allDay: Boolean(raw.all_day),
+    url: raw.url,
+    visibility: "public",
+  };
+
+  if (raw.image?.url) {
+    event.image = {
+      url: raw.image.url,
+      alt: raw.image.alt,
+      mediaType: inferMediaType(raw.image.url),
+    };
+  }
+
+  return event;
+}
+
+function inferMediaType(url: string): string | undefined {
+  const lower = url.toLowerCase();
+  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  if (lower.endsWith(".gif")) return "image/gif";
+  return undefined;
+}
+
+export function toTribeDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  const second = String(date.getUTCSeconds()).padStart(2, "0");
+  return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
+}

--- a/packages/scrapers/src/registry.ts
+++ b/packages/scrapers/src/registry.ts
@@ -5,7 +5,7 @@
 import type { Scraper } from "./scraper.js";
 import { FlexScraper } from "./scrapers/flex-at.js";
 
-// wirmachen.wien scrapers (6 organisations)
+// wirmachen.wien scrapers (7 organisations)
 import {
   CriticalMassViennaScraper,
   RadlobbyWienScraper,
@@ -13,6 +13,7 @@ import {
   SpaceAndPlaceScraper,
   KirchberggasseScraper,
   WestbahnparkScraper,
+  GehtDochScraper,
 } from "./scrapers/wirmachenwien/index.js";
 
 export const registry: Scraper[] = [
@@ -27,6 +28,7 @@ export const registry: Scraper[] = [
   new SpaceAndPlaceScraper(),
   new KirchberggasseScraper(),
   new WestbahnparkScraper(),
+  new GehtDochScraper(),
 ];
 
 export function getScraperById(id: string): Scraper | undefined {

--- a/packages/scrapers/src/scrapers/flex-at.ts
+++ b/packages/scrapers/src/scrapers/flex-at.ts
@@ -7,34 +7,7 @@
 
 import type { EveryCalEvent } from "@everycal/core";
 import type { Scraper } from "../scraper.js";
-import { normalizeEventDateTime, normalizeUtcDateTime } from "../lib/datetime.js";
-
-interface TribeCategory {
-  name: string;
-}
-
-interface TribeImage {
-  url?: string;
-}
-
-interface TribeEvent {
-  id: number;
-  title?: string;
-  description?: string;
-  url?: string;
-  image?: TribeImage;
-  categories?: TribeCategory[];
-  utc_start_date?: string;
-  utc_end_date?: string;
-  start_date?: string;
-  end_date?: string;
-  all_day?: boolean;
-}
-
-interface TribeEventsResponse {
-  events: TribeEvent[];
-  next_rest_url?: string;
-}
+import { fetchTribeEvents, fromTribeEvent, toTribeDate } from "../lib/tribe.js";
 
 export class FlexScraper implements Scraper {
   readonly id = "flex_at";
@@ -44,91 +17,37 @@ export class FlexScraper implements Scraper {
   readonly avatarUrl = "https://flex.at/wp-content/uploads/2022/05/Flex-Logo-weiss.svg";
 
   async scrape(): Promise<Partial<EveryCalEvent>[]> {
-    const events: Partial<EveryCalEvent>[] = [];
-
     const now = new Date();
     const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
     const end = new Date(start);
     end.setMonth(end.getMonth() + 24);
 
-    let nextUrl = `${this.url}?status=publish&per_page=100&start_date=${encodeURIComponent(toTribeDate(start))}&end_date=${encodeURIComponent(toTribeDate(end))}`;
+    const queryUrl = `${this.url}?status=publish&per_page=100&start_date=${encodeURIComponent(toTribeDate(start))}&end_date=${encodeURIComponent(toTribeDate(end))}`;
+    const tribeEvents = await fetchTribeEvents(queryUrl);
 
-    while (nextUrl) {
-      const response = await fetch(nextUrl);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch Flex events API: ${response.status}`);
-      }
+    const events: Partial<EveryCalEvent>[] = [];
+    for (const raw of tribeEvents) {
+      const event = fromTribeEvent(raw, "flex-at");
+      if (!event.title || !event.startDate) continue;
 
-      const payload = (await response.json()) as TribeEventsResponse;
-      for (const raw of payload.events || []) {
-        const event = fromTribeEvent(raw);
-        if (!event.title || !event.startDate) continue;
+      event.location = {
+        name: "Flex",
+        address: "Donaukanal / Augartenbrucke, 1010 Wien",
+        latitude: 48.2177763,
+        longitude: 16.370909,
+        url: "https://flex.at",
+      };
 
-        event.location = {
-          name: "Flex",
-          address: "Donaukanal / Augartenbrucke, 1010 Wien",
-          latitude: 48.2177763,
-          longitude: 16.370909,
-          url: "https://flex.at",
-        };
+      const categoryTags = (raw.categories || [])
+        .map((c) => c.name?.trim().toLowerCase())
+        .filter((c): c is string => Boolean(c));
 
-        const categoryTags = (raw.categories || [])
-          .map((c) => c.name?.trim().toLowerCase())
-          .filter((c): c is string => Boolean(c));
+      const tags = new Set([...(event.tags || []), ...categoryTags, "wien", "music"]);
+      event.tags = Array.from(tags);
 
-        const tags = new Set([...(event.tags || []), ...categoryTags, "wien", "music"]);
-        event.tags = Array.from(tags);
-
-        events.push(event);
-      }
-
-      nextUrl = payload.next_rest_url || "";
+      events.push(event);
     }
 
     return events;
   }
-}
-
-function fromTribeEvent(raw: TribeEvent): Partial<EveryCalEvent> {
-  const startDate = raw.utc_start_date ? normalizeUtcDateTime(raw.utc_start_date) : normalizeEventDateTime(raw.start_date);
-  const endDate = raw.utc_end_date ? normalizeUtcDateTime(raw.utc_end_date) : normalizeEventDateTime(raw.end_date);
-
-  const event: Partial<EveryCalEvent> = {
-    id: `flex-at-${raw.id}`,
-    title: raw.title,
-    description: raw.description || undefined,
-    startDate,
-    endDate,
-    allDay: Boolean(raw.all_day),
-    url: raw.url,
-    visibility: "public",
-  };
-
-  if (raw.image?.url) {
-    event.image = {
-      url: raw.image.url,
-      mediaType: inferMediaType(raw.image.url),
-    };
-  }
-
-  return event;
-}
-
-function toTribeDate(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
-  const hour = String(date.getUTCHours()).padStart(2, "0");
-  const minute = String(date.getUTCMinutes()).padStart(2, "0");
-  const second = String(date.getUTCSeconds()).padStart(2, "0");
-  return `${year}-${month}-${day} ${hour}:${minute}:${second}`;
-}
-
-function inferMediaType(url: string): string | undefined {
-  const lower = url.toLowerCase();
-  if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) return "image/jpeg";
-  if (lower.endsWith(".png")) return "image/png";
-  if (lower.endsWith(".webp")) return "image/webp";
-  if (lower.endsWith(".gif")) return "image/gif";
-  return undefined;
 }

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
@@ -59,7 +59,7 @@ describe("GehtDochScraper", () => {
     });
 
     expect(events[0]?.tags).toEqual(
-      expect.arrayContaining(["wien", "zu-fuß-gehen", "öffentlicher-raum", "wirmachenwien", "community walk"])
+      expect.arrayContaining(["wien", "zu-fuß-gehen", "öffentlicher-raum", "wirmachenwien", "community-walk"])
     );
 
     expect(scraper.bio).toContain("zivilgesellschaftlich organisierter Verein");

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
@@ -63,6 +63,6 @@ describe("GehtDochScraper", () => {
     );
 
     expect(scraper.bio).toContain("zivilgesellschaftlich organisierter Verein");
-    expect(scraper.avatarUrl).toContain("wirmachen.wien");
+    expect(scraper.avatarUrl).toContain("geht-doch.info");
   });
 });

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GehtDochScraper } from "./geht-doch.js";
+
+function mockJsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as const;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("GehtDochScraper", () => {
+  it("maps Tribe events into normalized EveryCal events with profile metadata", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({
+        events: [
+          {
+            id: 12,
+            title: "<strong>Community Walk Wieden</strong>",
+            description: "<p>Jeden letzten Sonntag im Monat.</p>",
+            url: "https://geht-doch.info/event/community-walk-wieden/",
+            start_date: "2026-04-26 15:00:00",
+            end_date: "2026-04-26 17:00:00",
+            categories: [{ name: "Community Walk" }],
+            venue: {
+              venue: "Alois-Drasche-Park",
+              city: "Wien",
+            },
+          },
+        ],
+      })
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const scraper = new GehtDochScraper();
+    const events = await scraper.scrape();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("wp-json/tribe/events/v1/events");
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      id: "geht-doch-12",
+      title: "Community Walk Wieden",
+      description: "Jeden letzten Sonntag im Monat.",
+      startDate: "2026-04-26T15:00:00",
+      endDate: "2026-04-26T17:00:00",
+      organizer: "GEHT-DOCH",
+      visibility: "public",
+      location: {
+        name: "Alois-Drasche-Park",
+        address: "Wien",
+      },
+    });
+
+    expect(events[0]?.tags).toEqual(
+      expect.arrayContaining(["wien", "zu-fuß-gehen", "öffentlicher-raum", "wirmachenwien", "community walk"])
+    );
+
+    expect(scraper.bio).toContain("zivilgesellschaftlich organisierter Verein");
+    expect(scraper.avatarUrl).toContain("wirmachen.wien");
+  });
+});

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
@@ -10,6 +10,12 @@ import { fetchTribeEvents, fromTribeEvent, toTribeDate } from "../../lib/tribe.j
 
 const API_URL = "https://geht-doch.info/wp-json/tribe/events/v1/events";
 
+function normalizeCategoryTag(value: string | undefined): string | undefined {
+  const base = value?.trim().toLowerCase().replace(/^#/, "");
+  if (!base) return undefined;
+  return base.replace(/\s+/g, "-").replace(/-+/g, "-");
+}
+
 export class GehtDochScraper implements Scraper {
   readonly id = "geht_doch";
   readonly name = "GEHT-DOCH";
@@ -42,7 +48,7 @@ export class GehtDochScraper implements Scraper {
         : { name: "Wien", address: "Wien, Austria" };
 
       const categoryTags = (raw.categories || [])
-        .map((c) => c.name?.trim().toLowerCase())
+        .map((c) => normalizeCategoryTag(c.name))
         .filter((c): c is string => Boolean(c));
 
       const tags = Array.from(new Set(["wien", "zu-fuß-gehen", "öffentlicher-raum", "wirmachenwien", ...categoryTags]));

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
@@ -15,9 +15,10 @@ export class GehtDochScraper implements Scraper {
   readonly name = "GEHT-DOCH";
   readonly eventTimezone = "Europe/Vienna";
   readonly url = "https://geht-doch.info/termine/";
-  readonly website = "https://geht-doch.wien/";
+  readonly website = "https://geht-doch.info/";
   readonly bio = "GEHT-DOCH ist ein zivilgesellschaftlich organisierter Verein zur Förderung des Zu Fuß Gehens und für menschengerechten öffentlichen Raum.";
-  readonly avatarUrl = "https://wirmachen.wien/wp-content/uploads/2024/06/old-man-walking-city.jpg";
+  readonly avatarUrl = "https://geht-doch.info/wp-content/uploads/2026/03/GD_logo_ohne_wien.png";
+  readonly defaultEventImageUrl = "https://geht-doch.info/wp-content/uploads/2026/04/20170916-Streetlife-Festival_Christian-Fuerthner-45.jpg";
 
   async scrape(): Promise<Partial<EveryCalEvent>[]> {
     const now = new Date();

--- a/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts
@@ -1,0 +1,63 @@
+/**
+ * Scraper for GEHT-DOCH (geht-doch.info).
+ *
+ * Uses The Events Calendar (Tribe) WordPress plugin with a REST API.
+ */
+
+import type { EveryCalEvent } from "@everycal/core";
+import type { Scraper } from "../../scraper.js";
+import { fetchTribeEvents, fromTribeEvent, toTribeDate } from "../../lib/tribe.js";
+
+const API_URL = "https://geht-doch.info/wp-json/tribe/events/v1/events";
+
+export class GehtDochScraper implements Scraper {
+  readonly id = "geht_doch";
+  readonly name = "GEHT-DOCH";
+  readonly eventTimezone = "Europe/Vienna";
+  readonly url = "https://geht-doch.info/termine/";
+  readonly website = "https://geht-doch.wien/";
+  readonly bio = "GEHT-DOCH ist ein zivilgesellschaftlich organisierter Verein zur Förderung des Zu Fuß Gehens und für menschengerechten öffentlichen Raum.";
+  readonly avatarUrl = "https://wirmachen.wien/wp-content/uploads/2024/06/old-man-walking-city.jpg";
+
+  async scrape(): Promise<Partial<EveryCalEvent>[]> {
+    const now = new Date();
+    const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1, 0, 0, 0));
+    const end = new Date(start);
+    end.setMonth(end.getMonth() + 24);
+
+    const queryUrl = `${API_URL}?status=publish&per_page=100&start_date=${encodeURIComponent(toTribeDate(start))}&end_date=${encodeURIComponent(toTribeDate(end))}`;
+    const tribeEvents = await fetchTribeEvents(queryUrl);
+
+    const events: Partial<EveryCalEvent>[] = [];
+    for (const raw of tribeEvents) {
+      const event = fromTribeEvent(raw, "geht-doch");
+      if (!event.title || !event.startDate) continue;
+
+      const location = raw.venue
+        ? {
+            name: raw.venue.venue?.trim() || "Wien",
+            address: [raw.venue.address, raw.venue.zip, raw.venue.city].filter(Boolean).join(", ") || undefined,
+          }
+        : { name: "Wien", address: "Wien, Austria" };
+
+      const categoryTags = (raw.categories || [])
+        .map((c) => c.name?.trim().toLowerCase())
+        .filter((c): c is string => Boolean(c));
+
+      const tags = Array.from(new Set(["wien", "zu-fuß-gehen", "öffentlicher-raum", "wirmachenwien", ...categoryTags]));
+
+      events.push({
+        ...event,
+        title: event.title.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim(),
+        description: event.description
+          ? event.description.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()
+          : undefined,
+        location,
+        organizer: "GEHT-DOCH",
+        tags,
+      });
+    }
+
+    return events;
+  }
+}

--- a/packages/scrapers/src/scrapers/wirmachenwien/index.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/index.ts
@@ -15,3 +15,5 @@ export { MatznerViertelScraper } from "./matznerviertel.js";
 export { SpaceAndPlaceScraper } from "./space-and-place.js";
 export { KirchberggasseScraper } from "./kirchberggasse.js";
 export { WestbahnparkScraper } from "./westbahnpark.js";
+
+export { GehtDochScraper } from "./geht-doch.js";

--- a/packages/scrapers/src/scrapers/wirmachenwien/matznerviertel.ts
+++ b/packages/scrapers/src/scrapers/wirmachenwien/matznerviertel.ts
@@ -2,34 +2,13 @@
  * Scraper for Lebenswertes Matznerviertel (matznerviertel.at).
  *
  * Uses The Events Calendar (Tribe) WordPress plugin with a REST API.
- * Events are fetched from the Tribe Events V1 JSON API.
  */
 
 import type { EveryCalEvent } from "@everycal/core";
 import type { Scraper } from "../../scraper.js";
-import { normalizeEventDateTime } from "../../lib/datetime.js";
+import { fetchTribeEvents, fromTribeEvent } from "../../lib/tribe.js";
 
-const API_URL = "https://matznerviertel.at/wp-json/tribe/events/v1/events";
-
-interface TribeEvent {
-  id: number;
-  url: string;
-  title: string;
-  description: string;
-  start_date: string;
-  end_date: string;
-  all_day: boolean;
-  venue?: {
-    venue: string;
-    address?: string;
-    city?: string;
-    zip?: string;
-  };
-  image?: {
-    url: string;
-    alt?: string;
-  };
-}
+const API_URL = "https://matznerviertel.at/wp-json/tribe/events/v1/events?per_page=50&start_date=2020-01-01";
 
 export class MatznerViertelScraper implements Scraper {
   readonly id = "matznerviertel";
@@ -42,47 +21,29 @@ export class MatznerViertelScraper implements Scraper {
   readonly defaultEventImageUrl = "https://wirmachen.wien/wp-content/uploads/2023/12/Matznerviertel.jpeg";
 
   async scrape(): Promise<Partial<EveryCalEvent>[]> {
-    const response = await fetch(`${API_URL}?per_page=50&start_date=2020-01-01`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch Matznerviertel events: ${response.status}`);
-    }
-
-    const json = (await response.json()) as { events: TribeEvent[] };
+    const tribeEvents = await fetchTribeEvents(API_URL);
     const events: Partial<EveryCalEvent>[] = [];
 
-    for (const ev of json.events) {
-      if (!ev.title || !ev.start_date) continue;
+    for (const raw of tribeEvents) {
+      const event = fromTribeEvent(raw, "matznerviertel");
+      if (!event.title || !event.startDate) continue;
 
-      const startDate = normalizeEventDateTime(ev.start_date);
-      if (!startDate) continue;
-
-      const endDate = normalizeEventDateTime(ev.end_date);
-
-      // Strip HTML tags from description
-      const description = ev.description
-        ? ev.description.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()
-        : undefined;
-
-      const location = ev.venue
+      const location = raw.venue
         ? {
-            name: ev.venue.venue,
-            address: [ev.venue.address, ev.venue.zip, ev.venue.city].filter(Boolean).join(", ") || undefined,
+            name: raw.venue.venue?.trim() || "Matznerviertel",
+            address: [raw.venue.address, raw.venue.zip, raw.venue.city].filter(Boolean).join(", ") || undefined,
           }
         : { name: "Matznerviertel", address: "Matznerviertel, 1140 Wien" };
 
       events.push({
-        id: `matznerviertel-${ev.id}`,
-        title: ev.title.replace(/<[^>]+>/g, "").trim(),
-        description: description || undefined,
-        startDate,
-        endDate,
-        allDay: ev.all_day,
-        url: ev.url,
+        ...event,
+        description: event.description
+          ? event.description.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim()
+          : undefined,
+        title: event.title.replace(/<[^>]+>/g, "").trim(),
         location,
-        image: ev.image ? { url: ev.image.url, alt: ev.image.alt } : undefined,
         organizer: "Lebenswertes Matznerviertel",
         tags: ["wien", "bürgerinnen-initiative", "matznerviertel", "rudolfsheim-fünfhaus", "wirmachenwien"],
-        visibility: "public",
       });
     }
 

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -12,6 +12,7 @@
 import { Hono } from "hono";
 import type { Context } from "hono";
 import crypto from "node:crypto";
+import { normalizeHashtagName } from "@everycal/core";
 import type { DB } from "../db.js";
 import { generateKeyPair, verifySignature } from "../lib/crypto.js";
 import {
@@ -53,12 +54,6 @@ function toEpochMillisOrZero(value: unknown): number {
   if (!iso) return 0;
   const ms = Date.parse(iso);
   return Number.isNaN(ms) ? 0 : ms;
-}
-
-function normalizeHashtagName(tag: string): string | undefined {
-  const base = tag.replace(/^#/, "").trim();
-  if (!base) return undefined;
-  return base.replace(/\s+/g, "-").replace(/-+/g, "-");
 }
 
 function ensureKeyPair(db: DB, accountId: string): { publicKey: string; privateKey: string } {

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -55,6 +55,12 @@ function toEpochMillisOrZero(value: unknown): number {
   return Number.isNaN(ms) ? 0 : ms;
 }
 
+function normalizeHashtagName(tag: string): string | undefined {
+  const base = tag.replace(/^#/, "").trim();
+  if (!base) return undefined;
+  return base.replace(/\s+/g, "-").replace(/-+/g, "-");
+}
+
 function ensureKeyPair(db: DB, accountId: string): { publicKey: string; privateKey: string } {
   const row = db
     .prepare("SELECT public_key, private_key FROM accounts WHERE id = ?")
@@ -813,10 +819,15 @@ function rowToAPEvent(
   if (attachments.length > 0) event.attachment = attachments;
 
   if (tags.length > 0) {
-    event.tag = tags.map((t) => ({
-      type: "Hashtag",
-      name: t.startsWith("#") ? t : `#${t}`,
-    }));
+    const normalizedTags = tags
+      .map(normalizeHashtagName)
+      .filter((t): t is string => Boolean(t));
+    if (normalizedTags.length > 0) {
+      event.tag = normalizedTags.map((t) => ({
+        type: "Hashtag",
+        name: `#${t}`,
+      }));
+    }
   }
 
   if (row.og_image_url) {

--- a/packages/server/tests/activitypub-timezone.test.ts
+++ b/packages/server/tests/activitypub-timezone.test.ts
@@ -183,6 +183,40 @@ describe("ActivityPub timezone interoperability", () => {
     expect(Array.isArray(body["@context"])).toBe(true);
   });
 
+  it("serves federated Event objects with normalized hashtag tags", async () => {
+    db.prepare(
+      `INSERT INTO events (id, account_id, slug, title, start_date, start_at_utc, event_timezone, visibility)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'public')`
+    ).run(
+      "e3",
+      "u1",
+      "event-three",
+      "Event Three",
+      "2026-03-05T18:00:00",
+      "2026-03-05T17:00:00.000Z",
+      "Europe/Vienna",
+    );
+    db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?), (?, ?), (?, ?)").run(
+      "e3",
+      "community walk",
+      "e3",
+      "#already-tagged",
+      "e3",
+      "two   spaces",
+    );
+
+    const app = makeApp(db);
+    const res = await app.request("http://localhost/events/e3", {
+      headers: { accept: "application/activity+json" },
+    });
+    const body = await res.json() as Record<string, any>;
+
+    expect(res.status).toBe(200);
+    const names = ((body.tag as Array<{ name: string }>) || []).map((t) => t.name);
+    expect(names).toEqual(expect.arrayContaining(["#community-walk", "#already-tagged", "#two-spaces"]));
+    for (const name of names) expect(name).not.toMatch(/\s/);
+  });
+
   it("ingests inbound AP timezone quality variants", async () => {
     const app = makeApp(db);
     const actor = "https://remote.example/users/a";

--- a/packages/wordpress/scripts/plugin-zip.mjs
+++ b/packages/wordpress/scripts/plugin-zip.mjs
@@ -40,9 +40,13 @@ try {
 	await mkdir( tempPluginDir, { recursive: true } );
 
 	for ( const entry of requiredEntries ) {
-		await cp( path.join( packageDir, entry ), path.join( tempPluginDir, entry ), {
-			recursive: true,
-		} );
+		await cp(
+			path.join( packageDir, entry ),
+			path.join( tempPluginDir, entry ),
+			{
+				recursive: true,
+			}
+		);
 	}
 
 	await rm( outputZipPath, { force: true } );
@@ -51,8 +55,8 @@ try {
 		cwd: tempRoot,
 	} );
 
-	console.log( `Created ${ outputZipName }` );
-	console.log( `Path: ${ outputZipPath }` );
+	process.stdout.write( `Created ${ outputZipName }\n` );
+	process.stdout.write( `Path: ${ outputZipPath }\n` );
 } finally {
 	await rm( tempRoot, { recursive: true, force: true } );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,8 @@ overrides:
   minimatch: '>=10.2.3'
   webpack-dev-server: '>=5.2.1'
   ajv: '>=8.18.0'
-  '@eslint/eslintrc>ajv': '>=6.14.0'
-  eslint>ajv: '>=6.14.0'
+  '@eslint/eslintrc>ajv': ^6.12.6
+  eslint>ajv: ^6.12.6
   qs: '>=6.14.2'
   basic-ftp: '>=5.2.2'
   wait-on>axios: '>=1.15.0'
@@ -19,6 +19,7 @@ overrides:
   svgo: '>=3.3.3'
   immutable: '>=5.1.5'
   picomatch: '>=4.0.4'
+  schema-utils@3>ajv: ^6.12.6
 
 importers:
 
@@ -4373,6 +4374,9 @@ packages:
     peerDependencies:
       ajv: '>=8.18.0'
 
+  ajv@6.14.0:
+    resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -6934,6 +6938,9 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -9380,6 +9387,9 @@ packages:
   upper-case@2.0.2:
     resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
 
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
   url-loader@4.1.1:
     resolution: {integrity: sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==}
     engines: {node: '>= 10.13.0'}
@@ -11463,7 +11473,7 @@ snapshots:
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
-      ajv: 8.18.0
+      ajv: 6.14.0
       debug: 4.4.3
       espree: 9.6.1
       globals: 13.24.0
@@ -14666,14 +14676,21 @@ snapshots:
     optionalDependencies:
       ajv: 8.18.0
 
-  ajv-keywords@3.5.2(ajv@8.18.0):
+  ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
-      ajv: 8.18.0
+      ajv: 6.14.0
 
   ajv-keywords@5.1.0(ajv@8.18.0):
     dependencies:
       ajv: 8.18.0
       fast-deep-equal: 3.1.3
+
+  ajv@6.14.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.18.0:
     dependencies:
@@ -16287,7 +16304,7 @@ snapshots:
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       '@ungap/structured-clone': 1.3.0
-      ajv: 8.18.0
+      ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
       debug: 4.4.3
@@ -17796,6 +17813,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
+
+  json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -19576,8 +19595,8 @@ snapshots:
   schema-utils@3.3.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.18.0
-      ajv-keywords: 3.5.2(ajv@8.18.0)
+      ajv: 6.14.0
+      ajv-keywords: 3.5.2(ajv@6.14.0)
 
   schema-utils@4.3.3:
     dependencies:
@@ -20539,6 +20558,10 @@ snapshots:
   upper-case@2.0.2:
     dependencies:
       tslib: 2.8.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-loader@4.1.1(webpack@5.105.4):
     dependencies:


### PR DESCRIPTION
### Motivation
- Add a scraper for GEHT-DOCH (geht-doch.info) that imports events published via The Events Calendar (Tribe) and ensures the scraper account is populated with relevant profile metadata. 
- Reduce duplication across Tribe-based scrapers by extracting common API pagination and event mapping logic into a reusable helper.

### Description
- Added `packages/scrapers/src/lib/tribe.ts` which centralizes Tribe types, paginated `fetchTribeEvents`, `fromTribeEvent` mapping, `toTribeDate`, and media type inference. 
- Implemented `GehtDochScraper` in `packages/scrapers/src/scrapers/wirmachenwien/geht-doch.ts` that consumes the shared Tribe helper, normalizes/cleans fields, enriches tags, and exposes `website`, `bio`, and `avatarUrl` for profile sync. 
- Refactored `FlexScraper` and `MatznerviertelScraper` to use the shared Tribe utilities (DRY), and exported/registered the new scraper in the wirmachen.wien barrel and global `registry`. 
- Added unit tests `geht-doch.test.ts` covering mapping/cleanup and profile metadata expectations. 

### Testing
- Ran TypeScript checks with `pnpm --filter @everycal/scrapers lint` which completed successfully. 
- Ran unit tests with `pnpm --filter @everycal/scrapers test` and all scraper tests passed (`Test Files 10 passed`, `Tests 28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e224a6e94c8321b538f5c9bbb71c45)