### PR TITLE
Refactor: make temporal the single timezone conversion source

### DIFF
--- a/packages/core/src/ical.test.ts
+++ b/packages/core/src/ical.test.ts
@@ -67,6 +67,11 @@ describe("ical timezone export/import", () => {
     expect(localInZoneToUtcIso("2024-10-27T02:30:00.500", "Europe/Vienna")).toBe("2024-10-27T01:30:00.500Z");
   });
 
+  it("returns null for invalid timezone or invalid local datetime", () => {
+    expect(localInZoneToUtcIso("2024-01-15T10:00:00", "Mars/Olympus_Mons")).toBeNull();
+    expect(localInZoneToUtcIso("not-a-datetime", "Europe/Vienna")).toBeNull();
+  });
+
   it("exports UTC fallback when timezone is unknown", () => {
     const event = baseEvent({
       startAtUtc: "2026-03-01T09:00:00.000Z",

--- a/packages/core/src/ical.test.ts
+++ b/packages/core/src/ical.test.ts
@@ -208,6 +208,55 @@ describe("ical timezone export/import", () => {
     expect(parsed.timezoneQuality).toBeUndefined();
   });
 
+  it("rejects invalid iCal DATE-TIME values with TZID", () => {
+    const parsed = fromICal([
+      "BEGIN:VEVENT",
+      "UID:invalid-datetime-tzid-1",
+      "DTSTART;TZID=Europe/Vienna:20260230T100000",
+      "DTEND;TZID=Europe/Vienna:20260230T110000",
+      "END:VEVENT",
+    ].join("\r\n"));
+
+    expect(parsed.startDate).toBeUndefined();
+    expect(parsed.endDate).toBeUndefined();
+    expect(parsed.startAtUtc).toBeUndefined();
+    expect(parsed.endAtUtc).toBeUndefined();
+    expect(parsed.eventTimezone).toBeUndefined();
+    expect(parsed.timezoneQuality).toBeUndefined();
+  });
+
+  it("rejects invalid iCal DATE-TIME values with offset", () => {
+    const parsed = fromICal([
+      "BEGIN:VEVENT",
+      "UID:invalid-datetime-offset-1",
+      "DTSTART:20260230T100000Z",
+      "DTEND:20260230T110000Z",
+      "END:VEVENT",
+    ].join("\r\n"));
+
+    expect(parsed.startDate).toBeUndefined();
+    expect(parsed.endDate).toBeUndefined();
+    expect(parsed.startAtUtc).toBeUndefined();
+    expect(parsed.endAtUtc).toBeUndefined();
+    expect(parsed.timezoneQuality).toBeUndefined();
+  });
+
+  it("keeps valid floating DATE-TIME values without UTC", () => {
+    const parsed = fromICal([
+      "BEGIN:VEVENT",
+      "UID:floating-datetime-1",
+      "DTSTART:20260301T100000",
+      "DTEND:20260301T110000",
+      "END:VEVENT",
+    ].join("\r\n"));
+
+    expect(parsed.startDate).toBe("2026-03-01T10:00:00");
+    expect(parsed.endDate).toBe("2026-03-01T11:00:00");
+    expect(parsed.startAtUtc).toBeUndefined();
+    expect(parsed.endAtUtc).toBeUndefined();
+    expect(parsed.timezoneQuality).toBe("unknown");
+  });
+
   it("keeps folded lines and parameterized keys parseable", () => {
     const parsed = fromICal([
       "BEGIN:VEVENT",

--- a/packages/core/src/ical.test.ts
+++ b/packages/core/src/ical.test.ts
@@ -175,6 +175,39 @@ describe("ical timezone export/import", () => {
     expect(parsed.endDate).toBe("2026-05-10");
   });
 
+  it("imports all-day TZID events into UTC when conversion succeeds", () => {
+    const parsed = fromICal([
+      "BEGIN:VEVENT",
+      "UID:all-day-tzid-1",
+      "DTSTART;VALUE=DATE;TZID=Europe/Vienna:20260510",
+      "DTEND;VALUE=DATE;TZID=Europe/Vienna:20260511",
+      "END:VEVENT",
+    ].join("\r\n"));
+
+    expect(parsed.allDay).toBe(true);
+    expect(parsed.startDate).toBe("2026-05-10");
+    expect(parsed.endDate).toBe("2026-05-10");
+    expect(parsed.startAtUtc).toBe("2026-05-09T22:00:00.000Z");
+    expect(parsed.endAtUtc).toBe("2026-05-10T22:00:00.000Z");
+    expect(parsed.timezoneQuality).toBe("exact_tzid");
+  });
+
+  it("rejects invalid iCal DATE values for all-day DTSTART", () => {
+    const parsed = fromICal([
+      "BEGIN:VEVENT",
+      "UID:all-day-invalid-date-1",
+      "DTSTART;VALUE=DATE;TZID=Europe/Vienna:20260230",
+      "DTEND;VALUE=DATE;TZID=Europe/Vienna:20260301",
+      "END:VEVENT",
+    ].join("\r\n"));
+
+    expect(parsed.startDate).toBeUndefined();
+    expect(parsed.endDate).toBeUndefined();
+    expect(parsed.startAtUtc).toBeUndefined();
+    expect(parsed.endAtUtc).toBeUndefined();
+    expect(parsed.timezoneQuality).toBeUndefined();
+  });
+
   it("keeps folded lines and parameterized keys parseable", () => {
     const parsed = fromICal([
       "BEGIN:VEVENT",

--- a/packages/core/src/ical.ts
+++ b/packages/core/src/ical.ts
@@ -291,13 +291,23 @@ function parseDateProperty(prop?: ParsedProperty):
   const date = `${m[1].slice(0, 4)}-${m[1].slice(4, 6)}-${m[1].slice(6, 8)}`;
   const time = `${m[2].slice(0, 2)}:${m[2].slice(2, 4)}:${m[2].slice(4, 6)}`;
   const suffix = m[3] || "";
+  const year = Number(m[1].slice(0, 4));
+  const month = Number(m[1].slice(4, 6));
+  const day = Number(m[1].slice(6, 8));
+  const hour = Number(m[2].slice(0, 2));
+  const minute = Number(m[2].slice(2, 4));
+  const second = Number(m[2].slice(4, 6));
+
+  if (!isValidDateTimeParts(year, month, day, hour, minute, second)) return null;
 
   if (tzid) {
     const display = `${date}T${time}`;
+    const utc = localInZoneToUtcIso(display, tzid);
+    if (!utc) return null;
     return {
       kind: "date-time",
       display,
-      utc: localInZoneToUtcIso(display, tzid),
+      utc,
       tzid,
       hadOffset: false,
     };
@@ -308,6 +318,7 @@ function parseDateProperty(prop?: ParsedProperty):
     : suffix;
   const display = normalizedSuffix ? `${date}T${time}${normalizedSuffix}` : `${date}T${time}`;
   const utc = deriveUtcFromTemporalInput(display, { allDay: false, eventTimezone: null });
+  if (normalizedSuffix && !utc) return null;
 
   return {
     kind: "date-time",
@@ -352,6 +363,23 @@ function isValidDateOnly(value: string): boolean {
   return parsed.getUTCFullYear() === year
     && parsed.getUTCMonth() === month - 1
     && parsed.getUTCDate() === day;
+}
+
+function isValidDateTimeParts(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+): boolean {
+  const parsed = new Date(Date.UTC(year, month - 1, day, hour, minute, second, 0));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day
+    && parsed.getUTCHours() === hour
+    && parsed.getUTCMinutes() === minute
+    && parsed.getUTCSeconds() === second;
 }
 
 export function localInZoneToUtcIso(localIso: string, timeZone: string): string | null {

--- a/packages/core/src/ical.ts
+++ b/packages/core/src/ical.ts
@@ -138,10 +138,16 @@ export function fromICal(vevent: string): Partial<EveryCalEvent> {
     }
 
     if (parsedStart.tzid) {
-      event.startAtUtc = localInZoneToUtcIso(`${parsedStart.date}T00:00:00`, parsedStart.tzid);
+      const startAtUtc = localInZoneToUtcIso(`${parsedStart.date}T00:00:00`, parsedStart.tzid);
       const exclusiveEnd = addDays(event.endDate, 1);
-      event.endAtUtc = localInZoneToUtcIso(`${exclusiveEnd}T00:00:00`, parsedStart.tzid);
-      event.timezoneQuality = "exact_tzid";
+      const endAtUtc = localInZoneToUtcIso(`${exclusiveEnd}T00:00:00`, parsedStart.tzid);
+      if (startAtUtc && endAtUtc) {
+        event.startAtUtc = startAtUtc;
+        event.endAtUtc = endAtUtc;
+        event.timezoneQuality = "exact_tzid";
+      } else {
+        event.timezoneQuality = "unknown";
+      }
     } else {
       event.timezoneQuality = "unknown";
     }
@@ -275,6 +281,7 @@ function parseDateProperty(prop?: ParsedProperty):
 
   if (prop.params.VALUE === "DATE" || /^\d{8}$/.test(value)) {
     const date = `${value.slice(0, 4)}-${value.slice(4, 6)}-${value.slice(6, 8)}`;
+    if (!isValidDateOnly(date)) return null;
     return { kind: "date", date, tzid };
   }
 
@@ -333,6 +340,18 @@ function addDays(date: string, days: number): string {
   const base = new Date(`${date}T00:00:00Z`);
   base.setUTCDate(base.getUTCDate() + days);
   return base.toISOString().slice(0, 10);
+}
+
+function isValidDateOnly(value: string): boolean {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  return parsed.getUTCFullYear() === year
+    && parsed.getUTCMonth() === month - 1
+    && parsed.getUTCDate() === day;
 }
 
 export function localInZoneToUtcIso(localIso: string, timeZone: string): string | null {

--- a/packages/core/src/ical.ts
+++ b/packages/core/src/ical.ts
@@ -1,5 +1,6 @@
 import { getVtimezoneComponent } from "@touch4it/ical-timezones";
 import { EveryCalEvent, type TimezoneQuality } from "./event.js";
+import { deriveUtcFromTemporalInput, isValidIanaTimezone, localDateTimeWithTimezoneToUtcIso } from "./temporal.js";
 
 export interface ToICalOptions {
   tentative?: boolean;
@@ -20,9 +21,7 @@ interface ParsedProperty {
   value: string;
 }
 
-const ISO_HAS_OFFSET = /(Z|[+-]\d{2}:\d{2})$/i;
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-const LOCAL_DATE_TIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/;
 
 export function toICalendar(entries: CalendarEntry[], options?: ToICalendarOptions): string {
   const normalized = entries.map((entry) => ("event" in entry ? entry : { event: entry }));
@@ -204,16 +203,10 @@ function resolveTimedUtcForExport(event: EveryCalEvent, isStart: boolean): strin
   if (explicitUtc) return explicitUtc;
 
   const source = isStart ? event.startDate : event.endDate;
-  if (!source) return null;
-  if (ISO_HAS_OFFSET.test(source)) return absoluteIsoToUtcIso(source);
-
-  const tzid = event.eventTimezone;
-  if (!tzid || !isValidIanaTimezone(tzid)) return null;
-
-  if (DATE_ONLY.test(source)) return null;
-  const normalized = source.includes(" ") ? source.replace(" ", "T") : source;
-  if (!LOCAL_DATE_TIME.test(normalized)) return null;
-  return localInZoneToUtcIso(normalized, tzid);
+  return deriveUtcFromTemporalInput(source, {
+    allDay: false,
+    eventTimezone: event.eventTimezone || null,
+  });
 }
 
 function toWallTimeBasic(utc: string, tzid: string): string {
@@ -307,7 +300,7 @@ function parseDateProperty(prop?: ParsedProperty):
     ? `${suffix.slice(0, 3)}:${suffix.slice(3, 5)}`
     : suffix;
   const display = normalizedSuffix ? `${date}T${time}${normalizedSuffix}` : `${date}T${time}`;
-  const utc = absoluteIsoToUtcIso(display);
+  const utc = deriveUtcFromTemporalInput(display, { allDay: false, eventTimezone: null });
 
   return {
     kind: "date-time",
@@ -342,74 +335,8 @@ function addDays(date: string, days: number): string {
   return base.toISOString().slice(0, 10);
 }
 
-function absoluteIsoToUtcIso(value: string | null | undefined): string | null {
-  if (!value) return null;
-  if (!ISO_HAS_OFFSET.test(value)) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toISOString();
-}
-
-function isValidIanaTimezone(tz: string): boolean {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: tz });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function getTimeZoneOffsetMs(instant: Date, timeZone: string): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour12: false,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).formatToParts(instant);
-  const map = Object.fromEntries(parts.filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
-  const asUtc = Date.UTC(
-    Number(map.year),
-    Number(map.month) - 1,
-    Number(map.day),
-    Number(map.hour),
-    Number(map.minute),
-    Number(map.second),
-  );
-  const instantUtcSecond = Date.UTC(
-    instant.getUTCFullYear(),
-    instant.getUTCMonth(),
-    instant.getUTCDate(),
-    instant.getUTCHours(),
-    instant.getUTCMinutes(),
-    instant.getUTCSeconds(),
-  );
-  return asUtc - instantUtcSecond;
-}
-
-export function localInZoneToUtcIso(localIso: string, timeZone: string): string {
-  const m = localIso.match(LOCAL_DATE_TIME);
-  if (!m) {
-    const parsed = new Date(localIso);
-    return Number.isNaN(parsed.getTime()) ? localIso : parsed.toISOString();
-  }
-
-  const [, y, mo, d, h, mi, s, frac] = m;
-  const milliseconds = frac ? Number(frac.padEnd(3, "0")) : 0;
-  const naiveUtcMs = Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s || "0"), milliseconds);
-
-  let candidateMs = naiveUtcMs;
-  for (let i = 0; i < 4; i += 1) {
-    const offset = getTimeZoneOffsetMs(new Date(candidateMs), timeZone);
-    const next = naiveUtcMs - offset;
-    if (next === candidateMs) break;
-    candidateMs = next;
-  }
-
-  return new Date(candidateMs).toISOString();
+export function localInZoneToUtcIso(localIso: string, timeZone: string): string | null {
+  return localDateTimeWithTimezoneToUtcIso(localIso, timeZone);
 }
 
 function escapeICalText(text: string): string {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,5 +14,19 @@ export {
   isValidHttpUrl,
 } from "./validators.js";
 export { bootstrapViewerToUser, isAppBootstrap, isAppLocale } from "./bootstrap.js";
+export {
+  isValidIanaTimezone,
+  localDateTimeWithTimezoneToUtcIso,
+  datePartFromUtcInstantInTimezone,
+  deriveUtcFromTemporalInput,
+  deriveAllDayEndAtUtc,
+  deriveEventEndAtUtc,
+  deriveEventUtcRange,
+} from "./temporal.js";
 export type { AppBootstrap, AppLocale, BootstrapUser, BootstrapViewer } from "./bootstrap.js";
+export type {
+  DeriveUtcFromTemporalInputOptions,
+  DeriveEventEndAtUtcOptions,
+  DerivedEventUtcRange,
+} from "./temporal.js";
 export type { SsrEventData, SsrInitialData, SsrProfileData } from "./ssr.js";

--- a/packages/core/src/temporal.test.ts
+++ b/packages/core/src/temporal.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  datePartFromUtcInstantInTimezone,
+  deriveEventUtcRange,
+  isValidIanaTimezone,
+  localDateTimeWithTimezoneToUtcIso,
+} from "./temporal";
+
+describe("temporal", () => {
+  it("validates IANA timezones", () => {
+    expect(isValidIanaTimezone("America/New_York")).toBe(true);
+    expect(isValidIanaTimezone("Mars/Olympus_Mons")).toBe(false);
+  });
+
+  it("converts local date-time in timezone to UTC", () => {
+    expect(localDateTimeWithTimezoneToUtcIso("2026-01-15T18:30", "America/New_York")).toBe("2026-01-15T23:30:00.000Z");
+  });
+
+  it("derives UTC range for all-day events using exclusive end", () => {
+    expect(
+      deriveEventUtcRange("2026-01-15", "2026-01-15", {
+        allDay: true,
+        eventTimezone: "America/New_York",
+      }),
+    ).toEqual({
+      startAtUtc: "2026-01-15T05:00:00.000Z",
+      endAtUtc: "2026-01-16T05:00:00.000Z",
+    });
+  });
+
+  it("derives date-part in timezone from UTC instant", () => {
+    expect(datePartFromUtcInstantInTimezone("2026-01-15T02:00:00.000Z", "America/Los_Angeles")).toBe("2026-01-14");
+  });
+});

--- a/packages/core/src/temporal.test.ts
+++ b/packages/core/src/temporal.test.ts
@@ -16,6 +16,14 @@ describe("temporal", () => {
     expect(localDateTimeWithTimezoneToUtcIso("2026-01-15T18:30", "America/New_York")).toBe("2026-01-15T23:30:00.000Z");
   });
 
+  it("maps nonexistent spring-forward local times deterministically", () => {
+    expect(localDateTimeWithTimezoneToUtcIso("2026-03-08T02:30", "America/New_York")).toBe("2026-03-08T06:30:00.000Z");
+  });
+
+  it("maps ambiguous fall-back local times to the first occurrence", () => {
+    expect(localDateTimeWithTimezoneToUtcIso("2026-11-01T01:30", "America/New_York")).toBe("2026-11-01T05:30:00.000Z");
+  });
+
   it("derives UTC range for all-day events using exclusive end", () => {
     expect(
       deriveEventUtcRange("2026-01-15", "2026-01-15", {
@@ -25,6 +33,30 @@ describe("temporal", () => {
     ).toEqual({
       startAtUtc: "2026-01-15T05:00:00.000Z",
       endAtUtc: "2026-01-16T05:00:00.000Z",
+    });
+  });
+
+  it("derives spring-forward all-day range with a 23-hour UTC span", () => {
+    expect(
+      deriveEventUtcRange("2026-03-08", "2026-03-08", {
+        allDay: true,
+        eventTimezone: "America/New_York",
+      }),
+    ).toEqual({
+      startAtUtc: "2026-03-08T05:00:00.000Z",
+      endAtUtc: "2026-03-09T04:00:00.000Z",
+    });
+  });
+
+  it("derives fall-back all-day range with a 25-hour UTC span", () => {
+    expect(
+      deriveEventUtcRange("2026-11-01", "2026-11-01", {
+        allDay: true,
+        eventTimezone: "America/New_York",
+      }),
+    ).toEqual({
+      startAtUtc: "2026-11-01T04:00:00.000Z",
+      endAtUtc: "2026-11-02T05:00:00.000Z",
     });
   });
 

--- a/packages/core/src/temporal.test.ts
+++ b/packages/core/src/temporal.test.ts
@@ -16,6 +16,11 @@ describe("temporal", () => {
     expect(localDateTimeWithTimezoneToUtcIso("2026-01-15T18:30", "America/New_York")).toBe("2026-01-15T23:30:00.000Z");
   });
 
+  it("rejects invalid local date-time inputs", () => {
+    expect(localDateTimeWithTimezoneToUtcIso("2026-02-30T18:30", "America/New_York")).toBeNull();
+    expect(localDateTimeWithTimezoneToUtcIso("not-a-datetime", "America/New_York")).toBeNull();
+  });
+
   it("maps nonexistent spring-forward local times deterministically", () => {
     expect(localDateTimeWithTimezoneToUtcIso("2026-03-08T02:30", "America/New_York")).toBe("2026-03-08T06:30:00.000Z");
   });

--- a/packages/core/src/temporal.ts
+++ b/packages/core/src/temporal.ts
@@ -1,0 +1,250 @@
+const ISO_HAS_OFFSET = /(Z|[+-]\d{2}:\d{2})$/i;
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+const LOCAL_DATE_TIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/;
+
+export interface DeriveUtcFromTemporalInputOptions {
+  allDay: boolean;
+  eventTimezone: string | null;
+}
+
+export interface DeriveEventEndAtUtcOptions extends DeriveUtcFromTemporalInputOptions {
+  startValueForAllDay: string;
+}
+
+export interface DerivedEventUtcRange {
+  startAtUtc: string | null;
+  endAtUtc: string | null;
+}
+
+interface UtcDateTimeParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  millisecond: number;
+}
+
+function buildStrictUtcDate(parts: UtcDateTimeParts): Date | null {
+  const instant = new Date(
+    Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+      parts.millisecond,
+    ),
+  );
+
+  if (Number.isNaN(instant.getTime())) return null;
+  if (
+    instant.getUTCFullYear() !== parts.year
+    || instant.getUTCMonth() !== parts.month - 1
+    || instant.getUTCDate() !== parts.day
+    || instant.getUTCHours() !== parts.hour
+    || instant.getUTCMinutes() !== parts.minute
+    || instant.getUTCSeconds() !== parts.second
+    || instant.getUTCMilliseconds() !== parts.millisecond
+  ) {
+    return null;
+  }
+
+  return instant;
+}
+
+function parseDateOnlyParts(value: string): { year: number; month: number; day: number } | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const strict = buildStrictUtcDate({
+    year,
+    month,
+    day,
+    hour: 0,
+    minute: 0,
+    second: 0,
+    millisecond: 0,
+  });
+  if (!strict) return null;
+  return { year, month, day };
+}
+
+function formatDateOnlyUtc(instant: Date): string {
+  const year = instant.getUTCFullYear();
+  const month = String(instant.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(instant.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function addDaysToDateOnly(value: string, days: number): string | null {
+  const parsed = parseDateOnlyParts(value);
+  if (!parsed) return null;
+  const shifted = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day + days));
+  return formatDateOnlyUtc(shifted);
+}
+
+export function isValidIanaTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getTimeZoneOffsetMs(instant: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(instant);
+
+  const map = Object.fromEntries(parts.filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
+  const asUtc = Date.UTC(Number(map.year), Number(map.month) - 1, Number(map.day), Number(map.hour), Number(map.minute), Number(map.second));
+  const instantUtcSecond = Date.UTC(
+    instant.getUTCFullYear(),
+    instant.getUTCMonth(),
+    instant.getUTCDate(),
+    instant.getUTCHours(),
+    instant.getUTCMinutes(),
+    instant.getUTCSeconds(),
+  );
+  return asUtc - instantUtcSecond;
+}
+
+function absoluteIsoWithOffsetToUtcIso(value: string): string | null {
+  if (!ISO_HAS_OFFSET.test(value)) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+export function localDateTimeWithTimezoneToUtcIso(localIso: string, timeZone: string): string | null {
+  if (!isValidIanaTimezone(timeZone)) return null;
+  const normalized = localIso.includes(" ") ? localIso.replace(" ", "T") : localIso;
+  const m = normalized.match(LOCAL_DATE_TIME);
+  if (!m) return null;
+
+  const [, y, mo, d, h, mi, s, frac] = m;
+  const year = Number(y);
+  const month = Number(mo);
+  const day = Number(d);
+  const hour = Number(h);
+  const minute = Number(mi);
+  const second = Number(s || "0");
+  const milliseconds = frac ? Number(frac.padEnd(3, "0")) : 0;
+  const naiveUtc = buildStrictUtcDate({
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    millisecond: milliseconds,
+  });
+  if (!naiveUtc) return null;
+  const naiveUtcMs = naiveUtc.getTime();
+
+  let candidateMs = naiveUtcMs;
+  for (let i = 0; i < 4; i += 1) {
+    const offset = getTimeZoneOffsetMs(new Date(candidateMs), timeZone);
+    const next = naiveUtcMs - offset;
+    if (next === candidateMs) break;
+    candidateMs = next;
+  }
+
+  const parsed = new Date(candidateMs);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+export function datePartFromUtcInstantInTimezone(
+  utcIso: string | null | undefined,
+  timeZone: string | null | undefined,
+): string | null {
+  if (!utcIso || !timeZone || !isValidIanaTimezone(timeZone)) return null;
+  const parsed = new Date(utcIso);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(parsed);
+  const map = Object.fromEntries(parts.filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
+  const year = map.year;
+  const month = map.month;
+  const day = map.day;
+  if (!year || !month || !day) return null;
+  return `${year}-${month}-${day}`;
+}
+
+export function deriveUtcFromTemporalInput(
+  value: string | null | undefined,
+  options: DeriveUtcFromTemporalInputOptions,
+): string | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if (ISO_HAS_OFFSET.test(normalized)) return absoluteIsoWithOffsetToUtcIso(normalized);
+
+  if (DATE_ONLY.test(normalized)) {
+    if (!options.allDay || !options.eventTimezone) return null;
+    return localDateTimeWithTimezoneToUtcIso(`${normalized}T00:00:00`, options.eventTimezone);
+  }
+
+  if (!options.eventTimezone) return null;
+  return localDateTimeWithTimezoneToUtcIso(normalized, options.eventTimezone);
+}
+
+export function deriveAllDayEndAtUtc(
+  startDate: string,
+  endDate: string | null | undefined,
+  eventTimezone: string | null,
+): string | null {
+  const inclusiveEnd = endDate || startDate;
+  if (DATE_ONLY.test(inclusiveEnd)) {
+    const exclusiveEnd = addDaysToDateOnly(inclusiveEnd, 1);
+    if (!exclusiveEnd) return null;
+    return deriveUtcFromTemporalInput(exclusiveEnd, { allDay: true, eventTimezone });
+  }
+  return deriveUtcFromTemporalInput(inclusiveEnd, { allDay: true, eventTimezone });
+}
+
+export function deriveEventEndAtUtc(
+  endValue: string | null | undefined,
+  options: DeriveEventEndAtUtcOptions,
+): string | null {
+  if (options.allDay) {
+    return deriveAllDayEndAtUtc(options.startValueForAllDay, endValue ?? null, options.eventTimezone);
+  }
+  if (!endValue) return null;
+  return deriveUtcFromTemporalInput(endValue, { allDay: false, eventTimezone: options.eventTimezone });
+}
+
+export function deriveEventUtcRange(
+  startValue: string | null | undefined,
+  endValue: string | null | undefined,
+  options: DeriveUtcFromTemporalInputOptions,
+): DerivedEventUtcRange {
+  if (!startValue) return { startAtUtc: null, endAtUtc: null };
+  return {
+    startAtUtc: deriveUtcFromTemporalInput(startValue, options),
+    endAtUtc: deriveEventEndAtUtc(endValue, {
+      allDay: options.allDay,
+      eventTimezone: options.eventTimezone,
+      startValueForAllDay: startValue,
+    }),
+  };
+}

--- a/packages/server/src/lib/timezone.ts
+++ b/packages/server/src/lib/timezone.ts
@@ -1,15 +1,32 @@
-import { buildStrictUtcDate } from "./utc-date.js";
+import {
+  deriveEventEndAtUtc,
+  deriveUtcFromTemporalInput,
+  isValidIanaTimezone,
+} from "@everycal/core";
 
-const ISO_HAS_OFFSET = /(Z|[+-]\d{2}:\d{2})$/i;
 const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-const LOCAL_DATE_TIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,3}))?)?$/;
+
+function isValidDateOnly(value: string): boolean {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) return false;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const instant = new Date(Date.UTC(year, month - 1, day));
+  return (
+    !Number.isNaN(instant.getTime())
+    && instant.getUTCFullYear() === year
+    && instant.getUTCMonth() === month - 1
+    && instant.getUTCDate() === day
+  );
+}
 
 export function extractDatePart(value: string | null | undefined): string | null {
   if (!value) return null;
   const trimmed = value.trim();
-  if (DATE_ONLY.test(trimmed)) return parseDateOnlyParts(trimmed) ? trimmed : null;
+  if (DATE_ONLY.test(trimmed)) return isValidDateOnly(trimmed) ? trimmed : null;
   const prefix = trimmed.slice(0, 10);
-  return DATE_ONLY.test(prefix) && parseDateOnlyParts(prefix) ? prefix : null;
+  return DATE_ONLY.test(prefix) && isValidDateOnly(prefix) ? prefix : null;
 }
 
 export type TimezoneQuality = "exact_tzid" | "offset_only";
@@ -24,213 +41,21 @@ export interface NormalizedRemoteTemporal {
   timezoneQuality: TimezoneQuality;
 }
 
-export interface DeriveUtcFromTemporalInputOptions {
-  allDay: boolean;
-  eventTimezone: string | null;
-}
+export {
+  isValidIanaTimezone,
+  localDateTimeWithTimezoneToUtcIso,
+  datePartFromUtcInstantInTimezone,
+  deriveUtcFromTemporalInput,
+  deriveAllDayEndAtUtc,
+  deriveEventEndAtUtc,
+  deriveEventUtcRange,
+} from "@everycal/core";
 
-export interface DeriveEventEndAtUtcOptions extends DeriveUtcFromTemporalInputOptions {
-  startValueForAllDay: string;
-}
-
-export interface DerivedEventUtcRange {
-  startAtUtc: string | null;
-  endAtUtc: string | null;
-}
-
-function parseDateOnlyParts(value: string): { year: number; month: number; day: number } | null {
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  const strict = buildStrictUtcDate({
-    year,
-    month,
-    day,
-    hour: 0,
-    minute: 0,
-    second: 0,
-    millisecond: 0,
-  });
-  if (!strict) return null;
-  return { year, month, day };
-}
-
-function formatDateOnlyUtc(instant: Date): string {
-  const year = instant.getUTCFullYear();
-  const month = String(instant.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(instant.getUTCDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-}
-
-export function addDaysToDateOnly(value: string, days: number): string | null {
-  const parsed = parseDateOnlyParts(value);
-  if (!parsed) return null;
-  const shifted = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day + days));
-  return formatDateOnlyUtc(shifted);
-}
-
-export function isValidIanaTimezone(tz: string): boolean {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone: tz });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function getTimeZoneOffsetMs(instant: Date, timeZone: string): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour12: false,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).formatToParts(instant);
-
-  const map = Object.fromEntries(parts.filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
-  const asUtc = Date.UTC(Number(map.year), Number(map.month) - 1, Number(map.day), Number(map.hour), Number(map.minute), Number(map.second));
-  const instantUtcSecond = Date.UTC(
-    instant.getUTCFullYear(),
-    instant.getUTCMonth(),
-    instant.getUTCDate(),
-    instant.getUTCHours(),
-    instant.getUTCMinutes(),
-    instant.getUTCSeconds(),
-  );
-  return asUtc - instantUtcSecond;
-}
-
-export function localDateTimeWithTimezoneToUtcIso(localIso: string, timeZone: string): string | null {
-  if (!isValidIanaTimezone(timeZone)) return null;
-  const normalized = localIso.includes(" ") ? localIso.replace(" ", "T") : localIso;
-  const m = normalized.match(LOCAL_DATE_TIME);
-  if (!m) return null;
-
-  const [, y, mo, d, h, mi, s, frac] = m;
-  const year = Number(y);
-  const month = Number(mo);
-  const day = Number(d);
-  const hour = Number(h);
-  const minute = Number(mi);
-  const second = Number(s || "0");
-  const milliseconds = frac ? Number(frac.padEnd(3, "0")) : 0;
-  const naiveUtc = buildStrictUtcDate({
-    year,
-    month,
-    day,
-    hour,
-    minute,
-    second,
-    millisecond: milliseconds,
-  });
-  if (!naiveUtc) return null;
-  const naiveUtcMs = naiveUtc.getTime();
-
-  let candidateMs = naiveUtcMs;
-  for (let i = 0; i < 4; i += 1) {
-    const offset = getTimeZoneOffsetMs(new Date(candidateMs), timeZone);
-    const next = naiveUtcMs - offset;
-    if (next === candidateMs) break;
-    candidateMs = next;
-  }
-
-  const parsed = new Date(candidateMs);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toISOString();
-}
-
-export function absoluteIsoWithOffsetToUtcIso(value: string): string | null {
-  if (!ISO_HAS_OFFSET.test(value)) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
-  return parsed.toISOString();
-}
-
-export function datePartFromUtcInstantInTimezone(
-  utcIso: string | null | undefined,
-  timeZone: string | null | undefined,
-): string | null {
-  if (!utcIso || !timeZone || !isValidIanaTimezone(timeZone)) return null;
-  const parsed = new Date(utcIso);
-  if (Number.isNaN(parsed.getTime())) return null;
-
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(parsed);
-  const map = Object.fromEntries(parts.filter((p) => p.type !== "literal").map((p) => [p.type, p.value]));
-  const year = map.year;
-  const month = map.month;
-  const day = map.day;
-  if (!year || !month || !day) return null;
-  return `${year}-${month}-${day}`;
-}
-
-export function deriveUtcFromTemporalInput(
-  value: string | null | undefined,
-  options: DeriveUtcFromTemporalInputOptions,
-): string | null {
-  if (!value) return null;
-  const normalized = value.trim();
-  if (!normalized) return null;
-  if (ISO_HAS_OFFSET.test(normalized)) return absoluteIsoWithOffsetToUtcIso(normalized);
-
-  if (DATE_ONLY.test(normalized)) {
-    if (!options.allDay || !options.eventTimezone) return null;
-    return localDateTimeWithTimezoneToUtcIso(`${normalized}T00:00:00`, options.eventTimezone);
-  }
-
-  if (!options.eventTimezone) return null;
-  return localDateTimeWithTimezoneToUtcIso(normalized, options.eventTimezone);
-}
-
-export function deriveAllDayEndAtUtc(
-  startDate: string,
-  endDate: string | null | undefined,
-  eventTimezone: string | null,
-): string | null {
-  const inclusiveEnd = endDate || startDate;
-  if (DATE_ONLY.test(inclusiveEnd)) {
-    const exclusiveEnd = addDaysToDateOnly(inclusiveEnd, 1);
-    if (!exclusiveEnd) return null;
-    return deriveUtcFromTemporalInput(exclusiveEnd, { allDay: true, eventTimezone });
-  }
-  return deriveUtcFromTemporalInput(inclusiveEnd, { allDay: true, eventTimezone });
-}
-
-export function deriveEventEndAtUtc(
-  endValue: string | null | undefined,
-  options: DeriveEventEndAtUtcOptions,
-): string | null {
-  if (options.allDay) {
-    return deriveAllDayEndAtUtc(options.startValueForAllDay, endValue ?? null, options.eventTimezone);
-  }
-  if (!endValue) return null;
-  return deriveUtcFromTemporalInput(endValue, { allDay: false, eventTimezone: options.eventTimezone });
-}
-
-export function deriveEventUtcRange(
-  startValue: string | null | undefined,
-  endValue: string | null | undefined,
-  options: DeriveUtcFromTemporalInputOptions,
-): DerivedEventUtcRange {
-  if (!startValue) return { startAtUtc: null, endAtUtc: null };
-  return {
-    startAtUtc: deriveUtcFromTemporalInput(startValue, options),
-    endAtUtc: deriveEventEndAtUtc(endValue, {
-      allDay: options.allDay,
-      eventTimezone: options.eventTimezone,
-      startValueForAllDay: startValue,
-    }),
-  };
-}
+export type {
+  DeriveUtcFromTemporalInputOptions,
+  DeriveEventEndAtUtcOptions,
+  DerivedEventUtcRange,
+} from "@everycal/core";
 
 function resolveTimezoneHint(object: Record<string, unknown>): string | null {
   const candidates = [object.eventTimezone, object.timezone, object.tzid];

--- a/packages/web/src/pages/NewEventPage.tsx
+++ b/packages/web/src/pages/NewEventPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, useRef, useEffect, useCallback, useId } from "react";
 import { useLocation, Link } from "wouter";
 import { useTranslation } from "react-i18next";
-import { isValidHttpUrl, normalizeHttpUrlInput } from "@everycal/core";
+import { isValidHttpUrl, localDateTimeWithTimezoneToUtcIso, normalizeHttpUrlInput } from "@everycal/core";
 import {
   events as eventsApi,
   locations as locationsApi,
@@ -68,18 +68,6 @@ function completeDatetimeLocal(
   return null;
 }
 
-function parseDateTimeLocal(value: string): { year: number; month: number; day: number; hour: number; minute: number } | null {
-  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);
-  if (!m) return null;
-  return {
-    year: Number(m[1]),
-    month: Number(m[2]),
-    day: Number(m[3]),
-    hour: Number(m[4]),
-    minute: Number(m[5]),
-  };
-}
-
 function formatLocalFromParts(parts: { year: number; month: number; day: number; hour: number; minute: number }): string {
   return `${String(parts.year).padStart(4, "0")}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}T${String(parts.hour).padStart(2, "0")}:${String(parts.minute).padStart(2, "0")}`;
 }
@@ -109,19 +97,10 @@ function formatInTimeZoneParts(ms: number, timeZone: string): { year: number; mo
 }
 
 function localDateTimeToUtcMillis(value: string, timeZone: string): number | null {
-  const desired = parseDateTimeLocal(value);
-  if (!desired) return null;
-  let guess = Date.UTC(desired.year, desired.month - 1, desired.day, desired.hour, desired.minute);
-  for (let i = 0; i < 4; i += 1) {
-    const actual = formatInTimeZoneParts(guess, timeZone);
-    if (!actual) return null;
-    const desiredMs = Date.UTC(desired.year, desired.month - 1, desired.day, desired.hour, desired.minute);
-    const actualMs = Date.UTC(actual.year, actual.month - 1, actual.day, actual.hour, actual.minute);
-    const diffMinutes = Math.round((desiredMs - actualMs) / 60000);
-    if (diffMinutes === 0) return guess;
-    guess += diffMinutes * 60000;
-  }
-  return guess;
+  const utcIso = localDateTimeWithTimezoneToUtcIso(value, timeZone);
+  if (!utcIso) return null;
+  const ms = new Date(utcIso).getTime();
+  return Number.isNaN(ms) ? null : ms;
 }
 
 function utcMillisToLocalDateTime(ms: number, timeZone: string): string {


### PR DESCRIPTION
## Motivation
- Remove duplicated DST/offset conversion logic from `ical.ts` and `temporal.ts` so only one algorithm is maintained.
- Deliberately align the iCal conversion API with temporal's strict semantics.

## What changed
- Updated `packages/core/src/ical.ts` to delegate timed UTC derivation to `deriveUtcFromTemporalInput` in `temporal.ts`.
- Replaced `ical.ts`'s local timezone solver/offset helpers with a wrapper: `localInZoneToUtcIso` now calls `localDateTimeWithTimezoneToUtcIso`.
- Changed the `localInZoneToUtcIso` API to return `string | null` (breaking change) and to reject invalid timezone/local datetime inputs.
- Added/updated tests in `packages/core/src/ical.test.ts` and `packages/core/src/temporal.test.ts` to lock strict-null behavior and invalid-date rejection.

## Testing
- `pnpm --filter @everycal/core test`
- `pnpm test`