### PR TITLE
fix: harden Unsplash trigger-download endpoint against SSRF

### DIFF
--- a/packages/server/src/routes/images.ts
+++ b/packages/server/src/routes/images.ts
@@ -79,7 +79,12 @@ export function imageRoutes(): Hono {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 
-    if (validatedUrl.protocol !== "https:" || validatedUrl.hostname !== "api.unsplash.com") {
+    if (
+      validatedUrl.protocol !== "https:"
+      || validatedUrl.host !== "api.unsplash.com"
+      || validatedUrl.username
+      || validatedUrl.password
+    ) {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 

--- a/packages/server/src/routes/images.ts
+++ b/packages/server/src/routes/images.ts
@@ -14,6 +14,7 @@ const UNSPLASH_ACCESS_KEY = process.env.UNSPLASH_ACCESS_KEY;
 const OPENVERSE_BASE = "https://api.openverse.org/v1";
 const UTM_SOURCE = "everycal";
 const UTM_MEDIUM = "referral";
+const UNSPLASH_PHOTO_ID_RE = /^[A-Za-z0-9_-]+$/;
 
 interface UnsplashPhoto {
   urls?: { regular?: string; small?: string; full?: string };
@@ -88,8 +89,16 @@ export function imageRoutes(): Hono {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 
-    // Download tracking endpoint should only target /photos/:id/download.
-    if (!/^\/photos\/[^/]+\/download$/.test(validatedUrl.pathname)) {
+    const pathParts = validatedUrl.pathname.split("/").filter(Boolean);
+    const photoId =
+      pathParts.length === 3
+      && pathParts[0] === "photos"
+      && pathParts[2] === "download"
+        ? pathParts[1]
+        : "";
+
+    // Download tracking endpoint should only target /photos/:id/download with valid Unsplash id.
+    if (!photoId || !UNSPLASH_PHOTO_ID_RE.test(photoId)) {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 

--- a/packages/server/src/routes/images.ts
+++ b/packages/server/src/routes/images.ts
@@ -3,7 +3,7 @@
  *
  * GET /api/v1/images/sources — list available sources
  * GET /api/v1/images/search?q=QUERY&source= — search for header images (returns url + attribution)
- * POST /api/v1/images/trigger-download — trigger Unsplash download tracking (per API guidelines)
+ * POST /api/v1/images/trigger-download — trigger Unsplash download tracking (auth, per API guidelines)
  */
 
 import { Hono } from "hono";
@@ -63,10 +63,11 @@ export function imageRoutes(): Hono {
     });
   });
 
-  /** Trigger Unsplash download tracking when user selects an image (per API guidelines). */
+  /** Trigger Unsplash download tracking when user selects an image (auth; per API guidelines). */
   router.post("/trigger-download", requireAuth(), async (c) => {
-    const body = (await c.req.json().catch(() => ({}))) as { downloadLocation?: string };
-    const rawUrl = body?.downloadLocation?.trim();
+    const body = (await c.req.json().catch(() => ({}))) as { downloadLocation?: unknown };
+    const downloadLocation = body?.downloadLocation;
+    const rawUrl = typeof downloadLocation === "string" ? downloadLocation.trim() : "";
     if (!rawUrl || !UNSPLASH_ACCESS_KEY) {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
@@ -82,8 +83,8 @@ export function imageRoutes(): Hono {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 
-    // Download tracking endpoint should only target Unsplash photo download URLs.
-    if (!validatedUrl.pathname.startsWith("/photos/") || !validatedUrl.pathname.endsWith("/download")) {
+    // Download tracking endpoint should only target /photos/:id/download.
+    if (!/^\/photos\/[^/]+\/download$/.test(validatedUrl.pathname)) {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 

--- a/packages/server/src/routes/images.ts
+++ b/packages/server/src/routes/images.ts
@@ -8,6 +8,7 @@
 
 import { Hono } from "hono";
 import { getLocale, t } from "../lib/i18n.js";
+import { requireAuth } from "../middleware/auth.js";
 
 const UNSPLASH_ACCESS_KEY = process.env.UNSPLASH_ACCESS_KEY;
 const OPENVERSE_BASE = "https://api.openverse.org/v1";
@@ -63,15 +64,32 @@ export function imageRoutes(): Hono {
   });
 
   /** Trigger Unsplash download tracking when user selects an image (per API guidelines). */
-  router.post("/trigger-download", async (c) => {
+  router.post("/trigger-download", requireAuth(), async (c) => {
     const body = (await c.req.json().catch(() => ({}))) as { downloadLocation?: string };
-    const url = body?.downloadLocation?.trim();
-    if (!url || !UNSPLASH_ACCESS_KEY) {
+    const rawUrl = body?.downloadLocation?.trim();
+    if (!rawUrl || !UNSPLASH_ACCESS_KEY) {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
+
+    let validatedUrl: URL;
     try {
-      const sep = url.includes("?") ? "&" : "?";
-      await fetch(`${url}${sep}client_id=${UNSPLASH_ACCESS_KEY}`);
+      validatedUrl = new URL(rawUrl);
+    } catch {
+      return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
+    }
+
+    if (validatedUrl.protocol !== "https:" || validatedUrl.hostname !== "api.unsplash.com") {
+      return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
+    }
+
+    // Download tracking endpoint should only target Unsplash photo download URLs.
+    if (!validatedUrl.pathname.startsWith("/photos/") || !validatedUrl.pathname.endsWith("/download")) {
+      return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
+    }
+
+    try {
+      validatedUrl.searchParams.set("client_id", UNSPLASH_ACCESS_KEY);
+      await fetch(validatedUrl.toString(), { redirect: "error" });
     } catch {
       // Non-critical; don't fail the request
     }

--- a/packages/server/src/routes/images.ts
+++ b/packages/server/src/routes/images.ts
@@ -93,12 +93,10 @@ export function imageRoutes(): Hono {
       return c.json({ error: t(getLocale(c), "common.invalid_request") }, 400);
     }
 
-    try {
-      validatedUrl.searchParams.set("client_id", UNSPLASH_ACCESS_KEY);
-      await fetch(validatedUrl.toString(), { redirect: "error" });
-    } catch {
+    validatedUrl.searchParams.set("client_id", UNSPLASH_ACCESS_KEY);
+    void fetch(validatedUrl.toString(), { redirect: "error" }).catch(() => {
       // Non-critical; don't fail the request
-    }
+    });
     return c.json({ ok: true });
   });
 

--- a/packages/server/tests/images-routes.test.ts
+++ b/packages/server/tests/images-routes.test.ts
@@ -92,6 +92,8 @@ describe("imageRoutes trigger-download", () => {
       "not-a-url",
       "http://api.unsplash.com/photos/abc/download",
       "https://example.com/photos/abc/download",
+      "https://api.unsplash.com:444/photos/abc/download",
+      "https://user:pass@api.unsplash.com/photos/abc/download",
       "https://api.unsplash.com/photos/abc",
       "https://api.unsplash.com/photos/a/b/download",
       "https://api.unsplash.com/photos//download",

--- a/packages/server/tests/images-routes.test.ts
+++ b/packages/server/tests/images-routes.test.ts
@@ -97,6 +97,9 @@ describe("imageRoutes trigger-download", () => {
       "https://api.unsplash.com/photos/abc",
       "https://api.unsplash.com/photos/a/b/download",
       "https://api.unsplash.com/photos//download",
+      "https://api.unsplash.com/photos/a%2Fb/download",
+      "https://api.unsplash.com/photos/a%2fb/download",
+      "https://api.unsplash.com/photos/a.b/download",
       "https://api.unsplash.com/photos/abc/download/extra",
     ];
 

--- a/packages/server/tests/images-routes.test.ts
+++ b/packages/server/tests/images-routes.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+async function loadImageRoutes(unsplashAccessKey: string | undefined) {
+  const previousKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (unsplashAccessKey === undefined) {
+    delete process.env.UNSPLASH_ACCESS_KEY;
+  } else {
+    process.env.UNSPLASH_ACCESS_KEY = unsplashAccessKey;
+  }
+
+  vi.resetModules();
+  const { imageRoutes } = await import("../src/routes/images.js");
+
+  if (previousKey === undefined) {
+    delete process.env.UNSPLASH_ACCESS_KEY;
+  } else {
+    process.env.UNSPLASH_ACCESS_KEY = previousKey;
+  }
+
+  return imageRoutes;
+}
+
+function makeApp(imageRoutesFactory: () => Hono, authenticated = true) {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("user", authenticated
+      ? { id: "u1", username: "alice", displayName: "Alice" }
+      : null);
+    await next();
+  });
+  app.route("/api/v1/images", imageRoutesFactory());
+  return app;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("imageRoutes trigger-download", () => {
+  it("requires authentication", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes, false);
+
+    const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ downloadLocation: "https://api.unsplash.com/photos/abc/download" }),
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for non-string downloadLocation payloads", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const invalidPayloads = [123, { url: "https://api.unsplash.com/photos/abc/download" }, ["x"], true, null];
+    for (const invalidPayload of invalidPayloads) {
+      const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ downloadLocation: invalidPayload }),
+      });
+      expect(res.status).toBe(400);
+    }
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+
+    const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for invalid Unsplash download URLs", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+
+    const invalidUrls = [
+      "not-a-url",
+      "http://api.unsplash.com/photos/abc/download",
+      "https://example.com/photos/abc/download",
+      "https://api.unsplash.com/photos/abc",
+      "https://api.unsplash.com/photos/a/b/download",
+      "https://api.unsplash.com/photos//download",
+      "https://api.unsplash.com/photos/abc/download/extra",
+    ];
+
+    for (const invalidUrl of invalidUrls) {
+      const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ downloadLocation: invalidUrl }),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  it("tracks download for a valid Unsplash URL", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ downloadLocation: "  https://api.unsplash.com/photos/abc/download?foo=bar  " }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [calledUrl, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const parsed = new URL(calledUrl);
+    expect(parsed.protocol).toBe("https:");
+    expect(parsed.hostname).toBe("api.unsplash.com");
+    expect(parsed.pathname).toBe("/photos/abc/download");
+    expect(parsed.searchParams.get("foo")).toBe("bar");
+    expect(parsed.searchParams.get("client_id")).toBe("unsplash-test-key");
+    expect(options).toEqual({ redirect: "error" });
+  });
+
+  it("returns ok even when tracking fetch fails", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+    const fetchMock = vi.fn().mockRejectedValue(new Error("network"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ downloadLocation: "https://api.unsplash.com/photos/abc/download" }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("returns 400 when Unsplash key is missing", async () => {
+    const imageRoutes = await loadImageRoutes(undefined);
+    const app = makeApp(imageRoutes);
+
+    const res = await app.request("http://localhost/api/v1/images/trigger-download", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ downloadLocation: "https://api.unsplash.com/photos/abc/download" }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("imageRoutes search and sources", () => {
+  it("reports available sources based on Unsplash config", async () => {
+    const imageRoutesWithKey = await loadImageRoutes("unsplash-test-key");
+    const appWithKey = makeApp(imageRoutesWithKey);
+    const withKeyRes = await appWithKey.request("http://localhost/api/v1/images/sources");
+    expect(withKeyRes.status).toBe(200);
+    await expect(withKeyRes.json()).resolves.toEqual({
+      sources: ["unsplash", "openverse"],
+      unsplashAvailable: true,
+    });
+
+    const imageRoutesWithoutKey = await loadImageRoutes(undefined);
+    const appWithoutKey = makeApp(imageRoutesWithoutKey);
+    const withoutKeyRes = await appWithoutKey.request("http://localhost/api/v1/images/sources");
+    expect(withoutKeyRes.status).toBe(200);
+    await expect(withoutKeyRes.json()).resolves.toEqual({
+      sources: ["openverse"],
+      unsplashAvailable: false,
+    });
+  });
+
+  it("returns 400 when search query is too short", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+
+    const res = await app.request("http://localhost/api/v1/images/search?q=a");
+    expect(res.status).toBe(400);
+  });
+
+  it("falls back to Openverse when Unsplash fails in auto mode", async () => {
+    const imageRoutes = await loadImageRoutes("unsplash-test-key");
+    const app = makeApp(imageRoutes);
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.startsWith("https://api.unsplash.com/search/photos?")) {
+        throw new Error("unsplash unavailable");
+      }
+      if (url.startsWith("https://api.openverse.org/v1/images/?")) {
+        return new Response(JSON.stringify({
+          results: [{
+            url: "https://cdn.openverse.org/image.jpg",
+            title: "Openverse Image",
+            foreign_landing_url: "https://example.org/image",
+            creator: "Jane Artist",
+            creator_url: "https://example.org/jane",
+            license: "by",
+            license_url: "https://creativecommons.org/licenses/by/4.0/",
+            attribution: "Photo by Jane Artist",
+          }],
+        }), { status: 200 });
+      }
+      return new Response(null, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await app.request("http://localhost/api/v1/images/search?q=sunset");
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      source: "openverse",
+      results: [{
+        url: "https://cdn.openverse.org/image.jpg",
+        attribution: {
+          source: "openverse",
+          title: "Openverse Image",
+          sourceUrl: "https://example.org/image",
+          creator: "Jane Artist",
+          creatorUrl: "https://example.org/jane",
+          license: "by",
+          licenseUrl: "https://creativecommons.org/licenses/by/4.0/",
+          attribution: "Photo by Jane Artist",
+        },
+      }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- require authentication on `POST /api/v1/images/trigger-download`
- validate `downloadLocation` as a strict Unsplash HTTPS URL (`api.unsplash.com`)
- only allow Unsplash photo download endpoint paths and append `client_id` via `URL.searchParams`
- disable redirects for this fetch to reduce abuse surface

## Why
The endpoint previously accepted arbitrary URLs and performed a server-side fetch, which enabled SSRF and leakage of the Unsplash API key to attacker-controlled hosts.