### PR TITLE
refactor: remove legacy runtime DB upgrades and introduce baseline migrations

### DIFF
--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -1,1299 +1,175 @@
 /**
- * SQLite database initialization and schema.
+ * SQLite database initialization and schema management.
  */
 
 import Database from "better-sqlite3";
-import { uniqueRemoteEventSlug } from "./lib/slugs.js";
-import {
-  absoluteIsoWithOffsetToUtcIso,
-  datePartFromUtcInstantInTimezone,
-  deriveAllDayEndAtUtc,
-  deriveUtcFromTemporalInput,
-  extractDatePart,
-  isValidIanaTimezone,
-} from "./lib/timezone.js";
+import { CURRENT_SCHEMA_VERSION, MIGRATIONS } from "./db/migrations.js";
 
 export type DB = Database.Database;
 
-const SYSTEM_TIMEZONE = "system";
-const SYSTEM_DATE_TIME_LOCALE = "system";
-const SYSTEM_THEME_PREFERENCE = "system";
+const REQUIRED_TABLES = [
+  "accounts",
+  "sessions",
+  "api_keys",
+  "events",
+  "event_tags",
+  "follows",
+  "identity_memberships",
+  "remote_follows",
+  "remote_actors",
+  "remote_events",
+  "remote_following",
+  "domain_discovery",
+  "event_rsvps",
+  "reposts",
+  "auto_reposts",
+  "actor_selection_operations",
+  "actor_selection_operation_items",
+  "login_attempts",
+  "calendar_feed_tokens",
+  "saved_locations",
+  "email_verification_tokens",
+  "password_reset_tokens",
+  "account_notification_prefs",
+  "email_change_requests",
+  "event_reminder_sent",
+];
 
-const ISO_HAS_OFFSET = /(Z|[+-]\d{2}:\d{2})$/i;
-const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-const SQLITE_UTC_DATE_TIME = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d{1,3})?$/;
+const REQUIRED_COLUMNS: Record<string, string[]> = {
+  accounts: [
+    "account_type",
+    "timezone",
+    "date_time_locale",
+    "theme_preference",
+    "default_event_visibility",
+    "city",
+    "city_lat",
+    "city_lng",
+    "email",
+    "email_verified",
+    "preferred_language",
+  ],
+  events: [
+    "created_by_account_id",
+    "slug",
+    "start_at_utc",
+    "end_at_utc",
+    "event_timezone",
+    "start_on",
+    "end_on",
+    "all_day",
+    "content_hash",
+    "canceled",
+    "missing_since",
+    "image_attribution",
+    "og_image_url",
+  ],
+  remote_events: [
+    "slug",
+    "all_day",
+    "start_at_utc",
+    "end_at_utc",
+    "start_on",
+    "end_on",
+    "event_timezone",
+    "timezone_quality",
+    "image_attribution",
+    "canceled",
+  ],
+  remote_actors: ["followers_count", "following_count", "fetch_status", "last_error", "next_retry_at", "gone_at"],
+  remote_follows: ["follower_shared_inbox"],
+  remote_following: ["follow_activity_id", "follow_object_uri"],
+  api_keys: ["key_prefix"],
+};
 
-function deriveStoredDatePartForTemporal(
-  rawValue: string | null | undefined,
-  utcValue: string | null | undefined,
-  options: { allDay: boolean; timezone: string | null },
-): string | null {
-  const rawDatePart = extractDatePart(rawValue);
-  const trimmed = typeof rawValue === "string" ? rawValue.trim() : "";
-  if (options.allDay || (trimmed && DATE_ONLY.test(trimmed))) {
-    return rawDatePart;
-  }
-
-  if (options.timezone) {
-    return datePartFromUtcInstantInTimezone(utcValue, options.timezone)
-      || rawDatePart
-      || extractDatePart(utcValue);
-  }
-
-  return rawDatePart || extractDatePart(utcValue);
+function tableExists(db: DB, table: string): boolean {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
+    .get(table) as { ok: number } | undefined;
+  return !!row?.ok;
 }
 
-function sqliteUtcDateTimeToUtcIso(value: string | null | undefined): string | null {
-  if (!value) return null;
-  if (!SQLITE_UTC_DATE_TIME.test(value)) return null;
-  const parsed = new Date(`${value.replace(" ", "T")}Z`);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toISOString();
+function tableColumns(db: DB, table: string): Set<string> {
+  if (!tableExists(db, table)) return new Set();
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
+  return new Set(rows.map((row) => row.name));
 }
 
-function canonicalUtcIso(value: string | null | undefined): string | null {
-  if (!value) return null;
-  if (ISO_HAS_OFFSET.test(value)) return absoluteIsoWithOffsetToUtcIso(value);
-  return sqliteUtcDateTimeToUtcIso(value);
+function hasUserTables(db: DB): boolean {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' LIMIT 1")
+    .get() as { ok: number } | undefined;
+  return !!row?.ok;
+}
+
+function schemaLooksLikeCurrentBaseline(db: DB): boolean {
+  for (const table of REQUIRED_TABLES) {
+    if (!tableExists(db, table)) return false;
+  }
+
+  for (const [table, required] of Object.entries(REQUIRED_COLUMNS)) {
+    const columns = tableColumns(db, table);
+    for (const column of required) {
+      if (!columns.has(column)) return false;
+    }
+  }
+
+  return true;
+}
+
+function applyPendingMigrations(db: DB, fromVersion: number): void {
+  for (const migration of MIGRATIONS) {
+    if (migration.version <= fromVersion) continue;
+
+    db.exec("BEGIN");
+    try {
+      migration.up(db);
+      db.pragma(`user_version = ${migration.version}`);
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw new Error(
+        `Failed database migration v${migration.version} (${migration.name}): ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}
+
+function assertSchemaIsSupported(db: DB): void {
+  if (!schemaLooksLikeCurrentBaseline(db)) {
+    throw new Error(
+      "Unsupported legacy database schema detected. Legacy runtime migrations were intentionally removed; restore from an up-to-date backup or run a one-time offline migration before starting this build."
+    );
+  }
 }
 
 export function initDatabase(path: string): DB {
   const db = new Database(path);
 
-  const tableHasColumn = (table: string, column: string): boolean => {
-    try {
-      const columns = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
-      return columns.some((col) => col.name === column);
-    } catch {
-      return false;
-    }
-  };
-
-  // Enable WAL mode for better concurrent read performance
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
 
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS accounts (
-      id TEXT PRIMARY KEY,
-      username TEXT NOT NULL UNIQUE,
-      account_type TEXT NOT NULL DEFAULT 'person' CHECK(account_type IN ('person','identity')),
-      display_name TEXT,
-      bio TEXT,
-      avatar_url TEXT,
-      password_hash TEXT,
-      private_key TEXT,
-      public_key TEXT,
-      is_bot INTEGER NOT NULL DEFAULT 0,
-      discoverable INTEGER NOT NULL DEFAULT 0,
-      timezone TEXT NOT NULL DEFAULT 'system',
-      date_time_locale TEXT NOT NULL DEFAULT 'system',
-      theme_preference TEXT NOT NULL DEFAULT 'system' CHECK(theme_preference IN ('system','light','dark')),
-      default_event_visibility TEXT NOT NULL DEFAULT 'public' CHECK(default_event_visibility IN ('public','unlisted','followers_only','private')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  const currentVersion = db.pragma("user_version", { simple: true }) as number;
+  if (currentVersion < 0) {
+    throw new Error(`Invalid SQLite user_version: ${currentVersion}`);
+  }
+  if (currentVersion > CURRENT_SCHEMA_VERSION) {
+    throw new Error(
+      `Database schema version ${currentVersion} is newer than this server supports (${CURRENT_SCHEMA_VERSION}).`
     );
+  }
 
-    CREATE TABLE IF NOT EXISTS sessions (
-      token TEXT PRIMARY KEY,
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      expires_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS api_keys (
-      id TEXT PRIMARY KEY,
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      key_hash TEXT NOT NULL,
-      label TEXT NOT NULL DEFAULT '',
-      last_used_at TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE TABLE IF NOT EXISTS events (
-      id TEXT PRIMARY KEY,
-      account_id TEXT NOT NULL REFERENCES accounts(id),
-      created_by_account_id TEXT REFERENCES accounts(id) ON DELETE SET NULL,
-      external_id TEXT,
-      slug TEXT,
-      title TEXT NOT NULL,
-      description TEXT,
-      start_date TEXT NOT NULL,
-      end_date TEXT,
-      start_at_utc TEXT NOT NULL,
-      end_at_utc TEXT,
-      event_timezone TEXT NOT NULL,
-      start_on TEXT,
-      end_on TEXT,
-      all_day INTEGER NOT NULL DEFAULT 0,
-      location_name TEXT,
-      location_address TEXT,
-      location_latitude REAL,
-      location_longitude REAL,
-      location_url TEXT,
-      image_url TEXT,
-      image_media_type TEXT,
-      image_alt TEXT,
-      url TEXT,
-      visibility TEXT NOT NULL DEFAULT 'public',
-      canceled INTEGER NOT NULL DEFAULT 0,
-      missing_since TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-      CHECK(end_at_utc IS NULL OR end_at_utc >= start_at_utc)
-    );
-
-    CREATE TABLE IF NOT EXISTS event_tags (
-      event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-      tag TEXT NOT NULL,
-      PRIMARY KEY (event_id, tag)
-    );
-
-    CREATE TABLE IF NOT EXISTS follows (
-      follower_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      following_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (follower_id, following_id)
-    );
-
-    CREATE TABLE IF NOT EXISTS identity_memberships (
-      identity_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      member_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      role TEXT NOT NULL CHECK(role IN ('owner','editor')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (identity_account_id, member_account_id)
-    );
-
-    CREATE TABLE IF NOT EXISTS remote_follows (
-      account_id TEXT NOT NULL REFERENCES accounts(id),
-      follower_actor_uri TEXT NOT NULL,
-      follower_inbox TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, follower_actor_uri)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_sessions_account ON sessions(account_id);
-    CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
-    CREATE INDEX IF NOT EXISTS idx_api_keys_account ON api_keys(account_id);
-
-    CREATE INDEX IF NOT EXISTS idx_events_account ON events(account_id);
-    CREATE INDEX IF NOT EXISTS idx_events_visibility ON events(visibility);
-    CREATE UNIQUE INDEX IF NOT EXISTS idx_events_external ON events(account_id, external_id) WHERE external_id IS NOT NULL;
-    CREATE INDEX IF NOT EXISTS idx_follows_follower ON follows(follower_id);
-    CREATE INDEX IF NOT EXISTS idx_follows_following ON follows(following_id);
-    CREATE INDEX IF NOT EXISTS idx_identity_memberships_member ON identity_memberships(member_account_id);
-    CREATE INDEX IF NOT EXISTS idx_identity_memberships_identity_role ON identity_memberships(identity_account_id, role);
-
-    -- Remote actors (cached ActivityPub actors from other servers)
-    CREATE TABLE IF NOT EXISTS remote_actors (
-      uri TEXT PRIMARY KEY,
-      type TEXT NOT NULL DEFAULT 'Person',
-      preferred_username TEXT NOT NULL,
-      display_name TEXT,
-      summary TEXT,
-      inbox TEXT NOT NULL,
-      outbox TEXT,
-      shared_inbox TEXT,
-      followers_url TEXT,
-      following_url TEXT,
-      icon_url TEXT,
-      image_url TEXT,
-      public_key_id TEXT,
-      public_key_pem TEXT,
-      domain TEXT NOT NULL,
-      last_fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
-      fetch_status TEXT NOT NULL DEFAULT 'active' CHECK(fetch_status IN ('active', 'error', 'gone')),
-      last_error TEXT,
-      next_retry_at TEXT,
-      gone_at TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_remote_actors_domain ON remote_actors(domain);
-    CREATE INDEX IF NOT EXISTS idx_remote_actors_username ON remote_actors(preferred_username, domain);
-
-    -- Remote events (events fetched from remote actors)
-    CREATE TABLE IF NOT EXISTS remote_events (
-      uri TEXT PRIMARY KEY,
-      actor_uri TEXT NOT NULL,
-      slug TEXT,
-      title TEXT NOT NULL,
-      description TEXT,
-      start_date TEXT NOT NULL,
-      end_date TEXT,
-      all_day INTEGER NOT NULL DEFAULT 0,
-      start_at_utc TEXT NOT NULL,
-      end_at_utc TEXT,
-      start_on TEXT,
-      end_on TEXT,
-      event_timezone TEXT,
-      timezone_quality TEXT NOT NULL CHECK(timezone_quality IN ('exact_tzid','offset_only')),
-      location_name TEXT,
-      location_address TEXT,
-      location_latitude REAL,
-      location_longitude REAL,
-      image_url TEXT,
-      image_media_type TEXT,
-      image_alt TEXT,
-      url TEXT,
-      tags TEXT,
-      raw_json TEXT,
-      published TEXT,
-      updated TEXT,
-      fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
-      CHECK((timezone_quality = 'exact_tzid' AND event_timezone IS NOT NULL) OR (timezone_quality != 'exact_tzid' AND event_timezone IS NULL)),
-      CHECK(end_at_utc IS NULL OR end_at_utc >= start_at_utc)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_remote_events_actor ON remote_events(actor_uri);
-
-    -- Track which remote actors local users follow
-    CREATE TABLE IF NOT EXISTS remote_following (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      actor_uri TEXT NOT NULL,
-      actor_inbox TEXT NOT NULL,
-      follow_activity_id TEXT,
-      follow_object_uri TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, actor_uri)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_remote_following_account ON remote_following(account_id);
-
-    -- Domain discovery: track when we last fetched full profile list from a remote server
-    CREATE TABLE IF NOT EXISTS domain_discovery (
-      domain TEXT PRIMARY KEY,
-      last_discovered_at TEXT NOT NULL DEFAULT (datetime('now')),
-      software_type TEXT
-    );
-
-    -- RSVPs: track attendance status for any event (local or remote)
-    -- event_uri is the local event ID for local events, or the remote event URI for remote events
-    CREATE TABLE IF NOT EXISTS event_rsvps (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      event_uri TEXT NOT NULL,
-      status TEXT NOT NULL CHECK(status IN ('going','maybe')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, event_uri)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_event_rsvps_account ON event_rsvps(account_id);
-    CREATE INDEX IF NOT EXISTS idx_event_rsvps_event ON event_rsvps(event_uri);
-
-    -- Reposts: a user reposts a single event onto their feed
-    CREATE TABLE IF NOT EXISTS reposts (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, event_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_reposts_account ON reposts(account_id);
-    CREATE INDEX IF NOT EXISTS idx_reposts_event ON reposts(event_id);
-
-    -- Auto-reposts: automatically repost all public events from source account
-    CREATE TABLE IF NOT EXISTS auto_reposts (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      source_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, source_account_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_auto_reposts_account ON auto_reposts(account_id);
-    CREATE INDEX IF NOT EXISTS idx_auto_reposts_source ON auto_reposts(source_account_id);
-
-    -- Actor selection operations: audit bulk follow/repost changes
-    CREATE TABLE IF NOT EXISTS actor_selection_operations (
-      id TEXT PRIMARY KEY,
-      action_kind TEXT NOT NULL,
-      target_type TEXT NOT NULL,
-      target_id TEXT NOT NULL,
-      initiated_by_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      status TEXT NOT NULL DEFAULT 'completed' CHECK(status IN ('pending','completed','failed')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      completed_at TEXT
-    );
-
-    CREATE TABLE IF NOT EXISTS actor_selection_operation_items (
-      operation_id TEXT NOT NULL REFERENCES actor_selection_operations(id) ON DELETE CASCADE,
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      before_state INTEGER NOT NULL,
-      after_state INTEGER NOT NULL,
-      status TEXT NOT NULL CHECK(status IN ('added','removed','unchanged','error')),
-      remote_status TEXT CHECK(remote_status IN ('none','pending','delivered','failed')),
-      message TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (operation_id, account_id)
-    );
-
-    CREATE INDEX IF NOT EXISTS idx_actor_selection_ops_initiated_by ON actor_selection_operations(initiated_by_account_id, created_at);
-    CREATE INDEX IF NOT EXISTS idx_actor_selection_items_operation ON actor_selection_operation_items(operation_id);
-
-    -- Login attempt tracking for account lockout
-    CREATE TABLE IF NOT EXISTS login_attempts (
-      username TEXT PRIMARY KEY,
-      attempts INTEGER NOT NULL DEFAULT 0,
-      locked_until TEXT,
-      last_attempt TEXT NOT NULL DEFAULT (datetime('now'))
-    );
-  `);
-
-  // Migration guard: legacy schemas may miss temporal columns expected at runtime.
-  try {
-    if (!tableHasColumn("events", "start_at_utc")) db.exec("ALTER TABLE events ADD COLUMN start_at_utc TEXT");
-    if (!tableHasColumn("events", "end_at_utc")) db.exec("ALTER TABLE events ADD COLUMN end_at_utc TEXT");
-    if (!tableHasColumn("events", "event_timezone")) db.exec("ALTER TABLE events ADD COLUMN event_timezone TEXT");
-    if (!tableHasColumn("events", "start_on")) db.exec("ALTER TABLE events ADD COLUMN start_on TEXT");
-    if (!tableHasColumn("events", "end_on")) db.exec("ALTER TABLE events ADD COLUMN end_on TEXT");
-
-    db.exec("UPDATE events SET event_timezone = 'UTC' WHERE event_timezone IS NULL OR trim(event_timezone) = ''");
-    db.exec("UPDATE events SET start_on = substr(trim(start_date), 1, 10) WHERE (start_on IS NULL OR trim(start_on) = '') AND start_date IS NOT NULL AND trim(start_date) GLOB '????-??-??*' AND date(substr(trim(start_date), 1, 10)) IS NOT NULL");
-    db.exec("UPDATE events SET end_on = substr(trim(end_date), 1, 10) WHERE (end_on IS NULL OR trim(end_on) = '') AND end_date IS NOT NULL AND trim(end_date) GLOB '????-??-??*' AND date(substr(trim(end_date), 1, 10)) IS NOT NULL");
-
-    const temporalRows = db.prepare(`
-      SELECT id, start_date, end_date, all_day, event_timezone, start_at_utc, end_at_utc, created_at
-      FROM events
-      WHERE id > ?
-        AND (
-          start_at_utc IS NULL
-          OR trim(start_at_utc) = ''
-          OR (
-            end_date IS NOT NULL
-            AND trim(end_date) != ''
-            AND (end_at_utc IS NULL OR trim(end_at_utc) = '')
-          )
-        )
-      ORDER BY id ASC
-      LIMIT ?
-    `);
-
-    const updateTemporalRows = db.transaction(() => {
-      const batchSize = 500;
-      let lastId = "";
-      const nowIso = new Date().toISOString();
-      while (true) {
-        const batch = temporalRows.all(lastId, batchSize) as Array<{
-          id: string;
-          start_date: string;
-          end_date: string | null;
-          all_day: number | null;
-          event_timezone: string;
-          start_at_utc: string | null;
-          end_at_utc: string | null;
-          created_at: string | null;
-        }>;
-        if (batch.length === 0) break;
-
-        for (const row of batch) {
-          const rawTimezone = row.event_timezone && row.event_timezone.trim() ? row.event_timezone.trim() : "UTC";
-          const timezone = isValidIanaTimezone(rawTimezone) ? rawTimezone : "UTC";
-          const allDay = !!row.all_day;
-          const startDateRaw = row.start_date || "";
-          const endDateRaw = row.end_date && row.end_date.trim() ? row.end_date : null;
-
-          const nextStartAtUtc = canonicalUtcIso(row.start_at_utc)
-            || deriveUtcFromTemporalInput(startDateRaw, { allDay, eventTimezone: timezone })
-            || sqliteUtcDateTimeToUtcIso(row.created_at)
-            || nowIso;
-
-          let nextEndAtUtc = canonicalUtcIso(row.end_at_utc)
-            || (allDay
-              ? deriveAllDayEndAtUtc(startDateRaw, endDateRaw, timezone)
-              : (endDateRaw
-                ? deriveUtcFromTemporalInput(endDateRaw, { allDay: false, eventTimezone: timezone })
-                : null));
-          if ((allDay || endDateRaw) && !nextEndAtUtc) nextEndAtUtc = nextStartAtUtc;
-          if (nextEndAtUtc && nextEndAtUtc < nextStartAtUtc) nextEndAtUtc = nextStartAtUtc;
-
-          const startOn = extractDatePart(startDateRaw) || nextStartAtUtc.slice(0, 10);
-          const endOn = extractDatePart(endDateRaw) || (endDateRaw ? nextEndAtUtc?.slice(0, 10) || nextStartAtUtc.slice(0, 10) : null);
-
-          updateTemporal.run(nextStartAtUtc, nextEndAtUtc, timezone, startOn, endOn, row.id);
-        }
-
-        lastId = batch[batch.length - 1]?.id || lastId;
-      }
-    });
-
-    const updateTemporal = db.prepare(`
-      UPDATE events
-      SET start_at_utc = ?, end_at_utc = ?, event_timezone = ?, start_on = ?, end_on = ?
-      WHERE id = ?
-    `);
-
-    updateTemporalRows();
-
-    const timezoneRows = db.prepare("SELECT id, event_timezone FROM events WHERE event_timezone IS NOT NULL AND trim(event_timezone) != ''").all() as Array<{
-      id: string;
-      event_timezone: string;
-    }>;
-    const normalizeTimezone = db.prepare("UPDATE events SET event_timezone = ? WHERE id = ?");
-    for (const row of timezoneRows) {
-      const timezone = row.event_timezone.trim();
-      if (isValidIanaTimezone(timezone)) continue;
-      normalizeTimezone.run("UTC", row.id);
+  if (currentVersion === 0) {
+    if (!hasUserTables(db)) {
+      applyPendingMigrations(db, 0);
+    } else {
+      assertSchemaIsSupported(db);
+      db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
     }
-
-    const unresolvedTemporalRows = db.prepare(`
-      SELECT COUNT(*) AS total
-      FROM events
-      WHERE start_at_utc IS NULL
-         OR trim(start_at_utc) = ''
-         OR event_timezone IS NULL
-         OR trim(event_timezone) = ''
-         OR start_on IS NULL
-         OR trim(start_on) = ''
-         OR (
-           end_date IS NOT NULL
-           AND trim(end_date) != ''
-           AND (
-             end_at_utc IS NULL
-             OR trim(end_at_utc) = ''
-             OR end_on IS NULL
-             OR trim(end_on) = ''
-           )
-         )
-    `).get() as { total: number };
-
-    if (unresolvedTemporalRows.total > 0) {
-      throw new Error(`events temporal migration left ${unresolvedTemporalRows.total} invalid rows`);
-    }
-
-    if (tableHasColumn("events", "start_at_utc")) {
-      db.exec("CREATE INDEX IF NOT EXISTS idx_events_start_at_utc ON events(start_at_utc)");
-    }
-    if (tableHasColumn("events", "start_on")) {
-      db.exec("CREATE INDEX IF NOT EXISTS idx_events_start_on ON events(start_on)");
-    }
-  } catch (e) {
-    if (tableHasColumn("events", "id")) throw e;
-    // Ignore partial/legacy states where events table is not fully initialized.
+  } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
+    applyPendingMigrations(db, currentVersion);
   }
 
-  try {
-    if (!tableHasColumn("remote_events", "start_at_utc")) {
-      const remoteFallbackExpr = tableHasColumn("remote_events", "fetched_at")
-        ? "COALESCE(NULLIF(fetched_at, ''), datetime('now'))"
-        : "datetime('now')";
-      db.exec("BEGIN");
-      try {
-        db.exec("ALTER TABLE remote_events ADD COLUMN start_at_utc TEXT");
-        db.exec(`
-          UPDATE remote_events
-          SET start_at_utc = COALESCE(NULLIF(start_date, ''), ${remoteFallbackExpr})
-          WHERE start_at_utc IS NULL OR trim(start_at_utc) = ''
-        `);
-        db.exec("COMMIT");
-      } catch (e) {
-        db.exec("ROLLBACK");
-        throw e;
-      }
-    }
-    if (tableHasColumn("remote_events", "start_at_utc")) {
-      db.exec("CREATE INDEX IF NOT EXISTS idx_remote_events_start_at_utc ON remote_events(start_at_utc)");
-    }
-
-    if (!tableHasColumn("remote_events", "start_on")) {
-      db.exec("ALTER TABLE remote_events ADD COLUMN start_on TEXT");
-    }
-    if (!tableHasColumn("remote_events", "end_on")) {
-      db.exec("ALTER TABLE remote_events ADD COLUMN end_on TEXT");
-    }
-    if (tableHasColumn("remote_events", "start_on")) {
-      db.exec(`
-        UPDATE remote_events
-        SET start_on = COALESCE(
-          CASE
-            WHEN start_date IS NOT NULL
-              AND trim(start_date) GLOB '????-??-??*'
-              AND date(substr(trim(start_date), 1, 10)) IS NOT NULL
-            THEN substr(trim(start_date), 1, 10)
-            ELSE NULL
-          END,
-          CASE
-            WHEN start_at_utc IS NOT NULL
-              AND trim(start_at_utc) GLOB '????-??-??*'
-              AND date(substr(trim(start_at_utc), 1, 10)) IS NOT NULL
-            THEN substr(trim(start_at_utc), 1, 10)
-            ELSE NULL
-          END
-        )
-        WHERE (start_on IS NULL OR trim(start_on) = '')
-          AND (
-            (start_date IS NOT NULL AND trim(start_date) GLOB '????-??-??*' AND date(substr(trim(start_date), 1, 10)) IS NOT NULL)
-            OR (start_at_utc IS NOT NULL AND trim(start_at_utc) GLOB '????-??-??*' AND date(substr(trim(start_at_utc), 1, 10)) IS NOT NULL)
-          )
-      `);
-      db.exec("CREATE INDEX IF NOT EXISTS idx_remote_events_start_on ON remote_events(start_on)");
-    }
-    if (tableHasColumn("remote_events", "end_on")) {
-      db.exec(`
-        UPDATE remote_events
-        SET end_on = COALESCE(
-          CASE
-            WHEN end_date IS NOT NULL
-              AND trim(end_date) GLOB '????-??-??*'
-              AND date(substr(trim(end_date), 1, 10)) IS NOT NULL
-            THEN substr(trim(end_date), 1, 10)
-            ELSE NULL
-          END,
-          CASE
-            WHEN end_at_utc IS NOT NULL
-              AND trim(end_at_utc) GLOB '????-??-??*'
-              AND date(substr(trim(end_at_utc), 1, 10)) IS NOT NULL
-            THEN substr(trim(end_at_utc), 1, 10)
-            ELSE NULL
-          END
-        )
-        WHERE (end_on IS NULL OR trim(end_on) = '')
-          AND (
-            (end_date IS NOT NULL AND trim(end_date) GLOB '????-??-??*' AND date(substr(trim(end_date), 1, 10)) IS NOT NULL)
-            OR (end_at_utc IS NOT NULL AND trim(end_at_utc) GLOB '????-??-??*' AND date(substr(trim(end_at_utc), 1, 10)) IS NOT NULL)
-          )
-      `);
-    }
-  } catch {
-    // Ignore partial/legacy states where remote_events table is not fully initialized
-  }
-
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN end_at_utc TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN event_timezone TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN timezone_quality TEXT NOT NULL DEFAULT 'offset_only'");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("UPDATE remote_events SET timezone_quality = 'offset_only' WHERE timezone_quality IS NULL OR timezone_quality = '' OR timezone_quality NOT IN ('exact_tzid','offset_only')");
-  } catch {
-    // Ignore when table not yet initialized
-  }
-
-  // Migration: add follower_shared_inbox to remote_follows if missing
-  try {
-    db.exec("ALTER TABLE remote_follows ADD COLUMN follower_shared_inbox TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: store Follow activity references for interoperable Undo
-  try {
-    db.exec("ALTER TABLE remote_following ADD COLUMN follow_activity_id TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_following ADD COLUMN follow_object_uri TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("UPDATE remote_following SET follow_object_uri = follow_activity_id WHERE follow_object_uri IS NULL AND follow_activity_id IS NOT NULL");
-  } catch {
-    // Ignore when table not yet initialized
-  }
-
-  // Migration: add is_bot and discoverable to accounts if missing
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN is_bot INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN discoverable INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: add website to accounts if missing
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN website TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: add default event visibility to accounts if missing
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN default_event_visibility TEXT NOT NULL DEFAULT 'public'");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: account type and delegated publishing membership tables
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN account_type TEXT NOT NULL DEFAULT 'person'");
-  } catch {
-    // Column already exists
-  }
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS identity_memberships (
-      identity_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      member_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      role TEXT NOT NULL CHECK(role IN ('owner','editor')),
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (identity_account_id, member_account_id)
-    )
-  `);
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_identity_memberships_member ON identity_memberships(member_account_id)");
-  } catch {
-    // Index already exists
-  }
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_identity_memberships_identity_role ON identity_memberships(identity_account_id, role)");
-  } catch {
-    // Index already exists
-  }
-  try {
-    db.exec("UPDATE identity_memberships SET role = 'editor' WHERE role = 'admin'");
-  } catch {
-    // Ignore if table missing in partial init
-  }
-
-  // Migration: creator attribution for delegated publishing
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN created_by_account_id TEXT REFERENCES accounts(id) ON DELETE SET NULL");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("UPDATE events SET created_by_account_id = account_id WHERE created_by_account_id IS NULL");
-  } catch {
-    // Ignore when events table not yet initialized
-  }
-
-  // Migration: add followers_count, following_count to remote_actors
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN followers_count INTEGER");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN following_count INTEGER");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN fetch_status TEXT NOT NULL DEFAULT 'active' CHECK(fetch_status IN ('active', 'error', 'gone'))");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN last_error TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN next_retry_at TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_actors ADD COLUMN gone_at TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("UPDATE remote_actors SET fetch_status = 'active' WHERE fetch_status IS NULL OR fetch_status = ''");
-  } catch {
-    // Ignore when table not yet initialized
-  }
-
-  // Migration: add slug to events if missing
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN slug TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: add content_hash to events for change detection during sync
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN content_hash TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: local event cancellation state for scraper sync (never hard-delete missing events)
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN canceled INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN missing_since TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: add key_prefix to api_keys for fast lookup
-  try {
-    db.exec("ALTER TABLE api_keys ADD COLUMN key_prefix TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix)");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: calendar_feed_tokens table (may have been created with token_hash in an earlier version)
-  const cftTable = db.prepare(
-    "SELECT sql FROM sqlite_master WHERE type='table' AND name='calendar_feed_tokens'"
-  ).get() as { sql: string } | undefined;
-  const cftHasToken = cftTable?.sql?.includes(" token ");
-  const needsRecreate = !cftTable || !cftHasToken;
-  if (needsRecreate) {
-    if (cftTable) db.exec("DROP TABLE calendar_feed_tokens");
-    db.exec(`
-      CREATE TABLE calendar_feed_tokens (
-        account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
-        token TEXT NOT NULL UNIQUE,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
-      );
-      CREATE INDEX idx_calendar_feed_tokens_token ON calendar_feed_tokens(token);
-    `);
-  } else {
-    try {
-      db.exec("CREATE INDEX IF NOT EXISTS idx_calendar_feed_tokens_token ON calendar_feed_tokens(token)");
-    } catch {
-      // Index already exists
-    }
-  }
-
-  // Migration: remove "interested" from event_rsvps (recreate table with new CHECK constraint)
-  const rsvpTable = db.prepare(
-    "SELECT sql FROM sqlite_master WHERE type='table' AND name='event_rsvps'"
-  ).get() as { sql: string } | undefined;
-  const rsvpNewTable = db.prepare(
-    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='event_rsvps_new'"
-  ).get();
-
-  if (rsvpNewTable) {
-    // Recovery: previous migration failed partway; event_rsvps_new exists, event_rsvps was dropped
-    db.exec("BEGIN");
-    try {
-      db.exec(`
-        ALTER TABLE event_rsvps_new RENAME TO event_rsvps;
-        CREATE INDEX IF NOT EXISTS idx_event_rsvps_account ON event_rsvps(account_id);
-        CREATE INDEX IF NOT EXISTS idx_event_rsvps_event ON event_rsvps(event_uri);
-      `);
-      db.exec("COMMIT");
-    } catch (e) {
-      db.exec("ROLLBACK");
-      throw e;
-    }
-  } else if (rsvpTable?.sql?.includes("'interested'")) {
-    db.exec("BEGIN");
-    try {
-      db.exec(`
-        DELETE FROM event_rsvps WHERE status = 'interested';
-        CREATE TABLE event_rsvps_new (
-          account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-          event_uri TEXT NOT NULL,
-          status TEXT NOT NULL CHECK(status IN ('going','maybe')),
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
-          PRIMARY KEY (account_id, event_uri)
-        );
-        INSERT INTO event_rsvps_new SELECT * FROM event_rsvps;
-        DROP TABLE event_rsvps;
-        ALTER TABLE event_rsvps_new RENAME TO event_rsvps;
-        CREATE INDEX IF NOT EXISTS idx_event_rsvps_account ON event_rsvps(account_id);
-        CREATE INDEX IF NOT EXISTS idx_event_rsvps_event ON event_rsvps(event_uri);
-      `);
-      db.exec("COMMIT");
-    } catch (e) {
-      db.exec("ROLLBACK");
-      throw e;
-    }
-  }
-
-  // Migration: add city fields to accounts (default Wien for existing users)
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN city TEXT NOT NULL DEFAULT 'Wien'");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN city_lat REAL NOT NULL DEFAULT 48.2082");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN city_lng REAL NOT NULL DEFAULT 16.3738");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: add image_attribution for Unsplash/Openverse crediting
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN image_attribution TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN image_attribution TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: canceled flag for remote events (ActivityPub Delete = mark canceled, not delete)
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN canceled INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: store all-day semantic for remote events
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN all_day INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec(`
-      UPDATE remote_events
-      SET all_day = 1
-      WHERE start_date GLOB '????-??-??'
-        AND (end_date IS NULL OR end_date GLOB '????-??-??')
-    `);
-  } catch {
-    // Ignore when table not yet initialized
-  }
-
-  // Migration: canonicalize remote temporal fields into strict UTC + timezone contract
-  try {
-    const rows = db.prepare(`
-      SELECT uri, start_date, end_date, all_day, start_at_utc, end_at_utc, start_on, end_on, event_timezone, timezone_quality, fetched_at
-      FROM remote_events
-      WHERE start_at_utc IS NULL
-         OR trim(start_at_utc) = ''
-         OR start_at_utc NOT GLOB '????-??-??T??:??:??*Z'
-         OR start_on IS NULL
-         OR trim(start_on) = ''
-         OR start_on NOT GLOB '????-??-??'
-         OR (
-           end_date IS NOT NULL
-           AND trim(end_date) != ''
-           AND (
-             end_on IS NULL
-             OR trim(end_on) = ''
-             OR end_on NOT GLOB '????-??-??'
-           )
-         )
-         OR (
-           end_date IS NOT NULL
-           AND trim(end_date) != ''
-           AND (
-             end_at_utc IS NULL
-             OR trim(end_at_utc) = ''
-             OR end_at_utc NOT GLOB '????-??-??T??:??:??*Z'
-           )
-         )
-         OR timezone_quality IS NULL
-         OR trim(timezone_quality) = ''
-         OR timezone_quality NOT IN ('exact_tzid','offset_only')
-         OR (timezone_quality = 'exact_tzid' AND (event_timezone IS NULL OR trim(event_timezone) = ''))
-         OR (timezone_quality != 'exact_tzid' AND event_timezone IS NOT NULL AND trim(event_timezone) != '')
-         OR all_day IS NULL
-         OR (
-           COALESCE(all_day, 0) = 0
-           AND start_date GLOB '????-??-??'
-           AND (end_date IS NULL OR end_date GLOB '????-??-??')
-         )
-         OR (
-           start_at_utc IS NOT NULL
-           AND trim(start_at_utc) != ''
-           AND end_at_utc IS NOT NULL
-           AND trim(end_at_utc) != ''
-           AND end_at_utc < start_at_utc
-         )
-    `).all() as Array<{
-      uri: string;
-      start_date: string;
-      end_date: string | null;
-      all_day: number;
-      start_at_utc: string | null;
-      end_at_utc: string | null;
-      start_on: string | null;
-      end_on: string | null;
-      event_timezone: string | null;
-      timezone_quality: string | null;
-      fetched_at: string | null;
-    }>;
-
-    const updateTemporal = db.prepare(`
-      UPDATE remote_events
-      SET all_day = ?, start_at_utc = ?, end_at_utc = ?, event_timezone = ?, timezone_quality = ?, start_on = ?, end_on = ?
-      WHERE uri = ?
-    `);
-
-    const nowIso = new Date().toISOString();
-    for (const row of rows) {
-      const inferredAllDay = DATE_ONLY.test(row.start_date) && (!row.end_date || DATE_ONLY.test(row.end_date));
-      const allDay = !!row.all_day || inferredAllDay;
-
-      const rawTimezone = row.event_timezone && row.event_timezone.trim() ? row.event_timezone.trim() : null;
-      const wantsExactTimezone = row.timezone_quality === "exact_tzid";
-      const timezone = rawTimezone && wantsExactTimezone && isValidIanaTimezone(rawTimezone) ? rawTimezone : null;
-
-      const nextStartAtUtc = deriveUtcFromTemporalInput(
-        row.start_date,
-        { allDay, eventTimezone: timezone },
-      )
-        || canonicalUtcIso(row.start_at_utc)
-        || canonicalUtcIso(row.fetched_at)
-        || nowIso;
-
-      let nextEndAtUtc = (allDay
-        ? deriveAllDayEndAtUtc(row.start_date, row.end_date, timezone)
-        : deriveUtcFromTemporalInput(
-          row.end_date,
-          { allDay: false, eventTimezone: timezone },
-        ))
-        || canonicalUtcIso(row.end_at_utc);
-      if ((allDay || row.end_date) && !nextEndAtUtc) nextEndAtUtc = nextStartAtUtc;
-      if (nextEndAtUtc && nextEndAtUtc < nextStartAtUtc) nextEndAtUtc = nextStartAtUtc;
-
-      const nextStartOn = deriveStoredDatePartForTemporal(row.start_date, nextStartAtUtc, {
-        allDay,
-        timezone,
-      });
-      const nextEndOn = deriveStoredDatePartForTemporal(row.end_date, nextEndAtUtc, {
-        allDay,
-        timezone,
-      });
-
-      const nextTimezoneQuality = timezone ? "exact_tzid" : "offset_only";
-      const nextAllDay = allDay ? 1 : 0;
-      const needsUpdate =
-        row.all_day === null
-        || (row.all_day ? 1 : 0) !== nextAllDay
-        || row.start_at_utc !== nextStartAtUtc
-        || row.end_at_utc !== nextEndAtUtc
-        || row.start_on !== nextStartOn
-        || row.end_on !== nextEndOn
-        || row.event_timezone !== timezone
-        || row.timezone_quality !== nextTimezoneQuality;
-
-      if (needsUpdate) {
-        updateTemporal.run(nextAllDay, nextStartAtUtc, nextEndAtUtc, timezone, nextTimezoneQuality, nextStartOn, nextEndOn, row.uri);
-      }
-    }
-  } catch {
-    // Ignore when table not yet initialized
-  }
-
-  // Migration: immutable slug for remote event canonical URLs
-  try {
-    db.exec("ALTER TABLE remote_events ADD COLUMN slug TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: backfill missing remote slugs for already-cached events
-  try {
-    const missing = db
-      .prepare(
-        `SELECT uri, actor_uri, title
-         FROM remote_events
-         WHERE slug IS NULL OR slug = ''
-         ORDER BY fetched_at ASC, uri ASC`
-      )
-      .all() as Array<{ uri: string; actor_uri: string; title: string }>;
-    const updateSlug = db.prepare("UPDATE remote_events SET slug = ? WHERE uri = ?");
-    for (const row of missing) {
-      const slug = uniqueRemoteEventSlug(db, row.actor_uri, row.title || "event");
-      updateSlug.run(slug, row.uri);
-    }
-  } catch {
-    // Ignore partial/legacy states where remote_events may not be initialized yet
-  }
-
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS saved_locations (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      name TEXT NOT NULL,
-      address TEXT,
-      latitude REAL,
-      longitude REAL,
-      used_at TEXT NOT NULL DEFAULT (datetime('now')),
-      UNIQUE(account_id, name, address)
-    )
-  `);
-  db.exec("CREATE INDEX IF NOT EXISTS idx_saved_locations_account ON saved_locations(account_id, used_at DESC)");
-
-  // Migration: email and verification for accounts
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN email TEXT");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN email_verified INTEGER NOT NULL DEFAULT 0");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN email_verified_at TEXT");
-  } catch {
-    // Column already exists
-  }
-
-  // Grandfather existing accounts (no email) as verified so they can still log in
-  try {
-    db.exec("UPDATE accounts SET email_verified = 1 WHERE email IS NULL");
-  } catch {
-    // Ignore
-  }
-
-  // Migration: email verification tokens
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS email_verification_tokens (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      token TEXT NOT NULL UNIQUE,
-      expires_at TEXT NOT NULL,
-      PRIMARY KEY (account_id)
-    )
-  `);
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token ON email_verification_tokens(token)");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: password reset tokens
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS password_reset_tokens (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      token TEXT NOT NULL UNIQUE,
-      expires_at TEXT NOT NULL,
-      PRIMARY KEY (account_id)
-    )
-  `);
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON password_reset_tokens(token)");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: account notification preferences
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS account_notification_prefs (
-      account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
-      reminder_enabled INTEGER NOT NULL DEFAULT 1,
-      reminder_hours_before INTEGER NOT NULL DEFAULT 24,
-      event_updated_enabled INTEGER NOT NULL DEFAULT 1,
-      event_cancelled_enabled INTEGER NOT NULL DEFAULT 1,
-      onboarding_completed INTEGER NOT NULL DEFAULT 0
-    )
-  `);
-
-  // Migration: email change requests (add/change email with verification)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS email_change_requests (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      new_email TEXT NOT NULL,
-      token TEXT NOT NULL UNIQUE,
-      expires_at TEXT NOT NULL,
-      PRIMARY KEY (account_id)
-    )
-  `);
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_email_change_requests_token ON email_change_requests(token)");
-  } catch {
-    /* index exists */
-  }
-
-  // Migration: event reminder sent (prevent duplicate reminders)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS event_reminder_sent (
-      account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-      event_uri TEXT NOT NULL,
-      reminder_type TEXT NOT NULL DEFAULT '24h',
-      sent_at TEXT NOT NULL DEFAULT (datetime('now')),
-      PRIMARY KEY (account_id, event_uri, reminder_type)
-    )
-  `);
-  try {
-    db.exec("CREATE INDEX IF NOT EXISTS idx_event_reminder_sent_account ON event_reminder_sent(account_id)");
-  } catch {
-    // Index already exists
-  }
-
-  // Migration: preferred language for i18n
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN preferred_language TEXT DEFAULT 'en'");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: og_image_url for custom OG images
-  try {
-    db.exec("ALTER TABLE events ADD COLUMN og_image_url TEXT");
-  } catch {
-    // Column already exists
-  }
-
-
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN timezone TEXT NOT NULL DEFAULT 'system'");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN date_time_locale TEXT NOT NULL DEFAULT 'system'");
-  } catch {
-    // Column already exists
-  }
-  try {
-    db.exec("ALTER TABLE accounts ADD COLUMN theme_preference TEXT NOT NULL DEFAULT 'system' CHECK(theme_preference IN ('system','light','dark'))");
-  } catch {
-    // Column already exists
-  }
-
-  // Migration: normalize accounts column defaults for timezone/locale on legacy DBs
-  try {
-    const accountCols = db.prepare("PRAGMA table_info(accounts)").all() as Array<{ name: string; dflt_value: string | null }>;
-    const timezoneDefault = accountCols.find((col) => col.name === "timezone")?.dflt_value;
-    const localeDefault = accountCols.find((col) => col.name === "date_time_locale")?.dflt_value;
-    const needsAccountsDefaultRebuild = timezoneDefault !== "'system'" || localeDefault !== "'system'";
-
-    if (needsAccountsDefaultRebuild) {
-      db.exec("PRAGMA foreign_keys = OFF");
-      db.exec("BEGIN");
-      try {
-        db.exec(`
-          CREATE TABLE accounts_new (
-            id TEXT PRIMARY KEY,
-            username TEXT NOT NULL UNIQUE,
-            account_type TEXT NOT NULL DEFAULT 'person' CHECK(account_type IN ('person','identity')),
-            display_name TEXT,
-            bio TEXT,
-            avatar_url TEXT,
-            password_hash TEXT,
-            private_key TEXT,
-            public_key TEXT,
-            is_bot INTEGER NOT NULL DEFAULT 0,
-            discoverable INTEGER NOT NULL DEFAULT 0,
-            timezone TEXT NOT NULL DEFAULT 'system',
-            date_time_locale TEXT NOT NULL DEFAULT 'system',
-            theme_preference TEXT NOT NULL DEFAULT 'system' CHECK(theme_preference IN ('system','light','dark')),
-            default_event_visibility TEXT NOT NULL DEFAULT 'public' CHECK(default_event_visibility IN ('public','unlisted','followers_only','private')),
-            created_at TEXT NOT NULL DEFAULT (datetime('now')),
-            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-            website TEXT,
-            city TEXT NOT NULL DEFAULT 'Wien',
-            city_lat REAL NOT NULL DEFAULT 48.2082,
-            city_lng REAL NOT NULL DEFAULT 16.3738,
-            email TEXT,
-            email_verified INTEGER NOT NULL DEFAULT 0,
-            email_verified_at TEXT,
-            preferred_language TEXT DEFAULT 'en'
-          )
-        `);
-        db.exec(`
-          INSERT INTO accounts_new (
-            id, username, account_type, display_name, bio, avatar_url, password_hash, private_key, public_key,
-            is_bot, discoverable, timezone, date_time_locale, theme_preference, default_event_visibility, created_at, updated_at,
-            website, city, city_lat, city_lng, email, email_verified, email_verified_at, preferred_language
-          )
-          SELECT
-            id,
-            username,
-            account_type,
-            display_name,
-            bio,
-            avatar_url,
-            password_hash,
-            private_key,
-            public_key,
-            is_bot,
-            discoverable,
-            COALESCE(NULLIF(timezone, ''), '${SYSTEM_TIMEZONE}') AS timezone,
-            COALESCE(NULLIF(date_time_locale, ''), '${SYSTEM_DATE_TIME_LOCALE}') AS date_time_locale,
-            CASE lower(trim(COALESCE(theme_preference, '')))
-              WHEN 'system' THEN 'system'
-              WHEN 'light' THEN 'light'
-              WHEN 'dark' THEN 'dark'
-              ELSE '${SYSTEM_THEME_PREFERENCE}'
-            END AS theme_preference,
-            default_event_visibility,
-            created_at,
-            updated_at,
-            website,
-            city,
-            city_lat,
-            city_lng,
-            email,
-            email_verified,
-            email_verified_at,
-            preferred_language
-          FROM accounts
-        `);
-        db.exec("DROP TABLE accounts");
-        db.exec("ALTER TABLE accounts_new RENAME TO accounts");
-        db.exec("COMMIT");
-      } catch (e) {
-        db.exec("ROLLBACK");
-        throw e;
-      } finally {
-        db.exec("PRAGMA foreign_keys = ON");
-      }
-    }
-  } catch {
-    // Ignore during partial initialization
-  }
-
-  try {
-    db.exec(
-      `UPDATE accounts
-       SET timezone = '${SYSTEM_TIMEZONE}'
-       WHERE timezone IS NULL OR trim(timezone) = ''`
-    );
-    db.exec(
-      `UPDATE accounts
-       SET date_time_locale = '${SYSTEM_DATE_TIME_LOCALE}'
-       WHERE date_time_locale IS NULL
-          OR trim(date_time_locale) = ''`
-    );
-    db.exec(
-      `UPDATE accounts
-       SET theme_preference = '${SYSTEM_THEME_PREFERENCE}'
-       WHERE theme_preference IS NULL
-          OR trim(theme_preference) = ''
-          OR theme_preference NOT IN ('system', 'light', 'dark')`
-    );
-  } catch {
-    // Ignore during partial initialization
-  }
-  db.exec("DROP TRIGGER IF EXISTS trg_accounts_time_format_insert");
-  db.exec("DROP TRIGGER IF EXISTS trg_accounts_time_format_update");
-  try {
-    db.exec("ALTER TABLE accounts DROP COLUMN time_format");
-  } catch {
-    // Column does not exist or SQLite version does not support DROP COLUMN
-  }
-
-
+  assertSchemaIsSupported(db);
   return db;
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -79,8 +79,16 @@ const REQUIRED_COLUMNS: Record<string, string[]> = {
   remote_actors: ["followers_count", "following_count", "fetch_status", "last_error", "next_retry_at", "gone_at"],
   remote_follows: ["follower_shared_inbox"],
   remote_following: ["follow_activity_id", "follow_object_uri"],
+  calendar_feed_tokens: ["token"],
   api_keys: ["key_prefix"],
 };
+
+function hasOnlySupportedRsvpStatuses(db: DB): boolean {
+  const invalid = db
+    .prepare("SELECT 1 AS bad FROM event_rsvps WHERE status IS NULL OR status NOT IN ('going','maybe') LIMIT 1")
+    .get() as { bad: number } | undefined;
+  return !invalid;
+}
 
 function tableExists(db: DB, table: string): boolean {
   const row = db
@@ -113,6 +121,8 @@ function schemaLooksLikeCurrentBaseline(db: DB): boolean {
       if (!columns.has(column)) return false;
     }
   }
+
+  if (!hasOnlySupportedRsvpStatuses(db)) return false;
 
   return true;
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -7,124 +7,11 @@ import { CURRENT_SCHEMA_VERSION, MIGRATIONS } from "./db/migrations.js";
 
 export type DB = Database.Database;
 
-const REQUIRED_TABLES = [
-  "accounts",
-  "sessions",
-  "api_keys",
-  "events",
-  "event_tags",
-  "follows",
-  "identity_memberships",
-  "remote_follows",
-  "remote_actors",
-  "remote_events",
-  "remote_following",
-  "domain_discovery",
-  "event_rsvps",
-  "reposts",
-  "auto_reposts",
-  "actor_selection_operations",
-  "actor_selection_operation_items",
-  "login_attempts",
-  "calendar_feed_tokens",
-  "saved_locations",
-  "email_verification_tokens",
-  "password_reset_tokens",
-  "account_notification_prefs",
-  "email_change_requests",
-  "event_reminder_sent",
-];
-
-const REQUIRED_COLUMNS: Record<string, string[]> = {
-  accounts: [
-    "account_type",
-    "timezone",
-    "date_time_locale",
-    "theme_preference",
-    "default_event_visibility",
-    "city",
-    "city_lat",
-    "city_lng",
-    "email",
-    "email_verified",
-    "preferred_language",
-  ],
-  events: [
-    "created_by_account_id",
-    "slug",
-    "start_at_utc",
-    "end_at_utc",
-    "event_timezone",
-    "start_on",
-    "end_on",
-    "all_day",
-    "content_hash",
-    "canceled",
-    "missing_since",
-    "image_attribution",
-    "og_image_url",
-  ],
-  remote_events: [
-    "slug",
-    "all_day",
-    "start_at_utc",
-    "end_at_utc",
-    "start_on",
-    "end_on",
-    "event_timezone",
-    "timezone_quality",
-    "image_attribution",
-    "canceled",
-  ],
-  remote_actors: ["followers_count", "following_count", "fetch_status", "last_error", "next_retry_at", "gone_at"],
-  remote_follows: ["follower_shared_inbox"],
-  remote_following: ["follow_activity_id", "follow_object_uri"],
-  calendar_feed_tokens: ["token"],
-  api_keys: ["key_prefix"],
-};
-
-function hasOnlySupportedRsvpStatuses(db: DB): boolean {
-  const invalid = db
-    .prepare("SELECT 1 AS bad FROM event_rsvps WHERE status IS NULL OR status NOT IN ('going','maybe') LIMIT 1")
-    .get() as { bad: number } | undefined;
-  return !invalid;
-}
-
-function tableExists(db: DB, table: string): boolean {
-  const row = db
-    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ?")
-    .get(table) as { ok: number } | undefined;
-  return !!row?.ok;
-}
-
-function tableColumns(db: DB, table: string): Set<string> {
-  if (!tableExists(db, table)) return new Set();
-  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
-  return new Set(rows.map((row) => row.name));
-}
-
 function hasUserTables(db: DB): boolean {
   const row = db
     .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' LIMIT 1")
     .get() as { ok: number } | undefined;
   return !!row?.ok;
-}
-
-function schemaLooksLikeCurrentBaseline(db: DB): boolean {
-  for (const table of REQUIRED_TABLES) {
-    if (!tableExists(db, table)) return false;
-  }
-
-  for (const [table, required] of Object.entries(REQUIRED_COLUMNS)) {
-    const columns = tableColumns(db, table);
-    for (const column of required) {
-      if (!columns.has(column)) return false;
-    }
-  }
-
-  if (!hasOnlySupportedRsvpStatuses(db)) return false;
-
-  return true;
 }
 
 function applyPendingMigrations(db: DB, fromVersion: number): void {
@@ -142,14 +29,6 @@ function applyPendingMigrations(db: DB, fromVersion: number): void {
         `Failed database migration v${migration.version} (${migration.name}): ${error instanceof Error ? error.message : String(error)}`
       );
     }
-  }
-}
-
-function assertSchemaIsSupported(db: DB): void {
-  if (!schemaLooksLikeCurrentBaseline(db)) {
-    throw new Error(
-      "Unsupported legacy database schema detected. Legacy runtime migrations were intentionally removed; restore from an up-to-date backup or run a one-time offline migration before starting this build."
-    );
   }
 }
 
@@ -173,13 +52,10 @@ export function initDatabase(path: string): DB {
     if (!hasUserTables(db)) {
       applyPendingMigrations(db, 0);
     } else {
-      assertSchemaIsSupported(db);
       db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
     }
   } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
     applyPendingMigrations(db, currentVersion);
   }
-
-  assertSchemaIsSupported(db);
   return db;
 }

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -1,0 +1,352 @@
+import type { DB } from "../db.js";
+
+export type Migration = {
+  version: number;
+  name: string;
+  up: (db: DB) => void;
+};
+
+const BASELINE_SCHEMA_SQL = `
+CREATE TABLE IF NOT EXISTS accounts (
+  id TEXT PRIMARY KEY,
+  username TEXT NOT NULL UNIQUE,
+  account_type TEXT NOT NULL DEFAULT 'person' CHECK(account_type IN ('person','identity')),
+  display_name TEXT,
+  bio TEXT,
+  avatar_url TEXT,
+  password_hash TEXT,
+  private_key TEXT,
+  public_key TEXT,
+  is_bot INTEGER NOT NULL DEFAULT 0,
+  discoverable INTEGER NOT NULL DEFAULT 0,
+  timezone TEXT NOT NULL DEFAULT 'system',
+  date_time_locale TEXT NOT NULL DEFAULT 'system',
+  theme_preference TEXT NOT NULL DEFAULT 'system' CHECK(theme_preference IN ('system','light','dark')),
+  default_event_visibility TEXT NOT NULL DEFAULT 'public' CHECK(default_event_visibility IN ('public','unlisted','followers_only','private')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  website TEXT,
+  city TEXT NOT NULL DEFAULT 'Wien',
+  city_lat REAL NOT NULL DEFAULT 48.2082,
+  city_lng REAL NOT NULL DEFAULT 16.3738,
+  email TEXT,
+  email_verified INTEGER NOT NULL DEFAULT 0,
+  email_verified_at TEXT,
+  preferred_language TEXT DEFAULT 'en'
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  token TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  expires_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS api_keys (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  key_hash TEXT NOT NULL,
+  label TEXT NOT NULL DEFAULT '',
+  last_used_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  key_prefix TEXT
+);
+
+CREATE TABLE IF NOT EXISTS events (
+  id TEXT PRIMARY KEY,
+  account_id TEXT NOT NULL REFERENCES accounts(id),
+  created_by_account_id TEXT REFERENCES accounts(id) ON DELETE SET NULL,
+  external_id TEXT,
+  slug TEXT,
+  title TEXT NOT NULL,
+  description TEXT,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  start_at_utc TEXT NOT NULL,
+  end_at_utc TEXT,
+  event_timezone TEXT NOT NULL,
+  start_on TEXT,
+  end_on TEXT,
+  all_day INTEGER NOT NULL DEFAULT 0,
+  location_name TEXT,
+  location_address TEXT,
+  location_latitude REAL,
+  location_longitude REAL,
+  location_url TEXT,
+  image_url TEXT,
+  image_media_type TEXT,
+  image_alt TEXT,
+  image_attribution TEXT,
+  og_image_url TEXT,
+  url TEXT,
+  visibility TEXT NOT NULL DEFAULT 'public',
+  content_hash TEXT,
+  canceled INTEGER NOT NULL DEFAULT 0,
+  missing_since TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  CHECK(end_at_utc IS NULL OR end_at_utc >= start_at_utc)
+);
+
+CREATE TABLE IF NOT EXISTS event_tags (
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  tag TEXT NOT NULL,
+  PRIMARY KEY (event_id, tag)
+);
+
+CREATE TABLE IF NOT EXISTS follows (
+  follower_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  following_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (follower_id, following_id)
+);
+
+CREATE TABLE IF NOT EXISTS identity_memberships (
+  identity_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  member_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  role TEXT NOT NULL CHECK(role IN ('owner','editor')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (identity_account_id, member_account_id)
+);
+
+CREATE TABLE IF NOT EXISTS remote_follows (
+  account_id TEXT NOT NULL REFERENCES accounts(id),
+  follower_actor_uri TEXT NOT NULL,
+  follower_inbox TEXT NOT NULL,
+  follower_shared_inbox TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, follower_actor_uri)
+);
+
+CREATE TABLE IF NOT EXISTS remote_actors (
+  uri TEXT PRIMARY KEY,
+  type TEXT NOT NULL DEFAULT 'Person',
+  preferred_username TEXT NOT NULL,
+  display_name TEXT,
+  summary TEXT,
+  inbox TEXT NOT NULL,
+  outbox TEXT,
+  shared_inbox TEXT,
+  followers_url TEXT,
+  following_url TEXT,
+  icon_url TEXT,
+  image_url TEXT,
+  public_key_id TEXT,
+  public_key_pem TEXT,
+  domain TEXT NOT NULL,
+  followers_count INTEGER,
+  following_count INTEGER,
+  last_fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+  fetch_status TEXT NOT NULL DEFAULT 'active' CHECK(fetch_status IN ('active', 'error', 'gone')),
+  last_error TEXT,
+  next_retry_at TEXT,
+  gone_at TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS remote_events (
+  uri TEXT PRIMARY KEY,
+  actor_uri TEXT NOT NULL,
+  slug TEXT,
+  title TEXT NOT NULL,
+  description TEXT,
+  start_date TEXT NOT NULL,
+  end_date TEXT,
+  all_day INTEGER NOT NULL DEFAULT 0,
+  start_at_utc TEXT NOT NULL,
+  end_at_utc TEXT,
+  start_on TEXT,
+  end_on TEXT,
+  event_timezone TEXT,
+  timezone_quality TEXT NOT NULL CHECK(timezone_quality IN ('exact_tzid','offset_only')),
+  location_name TEXT,
+  location_address TEXT,
+  location_latitude REAL,
+  location_longitude REAL,
+  image_url TEXT,
+  image_media_type TEXT,
+  image_alt TEXT,
+  image_attribution TEXT,
+  url TEXT,
+  tags TEXT,
+  raw_json TEXT,
+  published TEXT,
+  updated TEXT,
+  fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+  canceled INTEGER NOT NULL DEFAULT 0,
+  CHECK((timezone_quality = 'exact_tzid' AND event_timezone IS NOT NULL) OR (timezone_quality != 'exact_tzid' AND event_timezone IS NULL)),
+  CHECK(end_at_utc IS NULL OR end_at_utc >= start_at_utc)
+);
+
+CREATE TABLE IF NOT EXISTS remote_following (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  actor_uri TEXT NOT NULL,
+  actor_inbox TEXT NOT NULL,
+  follow_activity_id TEXT,
+  follow_object_uri TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, actor_uri)
+);
+
+CREATE TABLE IF NOT EXISTS domain_discovery (
+  domain TEXT PRIMARY KEY,
+  last_discovered_at TEXT NOT NULL DEFAULT (datetime('now')),
+  software_type TEXT
+);
+
+CREATE TABLE IF NOT EXISTS event_rsvps (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  event_uri TEXT NOT NULL,
+  status TEXT NOT NULL CHECK(status IN ('going','maybe')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, event_uri)
+);
+
+CREATE TABLE IF NOT EXISTS reposts (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  event_id TEXT NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, event_id)
+);
+
+CREATE TABLE IF NOT EXISTS auto_reposts (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  source_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, source_account_id)
+);
+
+CREATE TABLE IF NOT EXISTS actor_selection_operations (
+  id TEXT PRIMARY KEY,
+  action_kind TEXT NOT NULL,
+  target_type TEXT NOT NULL,
+  target_id TEXT NOT NULL,
+  initiated_by_account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'completed' CHECK(status IN ('pending','completed','failed')),
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS actor_selection_operation_items (
+  operation_id TEXT NOT NULL REFERENCES actor_selection_operations(id) ON DELETE CASCADE,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  before_state INTEGER NOT NULL,
+  after_state INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK(status IN ('added','removed','unchanged','error')),
+  remote_status TEXT CHECK(remote_status IN ('none','pending','delivered','failed')),
+  message TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (operation_id, account_id)
+);
+
+CREATE TABLE IF NOT EXISTS login_attempts (
+  username TEXT PRIMARY KEY,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  locked_until TEXT,
+  last_attempt TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS calendar_feed_tokens (
+  account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS saved_locations (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  address TEXT,
+  latitude REAL,
+  longitude REAL,
+  used_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(account_id, name, address)
+);
+
+CREATE TABLE IF NOT EXISTS email_verification_tokens (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (account_id)
+);
+
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  token TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (account_id)
+);
+
+CREATE TABLE IF NOT EXISTS account_notification_prefs (
+  account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  reminder_enabled INTEGER NOT NULL DEFAULT 1,
+  reminder_hours_before INTEGER NOT NULL DEFAULT 24,
+  event_updated_enabled INTEGER NOT NULL DEFAULT 1,
+  event_cancelled_enabled INTEGER NOT NULL DEFAULT 1,
+  onboarding_completed INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS email_change_requests (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  new_email TEXT NOT NULL,
+  token TEXT NOT NULL UNIQUE,
+  expires_at TEXT NOT NULL,
+  PRIMARY KEY (account_id)
+);
+
+CREATE TABLE IF NOT EXISTS event_reminder_sent (
+  account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  event_uri TEXT NOT NULL,
+  reminder_type TEXT NOT NULL DEFAULT '24h',
+  sent_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (account_id, event_uri, reminder_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_account ON sessions(account_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires ON sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_api_keys_account ON api_keys(account_id);
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(key_prefix);
+CREATE INDEX IF NOT EXISTS idx_events_account ON events(account_id);
+CREATE INDEX IF NOT EXISTS idx_events_visibility ON events(visibility);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_external ON events(account_id, external_id) WHERE external_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_events_start_at_utc ON events(start_at_utc);
+CREATE INDEX IF NOT EXISTS idx_events_start_on ON events(start_on);
+CREATE INDEX IF NOT EXISTS idx_follows_follower ON follows(follower_id);
+CREATE INDEX IF NOT EXISTS idx_follows_following ON follows(following_id);
+CREATE INDEX IF NOT EXISTS idx_identity_memberships_member ON identity_memberships(member_account_id);
+CREATE INDEX IF NOT EXISTS idx_identity_memberships_identity_role ON identity_memberships(identity_account_id, role);
+CREATE INDEX IF NOT EXISTS idx_remote_actors_domain ON remote_actors(domain);
+CREATE INDEX IF NOT EXISTS idx_remote_actors_username ON remote_actors(preferred_username, domain);
+CREATE INDEX IF NOT EXISTS idx_remote_events_actor ON remote_events(actor_uri);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_remote_events_start_at_utc ON remote_events(start_at_utc);
+CREATE INDEX IF NOT EXISTS idx_remote_events_start_on ON remote_events(start_on);
+CREATE INDEX IF NOT EXISTS idx_remote_following_account ON remote_following(account_id);
+CREATE INDEX IF NOT EXISTS idx_event_rsvps_account ON event_rsvps(account_id);
+CREATE INDEX IF NOT EXISTS idx_event_rsvps_event ON event_rsvps(event_uri);
+CREATE INDEX IF NOT EXISTS idx_reposts_account ON reposts(account_id);
+CREATE INDEX IF NOT EXISTS idx_reposts_event ON reposts(event_id);
+CREATE INDEX IF NOT EXISTS idx_auto_reposts_account ON auto_reposts(account_id);
+CREATE INDEX IF NOT EXISTS idx_auto_reposts_source ON auto_reposts(source_account_id);
+CREATE INDEX IF NOT EXISTS idx_actor_selection_ops_initiated_by ON actor_selection_operations(initiated_by_account_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_actor_selection_items_operation ON actor_selection_operation_items(operation_id);
+CREATE INDEX IF NOT EXISTS idx_calendar_feed_tokens_token ON calendar_feed_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_saved_locations_account ON saved_locations(account_id, used_at DESC);
+CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token ON email_verification_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON password_reset_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_email_change_requests_token ON email_change_requests(token);
+CREATE INDEX IF NOT EXISTS idx_event_reminder_sent_account ON event_reminder_sent(account_id);
+`;
+
+export const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    name: "baseline_schema",
+    up: (db) => {
+      db.exec(BASELINE_SCHEMA_SQL);
+    },
+  },
+];
+
+export const CURRENT_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -331,11 +331,7 @@ CREATE INDEX IF NOT EXISTS idx_auto_reposts_account ON auto_reposts(account_id);
 CREATE INDEX IF NOT EXISTS idx_auto_reposts_source ON auto_reposts(source_account_id);
 CREATE INDEX IF NOT EXISTS idx_actor_selection_ops_initiated_by ON actor_selection_operations(initiated_by_account_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_actor_selection_items_operation ON actor_selection_operation_items(operation_id);
-CREATE INDEX IF NOT EXISTS idx_calendar_feed_tokens_token ON calendar_feed_tokens(token);
 CREATE INDEX IF NOT EXISTS idx_saved_locations_account ON saved_locations(account_id, used_at DESC);
-CREATE INDEX IF NOT EXISTS idx_email_verification_tokens_token ON email_verification_tokens(token);
-CREATE INDEX IF NOT EXISTS idx_password_reset_tokens_token ON password_reset_tokens(token);
-CREATE INDEX IF NOT EXISTS idx_email_change_requests_token ON email_change_requests(token);
 CREATE INDEX IF NOT EXISTS idx_event_reminder_sent_account ON event_reminder_sent(account_id);
 `;
 

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -20,7 +20,22 @@ describe("account timezone/locale defaults", () => {
     expect(row.theme_preference).toBe("system");
   });
 
-  it("backfills null legacy account timezone/locale to system", () => {
+  it("adopts the schema version marker for already-current schema", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "current.sqlite");
+    const initial = initDatabase(dbPath);
+    initial.pragma("user_version = 0");
+    initial.close();
+
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(1);
+
+    reopened.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects unsupported legacy account schemas", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -32,150 +47,10 @@ describe("account timezone/locale defaults", () => {
         date_time_locale TEXT
       );
     `);
-    legacy.prepare("INSERT INTO accounts (id, username, timezone, date_time_locale) VALUES (?, ?, ?, ?)")
-      .run("u1", "user1", null, null);
     legacy.close();
 
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare("SELECT timezone, date_time_locale FROM accounts WHERE id = ?").get("u1") as {
-      timezone: string;
-      date_time_locale: string;
-    };
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
 
-    expect(row.timezone).toBe("system");
-    expect(row.date_time_locale).toBe("system");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("preserves explicit legacy timezone/locale values", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE accounts (
-        id TEXT PRIMARY KEY,
-        username TEXT NOT NULL UNIQUE,
-        timezone TEXT,
-        date_time_locale TEXT
-      );
-    `);
-    legacy.prepare("INSERT INTO accounts (id, username, timezone, date_time_locale) VALUES (?, ?, ?, ?)")
-      .run("u1", "user1", "Europe/Vienna", "en-GB");
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare("SELECT timezone, date_time_locale FROM accounts WHERE id = ?").get("u1") as {
-      timezone: string;
-      date_time_locale: string;
-    };
-
-    expect(row.timezone).toBe("Europe/Vienna");
-    expect(row.date_time_locale).toBe("en-GB");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("normalizes legacy column defaults for future inserts", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE accounts (
-        id TEXT PRIMARY KEY,
-        username TEXT NOT NULL UNIQUE,
-        account_type TEXT NOT NULL DEFAULT 'person',
-        display_name TEXT,
-        bio TEXT,
-        avatar_url TEXT,
-        password_hash TEXT,
-        private_key TEXT,
-        public_key TEXT,
-        is_bot INTEGER NOT NULL DEFAULT 0,
-        discoverable INTEGER NOT NULL DEFAULT 0,
-        timezone TEXT NOT NULL DEFAULT 'Europe/Vienna',
-        date_time_locale TEXT NOT NULL DEFAULT 'en-GB',
-        default_event_visibility TEXT NOT NULL DEFAULT 'public',
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-        website TEXT,
-        city TEXT NOT NULL DEFAULT 'Wien',
-        city_lat REAL NOT NULL DEFAULT 48.2082,
-        city_lng REAL NOT NULL DEFAULT 16.3738,
-        email TEXT,
-        email_verified INTEGER NOT NULL DEFAULT 0,
-        email_verified_at TEXT,
-        preferred_language TEXT DEFAULT 'en'
-      );
-    `);
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    migrated.prepare("INSERT INTO accounts (id, username) VALUES (?, ?)").run("u2", "user2");
-    const row = migrated.prepare("SELECT timezone, date_time_locale FROM accounts WHERE id = ?").get("u2") as {
-      timezone: string;
-      date_time_locale: string;
-    };
-
-    expect(row.timezone).toBe("system");
-    expect(row.date_time_locale).toBe("system");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("preserves and normalizes theme_preference during legacy accounts rebuild", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE accounts (
-        id TEXT PRIMARY KEY,
-        username TEXT NOT NULL UNIQUE,
-        account_type TEXT NOT NULL DEFAULT 'person',
-        display_name TEXT,
-        bio TEXT,
-        avatar_url TEXT,
-        password_hash TEXT,
-        private_key TEXT,
-        public_key TEXT,
-        is_bot INTEGER NOT NULL DEFAULT 0,
-        discoverable INTEGER NOT NULL DEFAULT 0,
-        timezone TEXT NOT NULL DEFAULT 'Europe/Vienna',
-        date_time_locale TEXT NOT NULL DEFAULT 'en-GB',
-        theme_preference TEXT NOT NULL DEFAULT 'system',
-        default_event_visibility TEXT NOT NULL DEFAULT 'public',
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-        website TEXT,
-        city TEXT NOT NULL DEFAULT 'Wien',
-        city_lat REAL NOT NULL DEFAULT 48.2082,
-        city_lng REAL NOT NULL DEFAULT 16.3738,
-        email TEXT,
-        email_verified INTEGER NOT NULL DEFAULT 0,
-        email_verified_at TEXT,
-        preferred_language TEXT DEFAULT 'en'
-      );
-    `);
-    legacy.prepare("INSERT INTO accounts (id, username, theme_preference) VALUES (?, ?, ?)")
-      .run("u1", "user1", "dark");
-    legacy.prepare("INSERT INTO accounts (id, username, theme_preference) VALUES (?, ?, ?)")
-      .run("u2", "user2", "AUTO");
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const rows = migrated
-      .prepare("SELECT id, theme_preference FROM accounts WHERE id IN (?, ?) ORDER BY id")
-      .all("u1", "u2") as Array<{ id: string; theme_preference: string }>;
-
-    expect(rows).toEqual([
-      { id: "u1", theme_preference: "dark" },
-      { id: "u2", theme_preference: "system" },
-    ]);
-
-    migrated.close();
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -36,7 +36,7 @@ describe("account timezone/locale defaults", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("rejects unsupported legacy account schemas", () => {
+  it("assumes legacy account schemas are current and marks schema version", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -50,12 +50,15 @@ describe("account timezone/locale defaults", () => {
     `);
     legacy.close();
 
-    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    reopened.close();
 
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("rejects calendar_feed_tokens schemas missing token column", () => {
+  it("assumes calendar_feed_tokens schemas missing token are current", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy-calendar-feed-tokens.sqlite");
     const db = initDatabase(dbPath);
@@ -72,12 +75,15 @@ describe("account timezone/locale defaults", () => {
     `);
     db.close();
 
-    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    reopened.close();
 
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("rejects event_rsvps data containing legacy statuses", () => {
+  it("assumes legacy event_rsvps status values are current", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy-event-rsvps-status.sqlite");
     const db = initDatabase(dbPath);
@@ -97,7 +103,10 @@ describe("account timezone/locale defaults", () => {
       .run("u1", "event:1", "interested");
     db.close();
 
-    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    reopened.close();
 
     rmSync(dir, { recursive: true, force: true });
   });

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -53,4 +53,51 @@ describe("account timezone/locale defaults", () => {
 
     rmSync(dir, { recursive: true, force: true });
   });
+
+  it("rejects calendar_feed_tokens schemas missing token column", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "legacy-calendar-feed-tokens.sqlite");
+    const db = initDatabase(dbPath);
+    db.exec(`
+      CREATE TABLE calendar_feed_tokens_new (
+        account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+        token_hash TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      INSERT INTO calendar_feed_tokens_new (account_id, token_hash, created_at)
+      SELECT account_id, token, created_at FROM calendar_feed_tokens;
+      DROP TABLE calendar_feed_tokens;
+      ALTER TABLE calendar_feed_tokens_new RENAME TO calendar_feed_tokens;
+    `);
+    db.close();
+
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects event_rsvps data containing legacy statuses", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "legacy-event-rsvps-status.sqlite");
+    const db = initDatabase(dbPath);
+    db.prepare("INSERT INTO accounts (id, username) VALUES (?, ?)").run("u1", "user1");
+    db.exec(`
+      CREATE TABLE event_rsvps_new (
+        account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+        event_uri TEXT NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (account_id, event_uri)
+      );
+      DROP TABLE event_rsvps;
+      ALTER TABLE event_rsvps_new RENAME TO event_rsvps;
+    `);
+    db.prepare("INSERT INTO event_rsvps (account_id, event_uri, status) VALUES (?, ?, ?)")
+      .run("u1", "event:1", "interested");
+    db.close();
+
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+
+    rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { initDatabase } from "../src/db.js";
+import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
 
 describe("account timezone/locale defaults", () => {
   it("defaults new accounts to system timezone, locale, and theme", () => {
@@ -29,7 +30,7 @@ describe("account timezone/locale defaults", () => {
 
     const reopened = initDatabase(dbPath);
     const userVersion = reopened.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(1);
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
 
     reopened.close();
     rmSync(dir, { recursive: true, force: true });

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -40,6 +40,7 @@ import { upsertRemoteEvent } from "../src/lib/remote-events.js";
 import { fetchAP, resolveRemoteActor, deliverToFollowers, validateFederationUrl } from "../src/lib/federation.js";
 import { notifyEventUpdated } from "../src/lib/notifications.js";
 import { generateAndSaveOgImage } from "../src/routes/og-images.js";
+import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
 
 const oneYearMs = 365 * 24 * 60 * 60 * 1000;
 
@@ -1161,7 +1162,7 @@ describe("event slug canonical behavior", () => {
 
     const reopened = initDatabase(dbPath);
     const userVersion = reopened.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(1);
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
 
     reopened.close();
     rmSync(dir, { recursive: true, force: true });

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -1152,7 +1152,22 @@ describe("event slug canonical behavior", () => {
     expect(res.status).toBe(404);
   });
 
-  it("migrates existing remote_events table without slug column", () => {
+  it("adopts the schema version marker for an already-current database", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "current.sqlite");
+    const initial = initDatabase(dbPath);
+    initial.pragma("user_version = 0");
+    initial.close();
+
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(1);
+
+    reopened.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("rejects unsupported legacy schemas instead of mutating them at runtime", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -1166,282 +1181,7 @@ describe("event slug canonical behavior", () => {
     `);
     legacy.close();
 
-    const migrated = initDatabase(dbPath);
-    const cols = migrated.prepare("PRAGMA table_info(remote_events)").all() as Array<{ name: string }>;
-    const hasSlug = cols.some((c) => c.name === "slug");
-    const hasStartAtUtc = cols.some((c) => c.name === "start_at_utc");
-    const hasTimezoneQuality = cols.some((c) => c.name === "timezone_quality");
-    expect(hasSlug).toBe(true);
-    expect(hasStartAtUtc).toBe(true);
-    expect(hasTimezoneQuality).toBe(true);
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("normalizes legacy local events to canonical UTC and valid timezone", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-local.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT,
-        external_id TEXT,
-        visibility TEXT,
-        title TEXT,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        all_day INTEGER NOT NULL DEFAULT 0,
-        event_timezone TEXT,
-        created_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      "INSERT INTO events (id, start_date, end_date, all_day, event_timezone, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-    ).run("legacy-1", "not-a-date", null, 0, "Not/AZone", "2024-05-01 10:30:00");
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT start_at_utc, event_timezone, start_on FROM events WHERE id = ?"
-    ).get("legacy-1") as { start_at_utc: string; event_timezone: string; start_on: string };
-
-    expect(row.start_at_utc).toBe("2024-05-01T10:30:00.000Z");
-    expect(row.event_timezone).toBe("UTC");
-    expect(row.start_on).toBe("2024-05-01");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("backfills invalid legacy timezone even when UTC columns already exist", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-local-invalid-tz.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT,
-        external_id TEXT,
-        visibility TEXT,
-        title TEXT,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        all_day INTEGER NOT NULL DEFAULT 0,
-        start_at_utc TEXT,
-        end_at_utc TEXT,
-        event_timezone TEXT,
-        created_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      "INSERT INTO events (id, start_date, end_date, all_day, start_at_utc, end_at_utc, event_timezone, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-    ).run(
-      "legacy-invalid-tz",
-      "2024-05-01T09:00:00",
-      null,
-      0,
-      "2024-05-01T09:00:00.000Z",
-      null,
-      "Not/AZone",
-      "2024-05-01 10:30:00"
-    );
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT event_timezone FROM events WHERE id = ?"
-    ).get("legacy-invalid-tz") as { event_timezone: string };
-
-    expect(row.event_timezone).toBe("UTC");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("backfills end_on from derived UTC when legacy end_date is invalid", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-local-invalid-end.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT,
-        external_id TEXT,
-        visibility TEXT,
-        title TEXT,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        all_day INTEGER NOT NULL DEFAULT 0,
-        event_timezone TEXT,
-        created_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      "INSERT INTO events (id, start_date, end_date, all_day, event_timezone, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-    ).run("legacy-invalid-end", "2024-05-01T09:00:00Z", "not-a-date", 0, "UTC", "2024-05-01 10:30:00");
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT start_at_utc, end_at_utc, end_on FROM events WHERE id = ?"
-    ).get("legacy-invalid-end") as { start_at_utc: string; end_at_utc: string | null; end_on: string | null };
-
-    expect(row.end_at_utc).toBe(row.start_at_utc);
-    expect(row.end_on).toBe("2024-05-01");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("backfills legacy all-day local events with end-exclusive UTC boundary", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-local-all-day.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT,
-        external_id TEXT,
-        visibility TEXT,
-        title TEXT,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        all_day INTEGER NOT NULL DEFAULT 0,
-        event_timezone TEXT,
-        created_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      "INSERT INTO events (id, start_date, end_date, all_day, event_timezone, created_at) VALUES (?, ?, ?, ?, ?, ?)"
-    ).run("legacy-all-day", "2026-08-10", "2026-08-11", 1, "Europe/Vienna", "2026-01-01 10:30:00");
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT start_at_utc, end_at_utc, start_on, end_on FROM events WHERE id = ?"
-    ).get("legacy-all-day") as {
-      start_at_utc: string;
-      end_at_utc: string | null;
-      start_on: string;
-      end_on: string;
-    };
-
-    expect(row.start_at_utc).toBe("2026-08-09T22:00:00.000Z");
-    expect(row.end_at_utc).toBe("2026-08-11T22:00:00.000Z");
-    expect(row.start_on).toBe("2026-08-10");
-    expect(row.end_on).toBe("2026-08-11");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("canonicalizes legacy remote event UTC values from absolute start_date", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-remote.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE remote_events (
-        uri TEXT PRIMARY KEY,
-        actor_uri TEXT NOT NULL,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        fetched_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      "INSERT INTO remote_events (uri, actor_uri, title, start_date, fetched_at) VALUES (?, ?, ?, ?, ?)"
-    ).run(
-      "https://remote.example/events/legacy-1",
-      "https://remote.example/users/alice",
-      "Legacy Remote",
-      "2026-03-01T10:00:00+01:00",
-      "2026-01-01 00:00:00"
-    );
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT start_at_utc, event_timezone, timezone_quality FROM remote_events WHERE uri = ?"
-    ).get("https://remote.example/events/legacy-1") as {
-      start_at_utc: string;
-      event_timezone: string | null;
-      timezone_quality: string;
-    };
-
-    expect(row.start_at_utc).toBe("2026-03-01T09:00:00.000Z");
-    expect(row.event_timezone).toBeNull();
-    expect(row.timezone_quality).toBe("offset_only");
-
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("recomputes legacy remote start_on/end_on in event timezone during canonicalization", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-remote-timezone-dateparts.sqlite");
-    const legacy = new Database(dbPath);
-    legacy.exec(`
-      CREATE TABLE remote_events (
-        uri TEXT PRIMARY KEY,
-        actor_uri TEXT NOT NULL,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        end_date TEXT,
-        all_day INTEGER NOT NULL DEFAULT 0,
-        start_at_utc TEXT,
-        end_at_utc TEXT,
-        start_on TEXT,
-        end_on TEXT,
-        event_timezone TEXT,
-        timezone_quality TEXT NOT NULL,
-        fetched_at TEXT NOT NULL
-      );
-    `);
-    legacy.prepare(
-      `INSERT INTO remote_events (
-        uri, actor_uri, title, start_date, end_date, all_day,
-        start_at_utc, end_at_utc, start_on, end_on,
-        event_timezone, timezone_quality, fetched_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    ).run(
-      "https://remote.example/events/legacy-tz-dateparts",
-      "https://remote.example/users/alice",
-      "Legacy TZ Date Parts",
-      "2026-01-01T00:30:00.000Z",
-      "2026-01-01T01:30:00.000Z",
-      0,
-      "2026-01-01T00:30:00.000Z",
-      "2025-12-31T23:30:00.000Z",
-      "2026-01-01",
-      "2026-01-01",
-      "America/Los_Angeles",
-      "exact_tzid",
-      "2026-01-01 00:00:00"
-    );
-    legacy.close();
-
-    const migrated = initDatabase(dbPath);
-    const row = migrated.prepare(
-      "SELECT start_at_utc, end_at_utc, start_on, end_on, event_timezone, timezone_quality FROM remote_events WHERE uri = ?"
-    ).get("https://remote.example/events/legacy-tz-dateparts") as {
-      start_at_utc: string;
-      end_at_utc: string;
-      start_on: string;
-      end_on: string;
-      event_timezone: string | null;
-      timezone_quality: string;
-    };
-
-    expect(row.start_at_utc).toBe("2026-01-01T00:30:00.000Z");
-    expect(row.end_at_utc).toBe("2026-01-01T01:30:00.000Z");
-    expect(row.event_timezone).toBe("America/Los_Angeles");
-    expect(row.timezone_quality).toBe("exact_tzid");
-    expect(row.start_on).toBe("2025-12-31");
-    expect(row.end_on).toBe("2025-12-31");
-
-    migrated.close();
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -1168,7 +1168,7 @@ describe("event slug canonical behavior", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("rejects unsupported legacy schemas instead of mutating them at runtime", () => {
+  it("assumes unsupported legacy schemas are current and marks schema version", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -1182,7 +1182,10 @@ describe("event slug canonical behavior", () => {
     `);
     legacy.close();
 
-    expect(() => initDatabase(dbPath)).toThrow(/Unsupported legacy database schema/i);
+    const reopened = initDatabase(dbPath);
+    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    reopened.close();
     rmSync(dir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary
- Remove `schemaLooksLikeCurrentBaseline()` and all related runtime schema-shape validation from `packages/server/src/db.ts`.
- Simplify startup behavior for unversioned databases that already have user tables: we now directly set `PRAGMA user_version` to the current schema version.
- Keep migrations focused on forward version upgrades (`user_version < CURRENT_SCHEMA_VERSION`) and fresh database bootstrap.

## Why
We are intentionally assuming our only current instance is already on the expected baseline. This PR removes legacy runtime verification paths so schema checks/migrations can evolve from this baseline onward in future PRs.

## Validation
- `pnpm --filter @everycal/server lint`