### PR TITLE
fix: lock down OG image generation and remove public trigger route

### DIFF
--- a/packages/og/src/og-image.test.ts
+++ b/packages/og/src/og-image.test.ts
@@ -144,10 +144,11 @@ describe("generateOgImage", () => {
   });
 
   it("composites header image when fetch succeeds", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       arrayBuffer: async () => Uint8Array.from([1, 2, 3]).buffer,
-    }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
 
     const buffer = await generateOgImage({
       event: buildEvent({
@@ -157,6 +158,10 @@ describe("generateOgImage", () => {
     });
 
     expect(buffer).toEqual(Buffer.from("final-png"));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/header.jpg",
+      expect.objectContaining({ redirect: "error" }),
+    );
   });
 
   it("formats timed events using event timezone", async () => {

--- a/packages/og/src/og-image.ts
+++ b/packages/og/src/og-image.ts
@@ -18,7 +18,10 @@ async function fetchWithTimeout(url: string, ms: number): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), ms);
   try {
-    return await fetch(url, { signal: controller.signal });
+    return await fetch(url, {
+      signal: controller.signal,
+      redirect: "error",
+    });
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -343,6 +343,16 @@ export const MIGRATIONS: Migration[] = [
       db.exec(BASELINE_SCHEMA_SQL);
     },
   },
+  {
+    version: 2,
+    name: "remote_events_og_image_url",
+    up: (db) => {
+      const columns = db.prepare("PRAGMA table_info(remote_events)").all() as Array<{ name: string }>;
+      if (!columns.some((column) => column.name === "og_image_url")) {
+        db.exec("ALTER TABLE remote_events ADD COLUMN og_image_url TEXT");
+      }
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -35,7 +35,6 @@ import { locationRoutes } from "./routes/locations.js";
 import { imageRoutes } from "./routes/images.js";
 import { serveUploadsRoutes } from "./routes/serve-uploads.js";
 import { serveOgImagesRoutes } from "./routes/serve-og-images.js";
-import { ogImageRoutes } from "./routes/og-images.js";
 import { cleanupExpiredSessions } from "./middleware/auth.js";
 import { getLocale, t } from "./lib/i18n.js";
 import { DATABASE_PATH } from "./lib/paths.js";
@@ -160,7 +159,6 @@ app.route("/api/v1/uploads", uploadRoutes());
 app.route("/api/v1/locations", locationRoutes(db));
 app.route("/api/v1/images", imageRoutes());
 app.route("/api/v1/federation", federationRoutes(db));
-app.route("/api/v1/og-images", ogImageRoutes(db));
 
 // ActivityPub / WebFinger / NodeInfo
 app.route("/.well-known", wellKnownRoutes(db));

--- a/packages/server/src/lib/event-serializers.ts
+++ b/packages/server/src/lib/event-serializers.ts
@@ -103,6 +103,7 @@ export function serializeRemoteEvent(row: Record<string, unknown>): Record<strin
           attribution: parseImageAttribution(row.image_attribution),
         }
       : null,
+    ogImageUrl: row.og_image_url || null,
     url: row.url,
     tags: row.tags ? (row.tags as string).split(",") : [],
     visibility: "public",

--- a/packages/server/src/lib/og-job-queue.ts
+++ b/packages/server/src/lib/og-job-queue.ts
@@ -1,0 +1,157 @@
+type OgJob = {
+  key: string;
+  run: () => Promise<void>;
+};
+
+const parsedConcurrency = Number.parseInt(process.env.OG_JOB_CONCURRENCY || "3", 10);
+let concurrency = Number.isFinite(parsedConcurrency) && parsedConcurrency > 0 ? parsedConcurrency : 3;
+
+const pendingJobsByKey = new Map<string, OgJob>();
+const pendingOrder: string[] = [];
+const deferredJobsByKey = new Map<string, OgJob>();
+
+let activeJobs = 0;
+let coalescedJobs = 0;
+let draining = false;
+let lastDepthLog = 0;
+
+function queueDepth(): number {
+  return activeJobs + pendingJobsByKey.size + deferredJobsByKey.size;
+}
+
+function logQueueDepthIfNeeded(): void {
+  const depth = queueDepth();
+  const threshold = 10;
+
+  if (depth >= threshold && depth !== lastDepthLog) {
+    console.warn(
+      `[OG] Queue depth ${depth} (active=${activeJobs}, pending=${pendingJobsByKey.size}, deferred=${deferredJobsByKey.size}, coalesced=${coalescedJobs})`
+    );
+    lastDepthLog = depth;
+  } else if (depth < threshold) {
+    lastDepthLog = 0;
+  }
+}
+
+function logCoalescingIfNeeded(): void {
+  if (coalescedJobs > 0 && coalescedJobs % 25 === 0) {
+    console.warn(`[OG] Coalesced ${coalescedJobs} OG jobs so far`);
+  }
+}
+
+function queuePendingJob(job: OgJob): void {
+  if (!pendingJobsByKey.has(job.key)) {
+    pendingOrder.push(job.key);
+  }
+  pendingJobsByKey.set(job.key, job);
+}
+
+function scheduleDrain(): void {
+  if (draining) return;
+  draining = true;
+  queueMicrotask(runDrain);
+}
+
+function runDrain(): void {
+  draining = false;
+
+  while (activeJobs < concurrency) {
+    let nextKey: string | undefined;
+    while (pendingOrder.length > 0) {
+      const key = pendingOrder.shift();
+      if (!key) continue;
+      if (pendingJobsByKey.has(key)) {
+        nextKey = key;
+        break;
+      }
+    }
+
+    if (!nextKey) {
+      logQueueDepthIfNeeded();
+      return;
+    }
+
+    const nextJob = pendingJobsByKey.get(nextKey);
+    if (!nextJob) continue;
+
+    pendingJobsByKey.delete(nextKey);
+    activeJobs += 1;
+
+    void nextJob
+      .run()
+      .catch((err) => {
+        console.error(`[OG] Queued OG job failed for key ${nextKey}:`, err);
+      })
+      .finally(() => {
+        activeJobs -= 1;
+        const deferred = deferredJobsByKey.get(nextKey);
+        if (deferred) {
+          deferredJobsByKey.delete(nextKey);
+          queuePendingJob(deferred);
+        }
+        logQueueDepthIfNeeded();
+        scheduleDrain();
+      });
+  }
+
+  logQueueDepthIfNeeded();
+}
+
+export function enqueueOgJob(key: string, run: () => Promise<void>): void {
+  const job: OgJob = { key, run };
+
+  if (pendingJobsByKey.has(key)) {
+    pendingJobsByKey.set(key, job);
+    coalescedJobs += 1;
+    logCoalescingIfNeeded();
+  } else if (deferredJobsByKey.has(key)) {
+    deferredJobsByKey.set(key, job);
+    coalescedJobs += 1;
+    logCoalescingIfNeeded();
+  } else {
+    queuePendingJob(job);
+  }
+
+  logQueueDepthIfNeeded();
+  scheduleDrain();
+}
+
+export function getOgJobQueueStats(): {
+  active: number;
+  pending: number;
+  deferred: number;
+  coalesced: number;
+  depth: number;
+  concurrency: number;
+} {
+  return {
+    active: activeJobs,
+    pending: pendingJobsByKey.size,
+    deferred: deferredJobsByKey.size,
+    coalesced: coalescedJobs,
+    depth: queueDepth(),
+    concurrency,
+  };
+}
+
+export function __resetOgJobQueueForTests(): void {
+  pendingJobsByKey.clear();
+  pendingOrder.length = 0;
+  deferredJobsByKey.clear();
+  activeJobs = 0;
+  coalescedJobs = 0;
+  draining = false;
+  lastDepthLog = 0;
+}
+
+export function __setOgJobQueueConcurrencyForTests(value: number): void {
+  concurrency = Math.max(1, Math.floor(value));
+}
+
+export async function __waitForOgJobQueueIdleForTests(): Promise<void> {
+  while (queueDepth() > 0 || draining) {
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 1);
+    });
+  }
+}

--- a/packages/server/src/lib/og-job-queue.ts
+++ b/packages/server/src/lib/og-job-queue.ts
@@ -1,6 +1,6 @@
 type OgJob = {
   key: string;
-  run: () => Promise<void>;
+  run: () => void | Promise<void>;
 };
 
 const parsedConcurrency = Number.parseInt(process.env.OG_JOB_CONCURRENCY || "3", 10);
@@ -79,8 +79,8 @@ function runDrain(): void {
     activeJobs += 1;
     activeKeys.add(nextKey);
 
-    void nextJob
-      .run()
+    void Promise.resolve()
+      .then(() => nextJob.run())
       .catch((err) => {
         console.error(`[OG] Queued OG job failed for key ${nextKey}:`, err);
       })
@@ -100,7 +100,7 @@ function runDrain(): void {
   logQueueDepthIfNeeded();
 }
 
-export function enqueueOgJob(key: string, run: () => Promise<void>): void {
+export function enqueueOgJob(key: string, run: () => void | Promise<void>): void {
   const job: OgJob = { key, run };
 
   if (pendingJobsByKey.has(key)) {

--- a/packages/server/src/lib/og-job-queue.ts
+++ b/packages/server/src/lib/og-job-queue.ts
@@ -8,6 +8,7 @@ let concurrency = Number.isFinite(parsedConcurrency) && parsedConcurrency > 0 ? 
 
 const pendingJobsByKey = new Map<string, OgJob>();
 const pendingOrder: string[] = [];
+let pendingHead = 0;
 const deferredJobsByKey = new Map<string, OgJob>();
 const activeKeys = new Set<string>();
 
@@ -47,6 +48,13 @@ function queuePendingJob(job: OgJob): void {
   pendingJobsByKey.set(job.key, job);
 }
 
+function compactPendingOrderIfNeeded(): void {
+  if (pendingHead > 1024 && pendingHead > pendingOrder.length / 2) {
+    pendingOrder.splice(0, pendingHead);
+    pendingHead = 0;
+  }
+}
+
 function scheduleDrain(): void {
   if (draining) return;
   draining = true;
@@ -58,14 +66,17 @@ function runDrain(): void {
 
   while (activeJobs < concurrency) {
     let nextKey: string | undefined;
-    while (pendingOrder.length > 0) {
-      const key = pendingOrder.shift();
+    while (pendingHead < pendingOrder.length) {
+      const key = pendingOrder[pendingHead];
+      pendingHead += 1;
       if (!key) continue;
       if (pendingJobsByKey.has(key)) {
         nextKey = key;
         break;
       }
     }
+
+    compactPendingOrderIfNeeded();
 
     if (!nextKey) {
       logQueueDepthIfNeeded();
@@ -140,6 +151,7 @@ export function getOgJobQueueStats(): {
 export function __resetOgJobQueueForTests(): void {
   pendingJobsByKey.clear();
   pendingOrder.length = 0;
+  pendingHead = 0;
   deferredJobsByKey.clear();
   activeKeys.clear();
   activeJobs = 0;

--- a/packages/server/src/lib/og-job-queue.ts
+++ b/packages/server/src/lib/og-job-queue.ts
@@ -9,6 +9,7 @@ let concurrency = Number.isFinite(parsedConcurrency) && parsedConcurrency > 0 ? 
 const pendingJobsByKey = new Map<string, OgJob>();
 const pendingOrder: string[] = [];
 const deferredJobsByKey = new Map<string, OgJob>();
+const activeKeys = new Set<string>();
 
 let activeJobs = 0;
 let coalescedJobs = 0;
@@ -76,6 +77,7 @@ function runDrain(): void {
 
     pendingJobsByKey.delete(nextKey);
     activeJobs += 1;
+    activeKeys.add(nextKey);
 
     void nextJob
       .run()
@@ -84,6 +86,7 @@ function runDrain(): void {
       })
       .finally(() => {
         activeJobs -= 1;
+        activeKeys.delete(nextKey);
         const deferred = deferredJobsByKey.get(nextKey);
         if (deferred) {
           deferredJobsByKey.delete(nextKey);
@@ -104,7 +107,7 @@ export function enqueueOgJob(key: string, run: () => Promise<void>): void {
     pendingJobsByKey.set(key, job);
     coalescedJobs += 1;
     logCoalescingIfNeeded();
-  } else if (deferredJobsByKey.has(key)) {
+  } else if (deferredJobsByKey.has(key) || activeKeys.has(key)) {
     deferredJobsByKey.set(key, job);
     coalescedJobs += 1;
     logCoalescingIfNeeded();
@@ -138,6 +141,7 @@ export function __resetOgJobQueueForTests(): void {
   pendingJobsByKey.clear();
   pendingOrder.length = 0;
   deferredJobsByKey.clear();
+  activeKeys.clear();
   activeJobs = 0;
   coalescedJobs = 0;
   draining = false;

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -653,8 +653,7 @@ function handleCreateUpdate(db: DB, activity: Record<string, unknown>, activityT
   });
 
   if (isRemoteActivityOgEligible(activity, object)) {
-    generateAndSaveRemoteOgImage(db, upserted.uri)
-      .then()
+    void generateAndSaveRemoteOgImage(db, upserted.uri)
       .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
   }
 

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -27,7 +27,7 @@ import { getLocale, t } from "../lib/i18n.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
 import { buildApEventObject, toUtcIsoOrUndefined } from "../lib/activitypub-event.js";
-import { generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
+import { clearRemoteOgImage, generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
 
 const AP_CONTENT_TYPES = [
   "application/activity+json",
@@ -655,6 +655,9 @@ function handleCreateUpdate(db: DB, activity: Record<string, unknown>, activityT
   if (isRemoteActivityOgEligible(activity, object)) {
     void generateAndSaveRemoteOgImage(db, upserted.uri)
       .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+  } else {
+    void clearRemoteOgImage(db, upserted.uri)
+      .catch((err) => console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err));
   }
 
   if (activityType === "Update" && changes.length > 0) {

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -27,6 +27,7 @@ import { getLocale, t } from "../lib/i18n.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
 import { buildApEventObject, toUtcIsoOrUndefined } from "../lib/activitypub-event.js";
+import { generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
 
 const AP_CONTENT_TYPES = [
   "application/activity+json",
@@ -646,10 +647,16 @@ function handleCreateUpdate(db: DB, activity: Record<string, unknown>, activityT
   }
 
 
-  upsertRemoteEvent(db, object, effectiveActor, {
+  const upserted = upsertRemoteEvent(db, object, effectiveActor, {
     clearCanceled: true,
     temporal,
   });
+
+  if (isRemoteActivityOgEligible(activity, object)) {
+    generateAndSaveRemoteOgImage(db, upserted.uri)
+      .then()
+      .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+  }
 
   if (activityType === "Update" && changes.length > 0) {
     const stored = db.prepare(

--- a/packages/server/src/routes/activitypub.ts
+++ b/packages/server/src/routes/activitypub.ts
@@ -24,6 +24,7 @@ import { notifyEventUpdated, notifyEventCancelled } from "../lib/notifications.j
 import { fallbackSlugFromUri } from "../lib/event-links.js";
 import { upsertRemoteEvent } from "../lib/remote-events.js";
 import { getLocale, t } from "../lib/i18n.js";
+import { enqueueOgJob } from "../lib/og-job-queue.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
 import { buildApEventObject, toUtcIsoOrUndefined } from "../lib/activitypub-event.js";
@@ -653,11 +654,21 @@ function handleCreateUpdate(db: DB, activity: Record<string, unknown>, activityT
   });
 
   if (isRemoteActivityOgEligible(activity, object)) {
-    void generateAndSaveRemoteOgImage(db, upserted.uri)
-      .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+    enqueueOgJob(`remote:${upserted.uri}`, async () => {
+      try {
+        await generateAndSaveRemoteOgImage(db, upserted.uri);
+      } catch (err) {
+        console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err);
+      }
+    });
   } else {
-    void clearRemoteOgImage(db, upserted.uri)
-      .catch((err) => console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err));
+    enqueueOgJob(`remote:${upserted.uri}`, async () => {
+      try {
+        await clearRemoteOgImage(db, upserted.uri);
+      } catch (err) {
+        console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err);
+      }
+    });
   }
 
   if (activityType === "Update" && changes.length > 0) {

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -26,7 +26,7 @@ import {
 import { stripHtml, sanitizeHtml } from "../lib/security.js";
 import { isValidVisibility, type EventVisibility } from "@everycal/core";
 import { getLocale, t } from "../lib/i18n.js";
-import { generateAndSaveOgImage, isOgEligibleVisibility } from "./og-images.js";
+import { clearLocalOgImage, generateAndSaveOgImage, isOgEligibleVisibility } from "./og-images.js";
 import { canManageIdentityEvents, listActingAccounts } from "../lib/identities.js";
 import { fetchAP, resolveRemoteActor, validateFederationUrl } from "../lib/federation.js";
 import { uniqueLocalEventSlug, uniqueRemoteEventSlug } from "../lib/slugs.js";
@@ -99,17 +99,6 @@ function formatTimeChangeValue(start: string, end: string | null | undefined): s
 
 function isDateOnly(value: string): boolean {
   return DATE_ONLY.test(value);
-}
-
-function clearLocalOgImageUrlIfSupported(db: DB, eventId: string): void {
-  try {
-    db.prepare("UPDATE events SET og_image_url = NULL WHERE id = ?").run(eventId);
-  } catch (err) {
-    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
-      return;
-    }
-    throw err;
-  }
 }
 
 function deriveStoredDatePart(
@@ -709,6 +698,7 @@ export function eventRoutes(db: DB): Hono {
     let rotatedOutPast = 0;
     let unchanged = 0;
     const ogEventIdsToGenerate = new Set<string>();
+    const ogEventIdsToClear = new Set<string>();
 
     function eventHash(ev: (typeof body.events)[number]): string {
       const data = JSON.stringify([
@@ -885,7 +875,7 @@ export function eventRoutes(db: DB): Hono {
             if (isOgEligibleVisibility(visibility)) {
               ogEventIdsToGenerate.add(existingRow.id);
             } else {
-              clearLocalOgImageUrlIfSupported(db, existingRow.id);
+              ogEventIdsToClear.add(existingRow.id);
             }
 
             deleteTagsStmt.run(existingRow.id);
@@ -956,6 +946,11 @@ export function eventRoutes(db: DB): Hono {
     for (const eventId of ogEventIdsToGenerate) {
       void generateAndSaveOgImage(db, eventId)
         .catch((err) => console.error(`[OG] Failed to create OG image for event ${eventId}:`, err));
+    }
+
+    for (const eventId of ogEventIdsToClear) {
+      await clearLocalOgImage(db, eventId)
+        .catch((err) => console.error(`[OG] Failed to clear OG image for event ${eventId}:`, err));
     }
 
     return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: deduped.length });
@@ -1656,7 +1651,8 @@ export function eventRoutes(db: DB): Hono {
         void generateAndSaveOgImage(db, id)
           .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
       } else {
-        clearLocalOgImageUrlIfSupported(db, id);
+        await clearLocalOgImage(db, id)
+          .catch((err) => console.error(`[OG] Failed to clear OG image for event ${id}:`, err));
       }
     }
 
@@ -1665,7 +1661,7 @@ export function eventRoutes(db: DB): Hono {
 
   // ─── DELETE /:id ────────────────────────────────────────────────────────
 
-  router.delete("/:id", requireAuth(), (c) => {
+  router.delete("/:id", requireAuth(), async (c) => {
     const user = c.get("user")!;
     const id = c.req.param("id");
 
@@ -1696,6 +1692,8 @@ export function eventRoutes(db: DB): Hono {
       });
     }
 
+    await clearLocalOgImage(db, id)
+      .catch((err) => console.error(`[OG] Failed to clear OG image for deleted event ${id}:`, err));
     db.prepare("DELETE FROM events WHERE id = ?").run(id);
 
     const baseUrl = process.env.BASE_URL || "http://localhost:3000";

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -948,9 +948,31 @@ export function eventRoutes(db: DB): Hono {
         .catch((err) => console.error(`[OG] Failed to create OG image for event ${eventId}:`, err));
     }
 
+    const ogClearConcurrency = 3;
+    const pendingOgClearJobs = new Set<Promise<void>>();
+    const scheduleOgClearJob = async (job: () => Promise<void>): Promise<void> => {
+      const task = job().catch((err) => {
+        console.error("[OG] Unexpected local OG clear failure:", err);
+      });
+      pendingOgClearJobs.add(task);
+      task.finally(() => pendingOgClearJobs.delete(task));
+      if (pendingOgClearJobs.size >= ogClearConcurrency) {
+        await Promise.race(pendingOgClearJobs);
+      }
+    };
+
     for (const eventId of ogEventIdsToClear) {
-      await clearLocalOgImage(db, eventId)
-        .catch((err) => console.error(`[OG] Failed to clear OG image for event ${eventId}:`, err));
+      await scheduleOgClearJob(() =>
+        clearLocalOgImage(db, eventId)
+          .then(() => undefined)
+          .catch((err) => {
+            console.error(`[OG] Failed to clear OG image for event ${eventId}:`, err);
+          })
+      );
+    }
+
+    if (pendingOgClearJobs.size > 0) {
+      await Promise.all(pendingOgClearJobs);
     }
 
     return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: deduped.length });

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -943,9 +943,31 @@ export function eventRoutes(db: DB): Hono {
       }
     }
 
+    const ogGenerateConcurrency = 3;
+    const pendingOgGenerateJobs = new Set<Promise<void>>();
+    const scheduleOgGenerateJob = async (job: () => Promise<void>): Promise<void> => {
+      const task = job().catch((err) => {
+        console.error("[OG] Unexpected local OG generation failure:", err);
+      });
+      pendingOgGenerateJobs.add(task);
+      task.finally(() => pendingOgGenerateJobs.delete(task));
+      if (pendingOgGenerateJobs.size >= ogGenerateConcurrency) {
+        await Promise.race(pendingOgGenerateJobs);
+      }
+    };
+
     for (const eventId of ogEventIdsToGenerate) {
-      void generateAndSaveOgImage(db, eventId)
-        .catch((err) => console.error(`[OG] Failed to create OG image for event ${eventId}:`, err));
+      await scheduleOgGenerateJob(() =>
+        generateAndSaveOgImage(db, eventId)
+          .then(() => undefined)
+          .catch((err) => {
+            console.error(`[OG] Failed to create OG image for event ${eventId}:`, err);
+          })
+      );
+    }
+
+    if (pendingOgGenerateJobs.size > 0) {
+      await Promise.all(pendingOgGenerateJobs);
     }
 
     const ogClearConcurrency = 3;

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -954,8 +954,7 @@ export function eventRoutes(db: DB): Hono {
     }
 
     for (const eventId of ogEventIdsToGenerate) {
-      generateAndSaveOgImage(db, eventId)
-        .then()
+      void generateAndSaveOgImage(db, eventId)
         .catch((err) => console.error(`[OG] Failed to create OG image for event ${eventId}:`, err));
     }
 
@@ -1380,8 +1379,7 @@ export function eventRoutes(db: DB): Hono {
     response.rsvpStatus = "going";
 
     if (isOgEligibleVisibility(visibility)) {
-      generateAndSaveOgImage(db, id)
-        .then()
+      void generateAndSaveOgImage(db, id)
         .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
     }
 
@@ -1655,8 +1653,7 @@ export function eventRoutes(db: DB): Hono {
 
     if (ogRelevantFieldsChanged || visibilityChanged) {
       if (shouldHaveOgImage) {
-        generateAndSaveOgImage(db, id)
-          .then()
+        void generateAndSaveOgImage(db, id)
           .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
       } else {
         clearLocalOgImageUrlIfSupported(db, id);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -26,6 +26,7 @@ import {
 import { stripHtml, sanitizeHtml } from "../lib/security.js";
 import { isValidVisibility, type EventVisibility } from "@everycal/core";
 import { getLocale, t } from "../lib/i18n.js";
+import { enqueueOgJob } from "../lib/og-job-queue.js";
 import { clearLocalOgImage, generateAndSaveOgImage, isOgEligibleVisibility } from "./og-images.js";
 import { canManageIdentityEvents, listActingAccounts } from "../lib/identities.js";
 import { fetchAP, resolveRemoteActor, validateFederationUrl } from "../lib/federation.js";
@@ -943,58 +944,24 @@ export function eventRoutes(db: DB): Hono {
       }
     }
 
-    const ogGenerateConcurrency = 3;
-    const pendingOgGenerateJobs = new Set<Promise<void>>();
-    const scheduleOgGenerateJob = async (job: () => Promise<void>): Promise<void> => {
-      const task = job().catch((err) => {
-        console.error("[OG] Unexpected local OG generation failure:", err);
-      });
-      pendingOgGenerateJobs.add(task);
-      task.finally(() => pendingOgGenerateJobs.delete(task));
-      if (pendingOgGenerateJobs.size >= ogGenerateConcurrency) {
-        await Promise.race(pendingOgGenerateJobs);
-      }
-    };
-
     for (const eventId of ogEventIdsToGenerate) {
-      await scheduleOgGenerateJob(() =>
-        generateAndSaveOgImage(db, eventId)
-          .then(() => undefined)
-          .catch((err) => {
-            console.error(`[OG] Failed to create OG image for event ${eventId}:`, err);
-          })
-      );
-    }
-
-    if (pendingOgGenerateJobs.size > 0) {
-      await Promise.all(pendingOgGenerateJobs);
-    }
-
-    const ogClearConcurrency = 3;
-    const pendingOgClearJobs = new Set<Promise<void>>();
-    const scheduleOgClearJob = async (job: () => Promise<void>): Promise<void> => {
-      const task = job().catch((err) => {
-        console.error("[OG] Unexpected local OG clear failure:", err);
+      enqueueOgJob(`local:${eventId}`, async () => {
+        try {
+          await generateAndSaveOgImage(db, eventId);
+        } catch (err) {
+          console.error(`[OG] Failed to create OG image for event ${eventId}:`, err);
+        }
       });
-      pendingOgClearJobs.add(task);
-      task.finally(() => pendingOgClearJobs.delete(task));
-      if (pendingOgClearJobs.size >= ogClearConcurrency) {
-        await Promise.race(pendingOgClearJobs);
-      }
-    };
+    }
 
     for (const eventId of ogEventIdsToClear) {
-      await scheduleOgClearJob(() =>
-        clearLocalOgImage(db, eventId)
-          .then(() => undefined)
-          .catch((err) => {
-            console.error(`[OG] Failed to clear OG image for event ${eventId}:`, err);
-          })
-      );
-    }
-
-    if (pendingOgClearJobs.size > 0) {
-      await Promise.all(pendingOgClearJobs);
+      enqueueOgJob(`local:${eventId}`, async () => {
+        try {
+          await clearLocalOgImage(db, eventId);
+        } catch (err) {
+          console.error(`[OG] Failed to clear OG image for event ${eventId}:`, err);
+        }
+      });
     }
 
     return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: deduped.length });

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -26,7 +26,7 @@ import {
 import { stripHtml, sanitizeHtml } from "../lib/security.js";
 import { isValidVisibility, type EventVisibility } from "@everycal/core";
 import { getLocale, t } from "../lib/i18n.js";
-import { generateAndSaveOgImage } from "./og-images.js";
+import { generateAndSaveOgImage, isOgEligibleVisibility } from "./og-images.js";
 import { canManageIdentityEvents, listActingAccounts } from "../lib/identities.js";
 import { fetchAP, resolveRemoteActor, validateFederationUrl } from "../lib/federation.js";
 import { uniqueLocalEventSlug, uniqueRemoteEventSlug } from "../lib/slugs.js";
@@ -99,6 +99,17 @@ function formatTimeChangeValue(start: string, end: string | null | undefined): s
 
 function isDateOnly(value: string): boolean {
   return DATE_ONLY.test(value);
+}
+
+function clearLocalOgImageUrlIfSupported(db: DB, eventId: string): void {
+  try {
+    db.prepare("UPDATE events SET og_image_url = NULL WHERE id = ?").run(eventId);
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+      return;
+    }
+    throw err;
+  }
 }
 
 function deriveStoredDatePart(
@@ -666,7 +677,7 @@ export function eventRoutes(db: DB): Hono {
 
     const existing = db
       .prepare(
-        "SELECT id, slug, external_id, content_hash, title, start_date, end_date, start_at_utc, end_at_utc, event_timezone, all_day, location_name, location_address, url, description, canceled, missing_since FROM events WHERE account_id = ? AND external_id IS NOT NULL"
+        "SELECT id, slug, external_id, content_hash, title, start_date, end_date, start_at_utc, end_at_utc, event_timezone, all_day, location_name, location_address, url, description, visibility, canceled, missing_since FROM events WHERE account_id = ? AND external_id IS NOT NULL"
       )
       .all(user.id) as {
       id: string;
@@ -684,6 +695,7 @@ export function eventRoutes(db: DB): Hono {
       event_timezone: string | null;
       url: string | null;
       description: string | null;
+      visibility: string;
       canceled: number;
       missing_since: string | null;
     }[];
@@ -696,6 +708,7 @@ export function eventRoutes(db: DB): Hono {
     let canceled = 0;
     let rotatedOutPast = 0;
     let unchanged = 0;
+    const ogEventIdsToGenerate = new Set<string>();
 
     function eventHash(ev: (typeof body.events)[number]): string {
       const data = JSON.stringify([
@@ -805,6 +818,9 @@ export function eventRoutes(db: DB): Hono {
               if (existingRow.canceled || existingRow.missing_since) {
                 restoreEventState.run(existingRow.id);
               }
+              if (isOgEligibleVisibility(visibility)) {
+                ogEventIdsToGenerate.add(existingRow.id);
+              }
               unchanged++;
               continue;
             }
@@ -869,6 +885,12 @@ export function eventRoutes(db: DB): Hono {
               ev.url || null, visibility, hash, existingRow.id,
             );
 
+            if (isOgEligibleVisibility(visibility)) {
+              ogEventIdsToGenerate.add(existingRow.id);
+            } else {
+              clearLocalOgImageUrlIfSupported(db, existingRow.id);
+            }
+
             deleteTagsStmt.run(existingRow.id);
             if (ev.tags) {
               for (const tag of ev.tags) insertTagStmt.run(existingRow.id, tag.trim());
@@ -915,6 +937,10 @@ export function eventRoutes(db: DB): Hono {
               ev.url || null, visibility, hash,
             );
 
+            if (isOgEligibleVisibility(visibility)) {
+              ogEventIdsToGenerate.add(id);
+            }
+
             if (ev.tags) {
               for (const tag of ev.tags) insertTagStmt.run(id, tag.trim());
             }
@@ -928,6 +954,12 @@ export function eventRoutes(db: DB): Hono {
       if (i + BATCH_SIZE < deduped.length) {
         await yieldToEventLoop();
       }
+    }
+
+    for (const eventId of ogEventIdsToGenerate) {
+      generateAndSaveOgImage(db, eventId)
+        .then()
+        .catch((err) => console.error(`[OG] Failed to create OG image for event ${eventId}:`, err));
     }
 
     return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: deduped.length });
@@ -1350,9 +1382,11 @@ export function eventRoutes(db: DB): Hono {
     if (!response) return c.json({ error: t(getLocale(c), "events.event_not_found_after_create") }, 500);
     response.rsvpStatus = "going";
 
-    generateAndSaveOgImage(db, id)
-      .then()
-      .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
+    if (isOgEligibleVisibility(visibility)) {
+      generateAndSaveOgImage(db, id)
+        .then()
+        .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
+    }
 
     return c.json(response, 201);
   });
@@ -1613,16 +1647,23 @@ export function eventRoutes(db: DB): Hono {
     const updated = readLocalEventById(id);
     if (!updated) return c.json({ error: t(getLocale(c), "events.event_not_found_after_update") }, 500);
 
+    const nextVisibility = body.visibility ?? existing.visibility;
+    const visibilityChanged = nextVisibility !== existing.visibility;
+    const shouldHaveOgImage = isOgEligibleVisibility(nextVisibility);
     const ogRelevantFieldsChanged =
       titleChanged ||
       timeChanged ||
       locationChanged ||
       body.image !== undefined;
 
-    if (ogRelevantFieldsChanged) {
-      generateAndSaveOgImage(db, id)
-        .then()
-        .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
+    if (ogRelevantFieldsChanged || visibilityChanged) {
+      if (shouldHaveOgImage) {
+        generateAndSaveOgImage(db, id)
+          .then()
+          .catch((err) => console.error(`[OG] Failed to create OG image for event ${id}:`, err));
+      } else {
+        clearLocalOgImageUrlIfSupported(db, id);
+      }
     }
 
     return c.json(updated);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -818,9 +818,6 @@ export function eventRoutes(db: DB): Hono {
               if (existingRow.canceled || existingRow.missing_since) {
                 restoreEventState.run(existingRow.id);
               }
-              if (isOgEligibleVisibility(visibility)) {
-                ogEventIdsToGenerate.add(existingRow.id);
-              }
               unchanged++;
               continue;
             }

--- a/packages/server/src/routes/federation-api.ts
+++ b/packages/server/src/routes/federation-api.ts
@@ -29,6 +29,7 @@ import { upsertRemoteEvent } from "../lib/remote-events.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { buildDateRangeFilter, DateQueryParamError, parseDateRangeParams } from "../lib/date-query.js";
 import { serializeRemoteEvent } from "../lib/event-serializers.js";
+import { enqueueOgJob } from "../lib/og-job-queue.js";
 import { clearRemoteOgImage, generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
 import {
   ActorSelectionPayloadError,
@@ -169,19 +170,6 @@ export function federationRoutes(db: DB): Hono {
     try {
       const items = await fetchRemoteOutbox(actor.outbox);
       let imported = 0;
-      const ogConcurrency = 3;
-      const pendingOgJobs = new Set<Promise<void>>();
-
-      const scheduleOgJob = async (job: () => Promise<void>): Promise<void> => {
-        const task = job().catch((err) => {
-          console.error("[OG] Unexpected remote OG job failure:", err);
-        });
-        pendingOgJobs.add(task);
-        task.finally(() => pendingOgJobs.delete(task));
-        if (pendingOgJobs.size >= ogConcurrency) {
-          await Promise.race(pendingOgJobs);
-        }
-      };
 
       for (const item of items) {
         // Outbox items may be full activities or URL references — resolve if needed
@@ -235,27 +223,23 @@ export function federationRoutes(db: DB): Hono {
         if (!temporal) continue;
         const upserted = upsertRemoteEvent(db, fullObj, actor.uri, { temporal });
         if (isRemoteActivityOgEligible(activity, fullObj)) {
-          await scheduleOgJob(() =>
-            generateAndSaveRemoteOgImage(db, upserted.uri)
-              .then(() => undefined)
-              .catch((err) => {
-                console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err);
-              })
-          );
+          enqueueOgJob(`remote:${upserted.uri}`, async () => {
+            try {
+              await generateAndSaveRemoteOgImage(db, upserted.uri);
+            } catch (err) {
+              console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err);
+            }
+          });
         } else {
-          await scheduleOgJob(() =>
-            clearRemoteOgImage(db, upserted.uri)
-              .then(() => undefined)
-              .catch((err) => {
-                console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err);
-              })
-          );
+          enqueueOgJob(`remote:${upserted.uri}`, async () => {
+            try {
+              await clearRemoteOgImage(db, upserted.uri);
+            } catch (err) {
+              console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err);
+            }
+          });
         }
         imported++;
-      }
-
-      if (pendingOgJobs.size > 0) {
-        await Promise.all(pendingOgJobs);
       }
 
       return c.json({ ok: true, imported, total: items.length });

--- a/packages/server/src/routes/federation-api.ts
+++ b/packages/server/src/routes/federation-api.ts
@@ -169,6 +169,19 @@ export function federationRoutes(db: DB): Hono {
     try {
       const items = await fetchRemoteOutbox(actor.outbox);
       let imported = 0;
+      const ogConcurrency = 3;
+      const pendingOgJobs = new Set<Promise<void>>();
+
+      const scheduleOgJob = async (job: () => Promise<void>): Promise<void> => {
+        const task = job().catch((err) => {
+          console.error("[OG] Unexpected remote OG job failure:", err);
+        });
+        pendingOgJobs.add(task);
+        task.finally(() => pendingOgJobs.delete(task));
+        if (pendingOgJobs.size >= ogConcurrency) {
+          await Promise.race(pendingOgJobs);
+        }
+      };
 
       for (const item of items) {
         // Outbox items may be full activities or URL references — resolve if needed
@@ -222,13 +235,27 @@ export function federationRoutes(db: DB): Hono {
         if (!temporal) continue;
         const upserted = upsertRemoteEvent(db, fullObj, actor.uri, { temporal });
         if (isRemoteActivityOgEligible(activity, fullObj)) {
-          void generateAndSaveRemoteOgImage(db, upserted.uri)
-            .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+          await scheduleOgJob(() =>
+            generateAndSaveRemoteOgImage(db, upserted.uri)
+              .then(() => undefined)
+              .catch((err) => {
+                console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err);
+              })
+          );
         } else {
-          void clearRemoteOgImage(db, upserted.uri)
-            .catch((err) => console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err));
+          await scheduleOgJob(() =>
+            clearRemoteOgImage(db, upserted.uri)
+              .then(() => undefined)
+              .catch((err) => {
+                console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err);
+              })
+          );
         }
         imported++;
+      }
+
+      if (pendingOgJobs.size > 0) {
+        await Promise.all(pendingOgJobs);
       }
 
       return c.json({ ok: true, imported, total: items.length });

--- a/packages/server/src/routes/federation-api.ts
+++ b/packages/server/src/routes/federation-api.ts
@@ -222,8 +222,7 @@ export function federationRoutes(db: DB): Hono {
         if (!temporal) continue;
         const upserted = upsertRemoteEvent(db, fullObj, actor.uri, { temporal });
         if (isRemoteActivityOgEligible(activity, fullObj)) {
-          generateAndSaveRemoteOgImage(db, upserted.uri)
-            .then()
+          void generateAndSaveRemoteOgImage(db, upserted.uri)
             .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
         }
         imported++;

--- a/packages/server/src/routes/federation-api.ts
+++ b/packages/server/src/routes/federation-api.ts
@@ -29,6 +29,7 @@ import { upsertRemoteEvent } from "../lib/remote-events.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { buildDateRangeFilter, DateQueryParamError, parseDateRangeParams } from "../lib/date-query.js";
 import { serializeRemoteEvent } from "../lib/event-serializers.js";
+import { generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
 import {
   ActorSelectionPayloadError,
   buildActorSelectionPlan,
@@ -219,7 +220,12 @@ export function federationRoutes(db: DB): Hono {
 
         const temporal = normalizeApTemporal(fullObj);
         if (!temporal) continue;
-        upsertRemoteEvent(db, fullObj, actor.uri, { temporal });
+        const upserted = upsertRemoteEvent(db, fullObj, actor.uri, { temporal });
+        if (isRemoteActivityOgEligible(activity, fullObj)) {
+          generateAndSaveRemoteOgImage(db, upserted.uri)
+            .then()
+            .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+        }
         imported++;
       }
 

--- a/packages/server/src/routes/federation-api.ts
+++ b/packages/server/src/routes/federation-api.ts
@@ -29,7 +29,7 @@ import { upsertRemoteEvent } from "../lib/remote-events.js";
 import { normalizeApTemporal } from "../lib/timezone.js";
 import { buildDateRangeFilter, DateQueryParamError, parseDateRangeParams } from "../lib/date-query.js";
 import { serializeRemoteEvent } from "../lib/event-serializers.js";
-import { generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
+import { clearRemoteOgImage, generateAndSaveRemoteOgImage, isRemoteActivityOgEligible } from "./og-images.js";
 import {
   ActorSelectionPayloadError,
   buildActorSelectionPlan,
@@ -224,6 +224,9 @@ export function federationRoutes(db: DB): Hono {
         if (isRemoteActivityOgEligible(activity, fullObj)) {
           void generateAndSaveRemoteOgImage(db, upserted.uri)
             .catch((err) => console.error(`[OG] Failed to create remote OG image for event ${upserted.uri}:`, err));
+        } else {
+          void clearRemoteOgImage(db, upserted.uri)
+            .catch((err) => console.error(`[OG] Failed to clear remote OG image for event ${upserted.uri}:`, err));
         }
         imported++;
       }

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -111,8 +111,8 @@ export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<s
       ? {
           name: event.location_name,
           address: event.location_address || undefined,
-          latitude: event.location_latitude || undefined,
-          longitude: event.location_longitude || undefined,
+          latitude: event.location_latitude ?? undefined,
+          longitude: event.location_longitude ?? undefined,
           url: event.location_url || undefined,
         }
       : undefined,
@@ -220,8 +220,8 @@ export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Pr
       ? {
           name: event.location_name,
           address: event.location_address || undefined,
-          latitude: event.location_latitude || undefined,
-          longitude: event.location_longitude || undefined,
+          latitude: event.location_latitude ?? undefined,
+          longitude: event.location_longitude ?? undefined,
         }
       : undefined,
     image: event.image_url

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -11,6 +11,7 @@ import { normalizeEventTimezone } from "../lib/event-timezone.js";
 import { validateFederationUrl } from "../lib/federation.js";
 
 const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
+const REMOTE_OG_FILENAME_RE = /^remote-[a-f0-9]{64}\.png$/;
 
 function normalizeRecipients(input: unknown): string[] {
   if (typeof input === "string") return [input];
@@ -75,6 +76,7 @@ function remoteOgFilenameFromUrl(ogImageUrl: string): string | null {
   if (!path.startsWith(prefix)) return null;
   const filename = path.slice(prefix.length);
   if (!filename || filename.includes("/") || filename.includes("\\")) return null;
+  if (!REMOTE_OG_FILENAME_RE.test(filename)) return null;
   return filename;
 }
 
@@ -130,6 +132,8 @@ export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void
   if (!ogImageUrl) return;
   const filename = remoteOgFilenameFromUrl(ogImageUrl);
   if (!filename) return;
+  const expectedFilename = getRemoteOgFilename(eventUri);
+  if (filename !== expectedFilename) return;
 
   const { unlink } = await import("node:fs/promises");
   const ogPath = join(OG_DIR, filename);

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -86,7 +86,7 @@ function localOgFilenameFromUrl(ogImageUrl: string, eventId: string): string | n
   if (!path.startsWith(prefix)) return null;
   const filename = path.slice(prefix.length);
   if (!filename || filename.includes("/") || filename.includes("\\")) return null;
-  const expectedFilename = `${eventId}.png`;
+  const expectedFilename = getOgImageFilename(eventId);
   return filename === expectedFilename ? filename : null;
 }
 
@@ -249,7 +249,7 @@ export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<s
   await writeFile(ogPath, ogBuffer);
 
   const version = Math.floor(new Date(event.updated_at).getTime() / 1000);
-  const ogImageUrl = `/og-images/${eventId}.png?v=${version}`;
+  const ogImageUrl = `/og-images/${ogFilename}?v=${version}`;
   updateLocalOgImageUrl(db, eventId, ogImageUrl);
 
   return ogImageUrl;

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -122,9 +122,17 @@ export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> 
 }
 
 export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void> {
-  const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
-    og_image_url: string | null;
-  } | undefined;
+  let row: { og_image_url: string | null } | undefined;
+  try {
+    row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
+      og_image_url: string | null;
+    } | undefined;
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+      return;
+    }
+    throw err;
+  }
 
   updateRemoteOgImageUrl(db, eventUri, null);
 

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -8,6 +8,7 @@ import { generateOgImage, getOgImageFilename } from "@everycal/og";
 import type { DB } from "../db.js";
 import { OG_DIR } from "../lib/paths.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
+import { validateFederationUrl } from "../lib/federation.js";
 
 const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
 
@@ -210,6 +211,20 @@ export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Pr
 
   if (!event || event.canceled) return null;
 
+  let safeImage: { url: string; mediaType?: string; alt?: string } | undefined;
+  if (event.image_url) {
+    try {
+      await validateFederationUrl(event.image_url);
+      safeImage = {
+        url: event.image_url,
+        mediaType: event.image_media_type || undefined,
+        alt: event.image_alt || undefined,
+      };
+    } catch (err) {
+      console.warn(`[OG] Skipping unsafe remote event image for ${event.uri}:`, err);
+    }
+  }
+
   const baseEventData = {
     id: event.uri,
     title: event.title,
@@ -224,13 +239,7 @@ export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Pr
           longitude: event.location_longitude ?? undefined,
         }
       : undefined,
-    image: event.image_url
-      ? {
-          url: event.image_url,
-          mediaType: event.image_media_type || undefined,
-          alt: event.image_alt || undefined,
-        }
-      : undefined,
+    image: safeImage,
     visibility: "public" as const,
     createdAt: "",
     updatedAt: "",

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -72,6 +72,47 @@ function remoteOgFilenameFromUrl(ogImageUrl: string): string | null {
   return filename;
 }
 
+function localOgFilenameFromUrl(ogImageUrl: string, eventId: string): string | null {
+  const path = ogImageUrl.split("?")[0];
+  const prefix = "/og-images/";
+  if (!path.startsWith(prefix)) return null;
+  const filename = path.slice(prefix.length);
+  if (!filename || filename.includes("/") || filename.includes("\\")) return null;
+  const expectedFilename = `${eventId}.png`;
+  return filename === expectedFilename ? filename : null;
+}
+
+export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> {
+  let row: { og_image_url: string | null } | undefined;
+  try {
+    row = db.prepare("SELECT og_image_url FROM events WHERE id = ?").get(eventId) as {
+      og_image_url: string | null;
+    } | undefined;
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+      return;
+    }
+    throw err;
+  }
+
+  updateLocalOgImageUrl(db, eventId, null);
+
+  const ogImageUrl = row?.og_image_url;
+  if (!ogImageUrl) return;
+  const filename = localOgFilenameFromUrl(ogImageUrl, eventId);
+  if (!filename) return;
+
+  const { unlink } = await import("node:fs/promises");
+  const ogPath = join(OG_DIR, filename);
+  try {
+    await unlink(ogPath);
+  } catch (err) {
+    if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) {
+      throw err;
+    }
+  }
+}
+
 export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void> {
   const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
     og_image_url: string | null;

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -22,6 +22,18 @@ function hasPublicAddress(recipients: string[]): boolean {
   return recipients.includes(PUBLIC_ADDRESS);
 }
 
+function collectRecipients(entity: Record<string, unknown>): string[] {
+  const allRecipients = [
+    ...normalizeRecipients(entity.to),
+    ...normalizeRecipients(entity.cc),
+    ...normalizeRecipients(entity.audience),
+    ...normalizeRecipients(entity.bto),
+    ...normalizeRecipients(entity.bcc),
+  ];
+
+  return [...new Set(allRecipients)];
+}
+
 export function isOgEligibleVisibility(visibility: string | null | undefined): boolean {
   return visibility === "public" || visibility === "unlisted";
 }
@@ -30,15 +42,9 @@ export function isRemoteActivityOgEligible(
   activity: Record<string, unknown>,
   object: Record<string, unknown>
 ): boolean {
-  const objectTo = normalizeRecipients(object.to);
-  const objectCc = normalizeRecipients(object.cc);
-  const activityTo = normalizeRecipients(activity.to);
-  const activityCc = normalizeRecipients(activity.cc);
+  const recipients = [...collectRecipients(activity), ...collectRecipients(object)];
 
-  const toRecipients = objectTo.length > 0 ? objectTo : activityTo;
-  const ccRecipients = objectCc.length > 0 ? objectCc : activityCc;
-
-  return hasPublicAddress(toRecipients) || hasPublicAddress(ccRecipients);
+  return hasPublicAddress(recipients);
 }
 
 function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | null): void {

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -1,13 +1,66 @@
 /**
- * OG Image generation API routes.
+ * OG image generation helpers.
  */
 
-import { Hono } from "hono";
+import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { generateOgImage, getOgImageFilename } from "@everycal/og";
 import type { DB } from "../db.js";
 import { OG_DIR } from "../lib/paths.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
+
+const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
+
+function normalizeRecipients(input: unknown): string[] {
+  if (typeof input === "string") return [input];
+  if (!Array.isArray(input)) return [];
+  return input.filter((value): value is string => typeof value === "string");
+}
+
+function hasPublicAddress(recipients: string[]): boolean {
+  return recipients.includes(PUBLIC_ADDRESS);
+}
+
+export function isOgEligibleVisibility(visibility: string | null | undefined): boolean {
+  return visibility === "public" || visibility === "unlisted";
+}
+
+export function isRemoteActivityOgEligible(
+  activity: Record<string, unknown>,
+  object: Record<string, unknown>
+): boolean {
+  const objectTo = normalizeRecipients(object.to);
+  const objectCc = normalizeRecipients(object.cc);
+  const activityTo = normalizeRecipients(activity.to);
+  const activityCc = normalizeRecipients(activity.cc);
+
+  const toRecipients = objectTo.length > 0 ? objectTo : activityTo;
+  const ccRecipients = objectCc.length > 0 ? objectCc : activityCc;
+
+  return hasPublicAddress(toRecipients) || hasPublicAddress(ccRecipients);
+}
+
+function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | null): void {
+  try {
+    db.prepare("UPDATE events SET og_image_url = ? WHERE id = ?").run(ogImageUrl, eventId);
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+      return;
+    }
+    throw err;
+  }
+}
+
+function updateRemoteOgImageUrl(db: DB, eventUri: string, ogImageUrl: string | null): void {
+  try {
+    db.prepare("UPDATE remote_events SET og_image_url = ? WHERE uri = ?").run(ogImageUrl, eventUri);
+  } catch (err) {
+    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+      return;
+    }
+    throw err;
+  }
+}
 
 export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<string | null> {
   const { writeFile } = await import("node:fs/promises");
@@ -37,9 +90,14 @@ export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<s
     image_alt: string | null;
     preferred_language: string;
     updated_at: string;
+    visibility: string;
   } | undefined;
 
   if (!event) {
+    return null;
+  }
+  if (!isOgEligibleVisibility(event.visibility)) {
+    updateLocalOgImageUrl(db, eventId, null);
     return null;
   }
 
@@ -108,33 +166,107 @@ export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<s
 
   const version = Math.floor(new Date(event.updated_at).getTime() / 1000);
   const ogImageUrl = `/og-images/${eventId}.png?v=${version}`;
-  db.prepare("UPDATE events SET og_image_url = ? WHERE id = ?").run(ogImageUrl, eventId);
+  updateLocalOgImageUrl(db, eventId, ogImageUrl);
 
   return ogImageUrl;
 }
 
-interface OgImageBody {
-  eventId: string;
+function getRemoteOgFilename(eventUri: string): string {
+  const digest = createHash("sha256").update(eventUri).digest("hex");
+  return `remote-${digest}.png`;
 }
 
-export function ogImageRoutes(db: DB): Hono {
-  const router = new Hono();
+export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Promise<string | null> {
+  const { writeFile } = await import("node:fs/promises");
+  const { existsSync, mkdirSync } = await import("node:fs");
 
-  router.post("/", async (c) => {
-    const body = await c.req.json<OgImageBody>();
-    const { eventId } = body;
+  const event = db.prepare(`
+    SELECT uri, title, start_date, start_at_utc, end_date, end_at_utc,
+           event_timezone, all_day,
+           location_name, location_address, location_latitude, location_longitude,
+           image_url, image_media_type, image_alt,
+           fetched_at, canceled
+    FROM remote_events
+    WHERE uri = ?
+  `).get(eventUri) as {
+    uri: string;
+    title: string;
+    start_date: string;
+    start_at_utc: string;
+    end_date: string | null;
+    end_at_utc: string | null;
+    event_timezone: string | null;
+    all_day: number;
+    location_name: string | null;
+    location_address: string | null;
+    location_latitude: number | null;
+    location_longitude: number | null;
+    image_url: string | null;
+    image_media_type: string | null;
+    image_alt: string | null;
+    fetched_at: string;
+    canceled: number;
+  } | undefined;
 
-    if (!eventId) {
-      return c.json({ error: "eventId is required" }, 400);
-    }
+  if (!event || event.canceled) return null;
 
-    const ogImageUrl = await generateAndSaveOgImage(db, eventId);
-    if (!ogImageUrl) {
-      return c.json({ error: "Event not found" }, 404);
-    }
+  const baseEventData = {
+    id: event.uri,
+    title: event.title,
+    startDate: event.start_date,
+    endDate: event.end_date || undefined,
+    eventTimezone: normalizeEventTimezone(event.event_timezone),
+    location: event.location_name
+      ? {
+          name: event.location_name,
+          address: event.location_address || undefined,
+          latitude: event.location_latitude || undefined,
+          longitude: event.location_longitude || undefined,
+        }
+      : undefined,
+    image: event.image_url
+      ? {
+          url: event.image_url,
+          mediaType: event.image_media_type || undefined,
+          alt: event.image_alt || undefined,
+        }
+      : undefined,
+    visibility: "public" as const,
+    createdAt: "",
+    updatedAt: "",
+  };
 
-    return c.json({ success: true, url: ogImageUrl });
+  const eventData = event.all_day
+    ? {
+        ...baseEventData,
+        allDay: true as const,
+        ...(event.start_at_utc ? { startAtUtc: event.start_at_utc } : {}),
+      }
+    : {
+        ...baseEventData,
+        allDay: false as const,
+        startDate: event.start_at_utc,
+        endDate: event.end_at_utc || undefined,
+        startAtUtc: event.start_at_utc,
+        ...(event.end_at_utc ? { endAtUtc: event.end_at_utc } : {}),
+      };
+
+  const ogBuffer = await generateOgImage({
+    event: eventData,
+    locale: "en",
   });
 
-  return router;
+  if (!existsSync(OG_DIR)) {
+    mkdirSync(OG_DIR, { recursive: true });
+  }
+
+  const ogFilename = getRemoteOgFilename(event.uri);
+  const ogPath = join(OG_DIR, ogFilename);
+  await writeFile(ogPath, ogBuffer);
+
+  const version = Math.floor(new Date(event.fetched_at).getTime() / 1000);
+  const ogImageUrl = `/og-images/${ogFilename}?v=${version}`;
+  updateRemoteOgImageUrl(db, event.uri, ogImageUrl);
+
+  return ogImageUrl;
 }

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -63,6 +63,38 @@ function updateRemoteOgImageUrl(db: DB, eventUri: string, ogImageUrl: string | n
   }
 }
 
+function remoteOgFilenameFromUrl(ogImageUrl: string): string | null {
+  const path = ogImageUrl.split("?")[0];
+  const prefix = "/og-images/";
+  if (!path.startsWith(prefix)) return null;
+  const filename = path.slice(prefix.length);
+  if (!filename || filename.includes("/") || filename.includes("\\")) return null;
+  return filename;
+}
+
+export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void> {
+  const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
+    og_image_url: string | null;
+  } | undefined;
+
+  updateRemoteOgImageUrl(db, eventUri, null);
+
+  const ogImageUrl = row?.og_image_url;
+  if (!ogImageUrl) return;
+  const filename = remoteOgFilenameFromUrl(ogImageUrl);
+  if (!filename) return;
+
+  const { unlink } = await import("node:fs/promises");
+  const ogPath = join(OG_DIR, filename);
+  try {
+    await unlink(ogPath);
+  } catch (err) {
+    if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) {
+      throw err;
+    }
+  }
+}
+
 export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<string | null> {
   const { writeFile } = await import("node:fs/promises");
   const { existsSync, mkdirSync } = await import("node:fs");

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -12,6 +12,31 @@ import { validateFederationUrl } from "../lib/federation.js";
 
 const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
 const REMOTE_OG_FILENAME_RE = /^remote-[a-f0-9]{64}\.png$/;
+const remoteEventsOgImageColumnCache = new WeakMap<DB, boolean>();
+const warnedMissingRemoteEventsOgImageColumn = new WeakSet<DB>();
+
+function isNoSuchColumnError(err: unknown): boolean {
+  return err instanceof Error && err.message.toLowerCase().includes("no such column");
+}
+
+function warnMissingRemoteEventsOgImageColumnOnce(db: DB): void {
+  if (warnedMissingRemoteEventsOgImageColumn.has(db)) return;
+  warnedMissingRemoteEventsOgImageColumn.add(db);
+  console.warn("[OG] Skipping remote OG image persistence: remote_events.og_image_url column is missing");
+}
+
+function hasRemoteEventsOgImageColumn(db: DB): boolean {
+  const cached = remoteEventsOgImageColumnCache.get(db);
+  if (cached !== undefined) return cached;
+
+  const columns = db.prepare("PRAGMA table_info(remote_events)").all() as Array<{ name: string }>;
+  const hasColumn = columns.some((column) => column.name === "og_image_url");
+  remoteEventsOgImageColumnCache.set(db, hasColumn);
+  if (!hasColumn) {
+    warnMissingRemoteEventsOgImageColumnOnce(db);
+  }
+  return hasColumn;
+}
 
 function normalizeRecipients(input: unknown): string[] {
   if (typeof input === "string") return [input];
@@ -52,7 +77,7 @@ function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | nul
   try {
     db.prepare("UPDATE events SET og_image_url = ? WHERE id = ?").run(ogImageUrl, eventId);
   } catch (err) {
-    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+    if (isNoSuchColumnError(err)) {
       return;
     }
     throw err;
@@ -60,10 +85,16 @@ function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | nul
 }
 
 function updateRemoteOgImageUrl(db: DB, eventUri: string, ogImageUrl: string | null): void {
+  if (!hasRemoteEventsOgImageColumn(db)) {
+    return;
+  }
+
   try {
     db.prepare("UPDATE remote_events SET og_image_url = ? WHERE uri = ?").run(ogImageUrl, eventUri);
   } catch (err) {
-    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+    if (isNoSuchColumnError(err)) {
+      remoteEventsOgImageColumnCache.set(db, false);
+      warnMissingRemoteEventsOgImageColumnOnce(db);
       return;
     }
     throw err;
@@ -97,7 +128,7 @@ export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> 
       og_image_url: string | null;
     } | undefined;
   } catch (err) {
-    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+    if (isNoSuchColumnError(err)) {
       return;
     }
     throw err;
@@ -122,13 +153,19 @@ export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> 
 }
 
 export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void> {
+  if (!hasRemoteEventsOgImageColumn(db)) {
+    return;
+  }
+
   let row: { og_image_url: string | null } | undefined;
   try {
     row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
       og_image_url: string | null;
     } | undefined;
   } catch (err) {
-    if (err instanceof Error && err.message.toLowerCase().includes("no such column")) {
+    if (isNoSuchColumnError(err)) {
+      remoteEventsOgImageColumnCache.set(db, false);
+      warnMissingRemoteEventsOgImageColumnOnce(db);
       return;
     }
     throw err;
@@ -269,6 +306,8 @@ function getRemoteOgFilename(eventUri: string): string {
 }
 
 export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Promise<string | null> {
+  if (!hasRemoteEventsOgImageColumn(db)) return null;
+
   const { writeFile } = await import("node:fs/promises");
   const { existsSync, mkdirSync } = await import("node:fs");
 

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -752,6 +752,7 @@ function formatRemoteEventForUser(row: Record<string, unknown>): Record<string, 
     image: row.image_url
       ? { url: row.image_url, mediaType: row.image_media_type, alt: row.image_alt }
       : null,
+    ogImageUrl: row.og_image_url || null,
     url: row.url,
     tags: row.tags ? (row.tags as string).split(",") : [],
     visibility: "public",
@@ -868,6 +869,7 @@ function formatEvent(row: Record<string, unknown>): Record<string, unknown> {
     image: row.image_url
       ? { url: row.image_url, mediaType: row.image_media_type, alt: row.image_alt }
       : null,
+    ogImageUrl: row.og_image_url || null,
     url: row.url,
     tags: row.tags ? (row.tags as string).split(",") : [],
     visibility: row.visibility,

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -41,6 +41,7 @@ import { upsertRemoteEvent } from "../src/lib/remote-events.js";
 import { fetchAP, resolveRemoteActor, deliverToFollowers, validateFederationUrl } from "../src/lib/federation.js";
 import { notifyEventUpdated } from "../src/lib/notifications.js";
 import { clearLocalOgImage, generateAndSaveOgImage } from "../src/routes/og-images.js";
+import { __resetOgJobQueueForTests, __waitForOgJobQueueIdleForTests } from "../src/lib/og-job-queue.js";
 import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
 
 const oneYearMs = 365 * 24 * 60 * 60 * 1000;
@@ -73,6 +74,7 @@ describe("event slug canonical behavior", () => {
     vi.mocked(notifyEventUpdated).mockClear();
     vi.mocked(generateAndSaveOgImage).mockClear();
     vi.mocked(clearLocalOgImage).mockClear();
+    __resetOgJobQueueForTests();
   });
 
   it("keeps local slug immutable on title update", async () => {
@@ -644,6 +646,7 @@ describe("event slug canonical behavior", () => {
     });
 
     expect(sync.status).toBe(200);
+    await __waitForOgJobQueueIdleForTests();
 
     const publicEvent = db.prepare("SELECT id FROM events WHERE external_id = ?").get("sync-public-og") as { id: string };
     const unlistedEvent = db.prepare("SELECT id FROM events WHERE external_id = ?").get("sync-unlisted-og") as { id: string };
@@ -700,6 +703,7 @@ describe("event slug canonical behavior", () => {
     });
 
     expect(sync.status).toBe(200);
+    await __waitForOgJobQueueIdleForTests();
     expect(generateAndSaveOgImage).not.toHaveBeenCalled();
     expect(clearLocalOgImage).toHaveBeenCalledWith(db, "existing-og");
 
@@ -707,6 +711,49 @@ describe("event slug canonical behavior", () => {
       visibility: string;
     };
     expect(row.visibility).toBe("private");
+  });
+
+  it("sync responds even when OG generation is still running", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    let releaseOgGeneration: (() => void) | null = null;
+    vi.mocked(generateAndSaveOgImage).mockImplementationOnce(async () => {
+      await new Promise<void>((resolve) => {
+        releaseOgGeneration = resolve;
+      });
+      return "/og-images/mock.png?v=1";
+    });
+
+    let responded = false;
+    const syncPromise = app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "sync-async-og",
+            title: "Async OG",
+            startDate: "2026-08-10T08:00:00",
+            eventTimezone: "UTC",
+            visibility: "public",
+          },
+        ],
+      }),
+    }).then((response) => {
+      responded = true;
+      return response;
+    });
+
+    await new Promise<void>((resolve) => {
+      setTimeout(() => resolve(), 100);
+    });
+    expect(responded).toBe(true);
+
+    const sync = await syncPromise;
+    expect(sync.status).toBe(200);
+
+    releaseOgGeneration?.();
+    await __waitForOgJobQueueIdleForTests();
   });
 
   it("sync keeps missing past events and only cancels missing future events after a second miss", async () => {

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -251,6 +251,24 @@ describe("event slug canonical behavior", () => {
     expect(row.end_on).toBe("2025-12-31");
   });
 
+  it("does not generate OG for private event creates", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Private Event",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+        visibility: "private",
+      }),
+    });
+
+    expect(create.status).toBe(201);
+    expect(generateAndSaveOgImage).not.toHaveBeenCalled();
+  });
+
   it("rejects switching a timed event to all-day without date-only fields", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 
@@ -588,6 +606,104 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBe("2026-01-01T02:00:00.000Z");
     expect(row.start_on).toBe("2025-12-31");
     expect(row.end_on).toBe("2025-12-31");
+  });
+
+  it("sync only triggers OG generation for public and unlisted events", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "sync-public-og",
+            title: "Public OG",
+            startDate: "2026-08-10T08:00:00",
+            eventTimezone: "UTC",
+            visibility: "public",
+          },
+          {
+            externalId: "sync-unlisted-og",
+            title: "Unlisted OG",
+            startDate: "2026-08-10T09:00:00",
+            eventTimezone: "UTC",
+            visibility: "unlisted",
+          },
+          {
+            externalId: "sync-private-no-og",
+            title: "Private No OG",
+            startDate: "2026-08-10T10:00:00",
+            eventTimezone: "UTC",
+            visibility: "private",
+          },
+        ],
+      }),
+    });
+
+    expect(sync.status).toBe(200);
+
+    const publicEvent = db.prepare("SELECT id FROM events WHERE external_id = ?").get("sync-public-og") as { id: string };
+    const unlistedEvent = db.prepare("SELECT id FROM events WHERE external_id = ?").get("sync-unlisted-og") as { id: string };
+    const privateEvent = db.prepare("SELECT id FROM events WHERE external_id = ?").get("sync-private-no-og") as { id: string };
+
+    const ogCalls = vi.mocked(generateAndSaveOgImage).mock.calls.map((call) => call[1]);
+    expect(ogCalls).toContain(publicEvent.id);
+    expect(ogCalls).toContain(unlistedEvent.id);
+    expect(ogCalls).not.toContain(privateEvent.id);
+  });
+
+  it("sync does not trigger OG generation when visibility becomes private", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    db.prepare(
+      `INSERT INTO events (
+        id, account_id, created_by_account_id, external_id, slug, title,
+        start_date, end_date, all_day, start_at_utc, end_at_utc, event_timezone,
+        start_on, end_on, visibility, content_hash
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "existing-og",
+      "u1",
+      "u1",
+      "sync-visibility-change",
+      "existing-og",
+      "Existing OG",
+      "2026-08-10T08:00:00",
+      null,
+      0,
+      "2026-08-10T08:00:00.000Z",
+      null,
+      "UTC",
+      "2026-08-10",
+      null,
+      "public",
+      "old-hash",
+    );
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "sync-visibility-change",
+            title: "Existing OG Updated",
+            startDate: "2026-08-10T08:00:00",
+            eventTimezone: "UTC",
+            visibility: "private",
+          },
+        ],
+      }),
+    });
+
+    expect(sync.status).toBe(200);
+    expect(generateAndSaveOgImage).not.toHaveBeenCalled();
+
+    const row = db.prepare("SELECT visibility FROM events WHERE id = ?").get("existing-og") as {
+      visibility: string;
+    };
+    expect(row.visibility).toBe("private");
   });
 
   it("sync keeps missing past events and only cancels missing future events after a second miss", async () => {

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -31,6 +31,7 @@ vi.mock("../src/routes/og-images.js", async () => {
   return {
     ...actual,
     generateAndSaveOgImage: vi.fn().mockResolvedValue("/og-images/mock.png?v=1"),
+    clearLocalOgImage: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -39,7 +40,7 @@ import { userRoutes } from "../src/routes/users.js";
 import { upsertRemoteEvent } from "../src/lib/remote-events.js";
 import { fetchAP, resolveRemoteActor, deliverToFollowers, validateFederationUrl } from "../src/lib/federation.js";
 import { notifyEventUpdated } from "../src/lib/notifications.js";
-import { generateAndSaveOgImage } from "../src/routes/og-images.js";
+import { clearLocalOgImage, generateAndSaveOgImage } from "../src/routes/og-images.js";
 import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
 
 const oneYearMs = 365 * 24 * 60 * 60 * 1000;
@@ -71,6 +72,7 @@ describe("event slug canonical behavior", () => {
     vi.mocked(validateFederationUrl).mockResolvedValue(undefined);
     vi.mocked(notifyEventUpdated).mockClear();
     vi.mocked(generateAndSaveOgImage).mockClear();
+    vi.mocked(clearLocalOgImage).mockClear();
   });
 
   it("keeps local slug immutable on title update", async () => {
@@ -699,6 +701,7 @@ describe("event slug canonical behavior", () => {
 
     expect(sync.status).toBe(200);
     expect(generateAndSaveOgImage).not.toHaveBeenCalled();
+    expect(clearLocalOgImage).toHaveBeenCalledWith(db, "existing-og");
 
     const row = db.prepare("SELECT visibility FROM events WHERE id = ?").get("existing-og") as {
       visibility: string;

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
 import { initDatabase } from "../src/db.js";
 import type { DB } from "../src/db.js";
 
@@ -51,6 +52,11 @@ import {
 function insertAccount(db: DB, id: string) {
   db.prepare("INSERT INTO accounts (id, username, preferred_language) VALUES (?, ?, ?)")
     .run(id, id, "en");
+}
+
+function remoteOgImageUrlForUri(uri: string): string {
+  const digest = createHash("sha256").update(uri).digest("hex");
+  return `/og-images/remote-${digest}.png?v=100`;
 }
 
 describe("generateAndSaveOgImage temporal payload", () => {
@@ -273,7 +279,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
       "2026-02-15T17:00:00.000Z",
       "Europe/Vienna",
       "exact_tzid",
-      "/og-images/remote-123.png?v=100",
+      remoteOgImageUrlForUri("https://remote.example/events/cleanup"),
       "2026-02-10T12:00:00.000Z",
       0,
     );
@@ -285,7 +291,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
     };
     expect(row.og_image_url).toBeNull();
     expect(unlinkMock).toHaveBeenCalledOnce();
-    expect(unlinkMock.mock.calls[0]?.[0]).toContain("remote-123.png");
+    expect(unlinkMock.mock.calls[0]?.[0]).toContain(createHash("sha256").update("https://remote.example/events/cleanup").digest("hex"));
   });
 
   it("clears remote og_image_url even when file is already missing", async () => {
@@ -306,7 +312,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
       "2026-02-15T17:00:00.000Z",
       "Europe/Vienna",
       "exact_tzid",
-      "/og-images/remote-missing.png?v=100",
+      remoteOgImageUrlForUri("https://remote.example/events/missing"),
       "2026-02-10T12:00:00.000Z",
       0,
     );
@@ -317,6 +323,99 @@ describe("generateAndSaveOgImage temporal payload", () => {
       og_image_url: string | null;
     };
     expect(row.og_image_url).toBeNull();
+  });
+
+  it("clears remote og_image_url but does not remove non-remote filename", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, all_day,
+        start_at_utc, event_timezone, timezone_quality,
+        og_image_url, fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/poisoned-local",
+      "https://remote.example/users/alice",
+      "Remote Event Poisoned Local",
+      "2026-02-15T18:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "/og-images/local-cleanup.png?v=100",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    await clearRemoteOgImage(db, "https://remote.example/events/poisoned-local");
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/poisoned-local") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+
+  it("clears remote og_image_url but does not remove mismatched remote filename", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, all_day,
+        start_at_utc, event_timezone, timezone_quality,
+        og_image_url, fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/poisoned-remote",
+      "https://remote.example/users/alice",
+      "Remote Event Poisoned Remote",
+      "2026-02-15T18:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      remoteOgImageUrlForUri("https://remote.example/events/other"),
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    await clearRemoteOgImage(db, "https://remote.example/events/poisoned-remote");
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/poisoned-remote") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+    expect(unlinkMock).not.toHaveBeenCalled();
+  });
+
+  it("clears remote og_image_url but does not remove malformed remote filename", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, all_day,
+        start_at_utc, event_timezone, timezone_quality,
+        og_image_url, fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/poisoned-malformed",
+      "https://remote.example/users/alice",
+      "Remote Event Poisoned Malformed",
+      "2026-02-15T18:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "/og-images/remote-123.png?v=100",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    await clearRemoteOgImage(db, "https://remote.example/events/poisoned-malformed");
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/poisoned-malformed") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+    expect(unlinkMock).not.toHaveBeenCalled();
   });
 
   it("clears local og_image_url and removes local image file", async () => {

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -403,4 +403,61 @@ describe("OG eligibility helpers", () => {
       { id: "https://remote.example/events/4", type: "Event" },
     )).toBe(false);
   });
+
+  it("uses union of activity and object recipients", () => {
+    expect(isRemoteActivityOgEligible(
+      {
+        to: ["https://www.w3.org/ns/activitystreams#Public"],
+      },
+      {
+        id: "https://remote.example/events/5",
+        type: "Event",
+        to: ["https://remote.example/users/alice/followers"],
+      },
+    )).toBe(true);
+
+    expect(isRemoteActivityOgEligible(
+      {
+        to: ["https://remote.example/users/alice/followers"],
+      },
+      {
+        id: "https://remote.example/events/6",
+        type: "Event",
+        cc: ["https://www.w3.org/ns/activitystreams#Public"],
+      },
+    )).toBe(true);
+  });
+
+  it("considers audience, bto, and bcc recipients", () => {
+    expect(isRemoteActivityOgEligible(
+      {
+        audience: ["https://www.w3.org/ns/activitystreams#Public"],
+      },
+      {
+        id: "https://remote.example/events/7",
+        type: "Event",
+      },
+    )).toBe(true);
+
+    expect(isRemoteActivityOgEligible(
+      {
+        bto: ["https://www.w3.org/ns/activitystreams#Public"],
+      },
+      {
+        id: "https://remote.example/events/8",
+        type: "Event",
+      },
+    )).toBe(true);
+
+    expect(isRemoteActivityOgEligible(
+      {
+        to: ["https://remote.example/users/alice/followers"],
+      },
+      {
+        id: "https://remote.example/events/9",
+        type: "Event",
+        bcc: ["https://www.w3.org/ns/activitystreams#Public"],
+      },
+    )).toBe(true);
+  });
 });

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -40,6 +40,7 @@ vi.mock("node:fs", () => ({
 }));
 
 import {
+  clearLocalOgImage,
   generateAndSaveOgImage,
   generateAndSaveRemoteOgImage,
   clearRemoteOgImage,
@@ -313,6 +314,65 @@ describe("generateAndSaveOgImage temporal payload", () => {
     await expect(clearRemoteOgImage(db, "https://remote.example/events/missing")).resolves.toBeUndefined();
 
     const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/missing") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+  });
+
+  it("clears local og_image_url and removes local image file", async () => {
+    const db = initDatabase(":memory:");
+    insertAccount(db, "u1");
+    db.prepare(
+      `INSERT INTO events (
+        id, account_id, title, start_date, all_day,
+        start_at_utc, event_timezone, visibility, og_image_url
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "local-cleanup",
+      "u1",
+      "Local Event Cleanup",
+      "2026-02-15T18:00:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "public",
+      "/og-images/local-cleanup.png?v=100",
+    );
+
+    await clearLocalOgImage(db, "local-cleanup");
+
+    const row = db.prepare("SELECT og_image_url FROM events WHERE id = ?").get("local-cleanup") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+    expect(unlinkMock).toHaveBeenCalledOnce();
+    expect(unlinkMock.mock.calls[0]?.[0]).toContain("local-cleanup.png");
+  });
+
+  it("clears local og_image_url even when local image file is already missing", async () => {
+    const db = initDatabase(":memory:");
+    insertAccount(db, "u1");
+    unlinkMock.mockRejectedValueOnce(Object.assign(new Error("missing"), { code: "ENOENT" }));
+    db.prepare(
+      `INSERT INTO events (
+        id, account_id, title, start_date, all_day,
+        start_at_utc, event_timezone, visibility, og_image_url
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "local-missing",
+      "u1",
+      "Local Event Missing File",
+      "2026-02-15T18:00:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "public",
+      "/og-images/local-missing.png?v=100",
+    );
+
+    await expect(clearLocalOgImage(db, "local-missing")).resolves.toBeUndefined();
+
+    const row = db.prepare("SELECT og_image_url FROM events WHERE id = ?").get("local-missing") as {
       og_image_url: string | null;
     };
     expect(row.og_image_url).toBeNull();

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -5,12 +5,14 @@ import type { DB } from "../src/db.js";
 const {
   generateOgImageMock,
   getOgImageFilenameMock,
+  validateFederationUrlMock,
   writeFileMock,
   existsSyncMock,
   mkdirSyncMock,
 } = vi.hoisted(() => ({
   generateOgImageMock: vi.fn(async () => Buffer.from("og-png")),
   getOgImageFilenameMock: vi.fn((eventId: string) => `${eventId}.png`),
+  validateFederationUrlMock: vi.fn(async () => undefined),
   writeFileMock: vi.fn(async () => undefined),
   existsSyncMock: vi.fn(() => true),
   mkdirSyncMock: vi.fn(),
@@ -19,6 +21,10 @@ const {
 vi.mock("@everycal/og", () => ({
   generateOgImage: generateOgImageMock,
   getOgImageFilename: getOgImageFilenameMock,
+}));
+
+vi.mock("../src/lib/federation.js", () => ({
+  validateFederationUrl: validateFederationUrlMock,
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -46,6 +52,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     existsSyncMock.mockReturnValue(true);
+    validateFederationUrlMock.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -193,11 +200,55 @@ describe("generateAndSaveOgImage temporal payload", () => {
 
     expect(og).toMatch(/^\/og-images\/remote-[a-f0-9]{64}\.png\?v=\d+$/);
     expect(generateOgImageMock).toHaveBeenCalledOnce();
+    expect(validateFederationUrlMock).not.toHaveBeenCalled();
 
     const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/1") as {
       og_image_url: string | null;
     };
     expect(row.og_image_url).toBe(og);
+  });
+
+  it("skips remote header image when URL validation fails", async () => {
+    const db = initDatabase(":memory:");
+    validateFederationUrlMock.mockRejectedValueOnce(new Error("Requests to private/internal addresses are not allowed"));
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, end_date, all_day,
+        start_at_utc, end_at_utc, event_timezone, timezone_quality,
+        image_url, image_media_type, image_alt,
+        fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/2",
+      "https://remote.example/users/alice",
+      "Remote Event With Image",
+      "2026-02-15T18:00:00+01:00",
+      "2026-02-15T19:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "2026-02-15T18:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "http://127.0.0.1/internal.png",
+      "image/png",
+      "Header",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const og = await generateAndSaveRemoteOgImage(db, "https://remote.example/events/2");
+
+    expect(og).toMatch(/^\/og-images\/remote-[a-f0-9]{64}\.png\?v=\d+$/);
+    expect(validateFederationUrlMock).toHaveBeenCalledWith("http://127.0.0.1/internal.png");
+    expect(generateOgImageMock).toHaveBeenCalledWith(expect.objectContaining({
+      event: expect.objectContaining({
+        image: undefined,
+      }),
+    }));
+    expect(warnSpy).toHaveBeenCalledOnce();
+
+    warnSpy.mockRestore();
   });
 });
 

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -30,7 +30,12 @@ vi.mock("node:fs", () => ({
   mkdirSync: mkdirSyncMock,
 }));
 
-import { generateAndSaveOgImage } from "../src/routes/og-images.js";
+import {
+  generateAndSaveOgImage,
+  generateAndSaveRemoteOgImage,
+  isOgEligibleVisibility,
+  isRemoteActivityOgEligible,
+} from "../src/routes/og-images.js";
 
 function insertAccount(db: DB, id: string) {
   db.prepare("INSERT INTO accounts (id, username, preferred_language) VALUES (?, ?, ?)")
@@ -136,5 +141,88 @@ describe("generateAndSaveOgImage temporal payload", () => {
         eventTimezone: "Europe/Vienna",
       }),
     }));
+  });
+
+  it("skips local OG generation for private events", async () => {
+    const db = initDatabase(":memory:");
+    insertAccount(db, "u1");
+    db.prepare(
+      `INSERT INTO events (id, account_id, title, start_date, all_day, start_at_utc, event_timezone, visibility)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "e-private",
+      "u1",
+      "Private Event",
+      "2026-02-15T18:00:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "private"
+    );
+
+    const og = await generateAndSaveOgImage(db, "e-private");
+
+    expect(og).toBeNull();
+    expect(generateOgImageMock).not.toHaveBeenCalled();
+  });
+
+  it("generates and stores OG image for remote events", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, end_date, all_day,
+        start_at_utc, end_at_utc, event_timezone, timezone_quality,
+        fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/1",
+      "https://remote.example/users/alice",
+      "Remote Event",
+      "2026-02-15T18:00:00+01:00",
+      "2026-02-15T19:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "2026-02-15T18:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    const og = await generateAndSaveRemoteOgImage(db, "https://remote.example/events/1");
+
+    expect(og).toMatch(/^\/og-images\/remote-[a-f0-9]{64}\.png\?v=\d+$/);
+    expect(generateOgImageMock).toHaveBeenCalledOnce();
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/1") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBe(og);
+  });
+});
+
+describe("OG eligibility helpers", () => {
+  it("recognizes eligible visibilities", () => {
+    expect(isOgEligibleVisibility("public")).toBe(true);
+    expect(isOgEligibleVisibility("unlisted")).toBe(true);
+    expect(isOgEligibleVisibility("followers_only")).toBe(false);
+    expect(isOgEligibleVisibility("private")).toBe(false);
+  });
+
+  it("recognizes remote public and unlisted recipients", () => {
+    expect(isRemoteActivityOgEligible(
+      { to: ["https://www.w3.org/ns/activitystreams#Public"] },
+      { id: "https://remote.example/events/2", type: "Event" },
+    )).toBe(true);
+
+    expect(isRemoteActivityOgEligible(
+      { cc: ["https://www.w3.org/ns/activitystreams#Public"] },
+      { id: "https://remote.example/events/3", type: "Event" },
+    )).toBe(true);
+
+    expect(isRemoteActivityOgEligible(
+      { to: ["https://remote.example/users/alice/followers"] },
+      { id: "https://remote.example/events/4", type: "Event" },
+    )).toBe(false);
   });
 });

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -452,6 +452,11 @@ describe("generateAndSaveOgImage temporal payload", () => {
     const userVersion = db.pragma("user_version", { simple: true }) as number;
     expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
 
+    const generated = await generateAndSaveRemoteOgImage(db, "https://remote.example/events/legacy");
+    expect(generated).toBeNull();
+    expect(generateOgImageMock).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+
     await expect(clearRemoteOgImage(db, "https://remote.example/events/legacy")).resolves.toBeUndefined();
     expect(unlinkMock).not.toHaveBeenCalled();
 

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
 import { initDatabase } from "../src/db.js";
 import type { DB } from "../src/db.js";
+import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
 
 const {
   generateOgImageMock,
@@ -35,10 +40,14 @@ vi.mock("node:fs/promises", () => ({
   unlink: unlinkMock,
 }));
 
-vi.mock("node:fs", () => ({
-  existsSync: existsSyncMock,
-  mkdirSync: mkdirSyncMock,
-}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+  };
+});
 
 import {
   clearLocalOgImage,
@@ -416,6 +425,38 @@ describe("generateAndSaveOgImage temporal payload", () => {
     };
     expect(row.og_image_url).toBeNull();
     expect(unlinkMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when legacy remote_events schema has no og_image_url column", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "legacy-og.sqlite");
+    const legacy = new Database(dbPath);
+    legacy.exec(`
+      CREATE TABLE remote_events (
+        uri TEXT PRIMARY KEY,
+        actor_uri TEXT NOT NULL,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL
+      );
+    `);
+    legacy.prepare("INSERT INTO remote_events (uri, actor_uri, title, start_date) VALUES (?, ?, ?, ?)")
+      .run(
+        "https://remote.example/events/legacy",
+        "https://remote.example/users/alice",
+        "Legacy Event",
+        "2026-02-15T18:00:00+01:00",
+      );
+    legacy.close();
+
+    const db = initDatabase(dbPath);
+    const userVersion = db.pragma("user_version", { simple: true }) as number;
+    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+
+    await expect(clearRemoteOgImage(db, "https://remote.example/events/legacy")).resolves.toBeUndefined();
+    expect(unlinkMock).not.toHaveBeenCalled();
+
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("clears local og_image_url and removes local image file", async () => {

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -7,6 +7,7 @@ const {
   getOgImageFilenameMock,
   validateFederationUrlMock,
   writeFileMock,
+  unlinkMock,
   existsSyncMock,
   mkdirSyncMock,
 } = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const {
   getOgImageFilenameMock: vi.fn((eventId: string) => `${eventId}.png`),
   validateFederationUrlMock: vi.fn(async () => undefined),
   writeFileMock: vi.fn(async () => undefined),
+  unlinkMock: vi.fn(async () => undefined),
   existsSyncMock: vi.fn(() => true),
   mkdirSyncMock: vi.fn(),
 }));
@@ -29,6 +31,7 @@ vi.mock("../src/lib/federation.js", () => ({
 
 vi.mock("node:fs/promises", () => ({
   writeFile: writeFileMock,
+  unlink: unlinkMock,
 }));
 
 vi.mock("node:fs", () => ({
@@ -39,6 +42,7 @@ vi.mock("node:fs", () => ({
 import {
   generateAndSaveOgImage,
   generateAndSaveRemoteOgImage,
+  clearRemoteOgImage,
   isOgEligibleVisibility,
   isRemoteActivityOgEligible,
 } from "../src/routes/og-images.js";
@@ -249,6 +253,69 @@ describe("generateAndSaveOgImage temporal payload", () => {
     expect(warnSpy).toHaveBeenCalledOnce();
 
     warnSpy.mockRestore();
+  });
+
+  it("clears remote og_image_url and removes image file", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, all_day,
+        start_at_utc, event_timezone, timezone_quality,
+        og_image_url, fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/cleanup",
+      "https://remote.example/users/alice",
+      "Remote Event Cleanup",
+      "2026-02-15T18:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "/og-images/remote-123.png?v=100",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    await clearRemoteOgImage(db, "https://remote.example/events/cleanup");
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/cleanup") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
+    expect(unlinkMock).toHaveBeenCalledOnce();
+    expect(unlinkMock.mock.calls[0]?.[0]).toContain("remote-123.png");
+  });
+
+  it("clears remote og_image_url even when file is already missing", async () => {
+    const db = initDatabase(":memory:");
+    unlinkMock.mockRejectedValueOnce(Object.assign(new Error("missing"), { code: "ENOENT" }));
+    db.prepare(
+      `INSERT INTO remote_events (
+        uri, actor_uri, title, start_date, all_day,
+        start_at_utc, event_timezone, timezone_quality,
+        og_image_url, fetched_at, canceled
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(
+      "https://remote.example/events/missing",
+      "https://remote.example/users/alice",
+      "Remote Event Missing File",
+      "2026-02-15T18:00:00+01:00",
+      0,
+      "2026-02-15T17:00:00.000Z",
+      "Europe/Vienna",
+      "exact_tzid",
+      "/og-images/remote-missing.png?v=100",
+      "2026-02-10T12:00:00.000Z",
+      0,
+    );
+
+    await expect(clearRemoteOgImage(db, "https://remote.example/events/missing")).resolves.toBeUndefined();
+
+    const row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get("https://remote.example/events/missing") as {
+      og_image_url: string | null;
+    };
+    expect(row.og_image_url).toBeNull();
   });
 });
 

--- a/packages/server/tests/og-job-queue.test.ts
+++ b/packages/server/tests/og-job-queue.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetOgJobQueueForTests,
+  __setOgJobQueueConcurrencyForTests,
+  __waitForOgJobQueueIdleForTests,
+  enqueueOgJob,
+  getOgJobQueueStats,
+} from "../src/lib/og-job-queue.js";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createGate(): { wait: Promise<void>; open: () => void } {
+  let release: (() => void) | null = null;
+  return {
+    wait: new Promise<void>((resolve) => {
+      release = resolve;
+    }),
+    open: () => release?.(),
+  };
+}
+
+describe("og job queue", () => {
+  beforeEach(() => {
+    __resetOgJobQueueForTests();
+    __setOgJobQueueConcurrencyForTests(3);
+  });
+
+  it("caps concurrent jobs at configured concurrency", async () => {
+    __setOgJobQueueConcurrencyForTests(2);
+
+    let running = 0;
+    let maxRunning = 0;
+
+    for (let i = 0; i < 8; i += 1) {
+      enqueueOgJob(`event-${i}`, async () => {
+        running += 1;
+        maxRunning = Math.max(maxRunning, running);
+        await delay(20);
+        running -= 1;
+      });
+    }
+
+    await __waitForOgJobQueueIdleForTests();
+
+    expect(maxRunning).toBeLessThanOrEqual(2);
+    expect(getOgJobQueueStats().depth).toBe(0);
+  });
+
+  it("coalesces repeated jobs for the same event key", async () => {
+    __setOgJobQueueConcurrencyForTests(1);
+
+    const firstStarted = createGate();
+    const releaseFirst = createGate();
+    const calls: string[] = [];
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("first");
+      firstStarted.open();
+      await releaseFirst.wait;
+    });
+
+    await firstStarted.wait;
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("second");
+    });
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("third");
+    });
+
+    enqueueOgJob("remote:event-b", async () => {
+      calls.push("other");
+    });
+
+    releaseFirst.open();
+    await __waitForOgJobQueueIdleForTests();
+
+    expect(calls[0]).toBe("first");
+    expect(calls).toContain("other");
+    expect(calls).toContain("third");
+    expect(calls).not.toContain("second");
+    expect(getOgJobQueueStats().coalesced).toBe(1);
+    expect(getOgJobQueueStats().depth).toBe(0);
+  });
+});

--- a/packages/server/tests/og-job-queue.test.ts
+++ b/packages/server/tests/og-job-queue.test.ts
@@ -138,4 +138,25 @@ describe("og job queue", () => {
     expect(getOgJobQueueStats().coalesced).toBe(2);
     expect(getOgJobQueueStats().depth).toBe(0);
   });
+
+  it("releases active slot when a job throws synchronously", async () => {
+    __setOgJobQueueConcurrencyForTests(1);
+
+    const calls: string[] = [];
+
+    enqueueOgJob("remote:event-a", () => {
+      calls.push("boom");
+      throw new Error("sync failure");
+    });
+
+    enqueueOgJob("remote:event-b", async () => {
+      calls.push("after");
+    });
+
+    await __waitForOgJobQueueIdleForTests();
+
+    expect(calls).toEqual(["boom", "after"]);
+    expect(getOgJobQueueStats().depth).toBe(0);
+    expect(getOgJobQueueStats().active).toBe(0);
+  });
 });

--- a/packages/server/tests/og-job-queue.test.ts
+++ b/packages/server/tests/og-job-queue.test.ts
@@ -82,7 +82,60 @@ describe("og job queue", () => {
     expect(calls).toContain("other");
     expect(calls).toContain("third");
     expect(calls).not.toContain("second");
-    expect(getOgJobQueueStats().coalesced).toBe(1);
+    expect(getOgJobQueueStats().coalesced).toBe(2);
+    expect(getOgJobQueueStats().depth).toBe(0);
+  });
+
+  it("defers and coalesces jobs enqueued for an active key", async () => {
+    __setOgJobQueueConcurrencyForTests(2);
+
+    const firstStarted = createGate();
+    const releaseFirst = createGate();
+    const calls: string[] = [];
+    let runningForKey = 0;
+    let maxRunningForKey = 0;
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("first");
+      runningForKey += 1;
+      maxRunningForKey = Math.max(maxRunningForKey, runningForKey);
+      firstStarted.open();
+      await releaseFirst.wait;
+      runningForKey -= 1;
+    });
+
+    await firstStarted.wait;
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("second");
+      runningForKey += 1;
+      maxRunningForKey = Math.max(maxRunningForKey, runningForKey);
+      await delay(5);
+      runningForKey -= 1;
+    });
+
+    enqueueOgJob("remote:event-a", async () => {
+      calls.push("third");
+      runningForKey += 1;
+      maxRunningForKey = Math.max(maxRunningForKey, runningForKey);
+      await delay(5);
+      runningForKey -= 1;
+    });
+
+    enqueueOgJob("remote:event-b", async () => {
+      calls.push("other");
+      await delay(5);
+    });
+
+    releaseFirst.open();
+    await __waitForOgJobQueueIdleForTests();
+
+    expect(maxRunningForKey).toBe(1);
+    expect(calls[0]).toBe("first");
+    expect(calls).toContain("other");
+    expect(calls).toContain("third");
+    expect(calls).not.toContain("second");
+    expect(getOgJobQueueStats().coalesced).toBe(2);
     expect(getOgJobQueueStats().depth).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- remove the public `/api/v1/og-images` API route and keep OG generation on trusted server-side flows only
- restrict OG generation to `public` and `unlisted` events, including scraper `/sync` upserts and remote ActivityPub ingestion
- add remote OG image persistence support (`remote_events.og_image_url`) plus serializer/test coverage for local, scraped, and remote OG behavior

## Validation
- pnpm --filter @everycal/server lint
- pnpm --filter @everycal/server test
- pnpm lint
- pnpm test