### PR TITLE
refactor(server): extract shared event write logic into lib/event-write.ts

### DIFF
--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -64,6 +64,12 @@ export type NormalizedWriteInput = {
   allDay: boolean;
 };
 
+function normalizeTemporalValue(value: string | null | undefined): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
 export function normalizeEventWriteInput(input: {
   startDate?: string;
   startDateTime?: string;
@@ -73,21 +79,25 @@ export function normalizeEventWriteInput(input: {
   allDay?: boolean;
   allowDateTimeFields: boolean;
 }): NormalizedWriteInput | null {
+  const startDate = normalizeTemporalValue(input.startDate);
+  const startDateTime = normalizeTemporalValue(input.startDateTime);
+  const endDate = normalizeTemporalValue(input.endDate);
+  const endDateTime = normalizeTemporalValue(input.endDateTime);
   const startValue = input.allowDateTimeFields
-    ? (input.startDateTime ?? input.startDate)
-    : input.startDate;
+    ? (startDateTime || startDate)
+    : startDate;
   const endValue = input.allowDateTimeFields
-    ? (input.endDateTime ?? input.endDate)
-    : input.endDate;
+    ? (endDateTime || endDate)
+    : endDate;
   if (!startValue || !input.eventTimezone) return null;
 
   const allDay = !!input.allDay;
   if (allDay) {
-    if (input.allowDateTimeFields && (input.startDateTime !== undefined || input.endDateTime !== undefined)) {
+    if (input.allowDateTimeFields && (startDateTime !== undefined || endDateTime !== undefined)) {
       return null;
     }
-    if (!input.startDate || !isDateOnly(input.startDate)) return null;
-    if (input.endDate !== undefined && input.endDate !== null && !isDateOnly(input.endDate)) return null;
+    if (!startDate || !isDateOnly(startDate)) return null;
+    if (endDate !== undefined && !isDateOnly(endDate)) return null;
   }
 
   return {

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -76,15 +76,15 @@ function normalizeTemporalValue(
   options?: { nullable?: boolean },
 ): { value: string | null | undefined; invalid: boolean } {
   if (value === undefined) return { value: undefined, invalid: false };
-  if (value === null) return options?.nullable ? { value: null, invalid: false } : { value: undefined, invalid: true };
+  if (value === null) return options?.nullable ? { value: null, invalid: false } : { value: undefined, invalid: false };
   if (typeof value !== "string") return { value: undefined, invalid: true };
   const trimmed = value.trim();
   return { value: trimmed || undefined, invalid: false };
 }
 
 export function normalizeEventWriteInput(input: {
-  startDate?: string;
-  startDateTime?: string;
+  startDate?: string | null;
+  startDateTime?: string | null;
   endDate?: string | null;
   endDateTime?: string | null;
   eventTimezone?: string;

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -64,10 +64,15 @@ export type NormalizedWriteInput = {
   allDay: boolean;
 };
 
-function normalizeTemporalValue(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
+function normalizeTemporalValue(
+  value: unknown,
+  options?: { nullable?: boolean },
+): { value: string | null | undefined; invalid: boolean } {
+  if (value === undefined) return { value: undefined, invalid: false };
+  if (value === null) return options?.nullable ? { value: null, invalid: false } : { value: undefined, invalid: true };
+  if (typeof value !== "string") return { value: undefined, invalid: true };
   const trimmed = value.trim();
-  return trimmed || undefined;
+  return { value: trimmed || undefined, invalid: false };
 }
 
 export function normalizeEventWriteInput(input: {
@@ -79,10 +84,22 @@ export function normalizeEventWriteInput(input: {
   allDay?: boolean;
   allowDateTimeFields: boolean;
 }): NormalizedWriteInput | null {
-  const startDate = normalizeTemporalValue(input.startDate);
-  const startDateTime = normalizeTemporalValue(input.startDateTime);
-  const endDate = normalizeTemporalValue(input.endDate);
-  const endDateTime = normalizeTemporalValue(input.endDateTime);
+  const normalizedStartDate = normalizeTemporalValue(input.startDate);
+  const normalizedStartDateTime = normalizeTemporalValue(input.startDateTime);
+  const normalizedEndDate = normalizeTemporalValue(input.endDate, { nullable: true });
+  const normalizedEndDateTime = normalizeTemporalValue(input.endDateTime, { nullable: true });
+  if (
+    normalizedStartDate.invalid
+    || normalizedStartDateTime.invalid
+    || normalizedEndDate.invalid
+    || normalizedEndDateTime.invalid
+  ) {
+    return null;
+  }
+  const startDate = normalizedStartDate.value ?? undefined;
+  const startDateTime = normalizedStartDateTime.value ?? undefined;
+  const endDate = normalizedEndDate.value;
+  const endDateTime = normalizedEndDateTime.value;
   const startValue = input.allowDateTimeFields
     ? (startDateTime || startDate)
     : startDate;
@@ -97,7 +114,7 @@ export function normalizeEventWriteInput(input: {
       return null;
     }
     if (!startDate || !isDateOnly(startDate)) return null;
-    if (endDate !== undefined && !isDateOnly(endDate)) return null;
+    if (endDate !== undefined && endDate !== null && !isDateOnly(endDate)) return null;
   }
 
   return {

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -36,8 +36,15 @@ export function sanitizeEventWriteFields(body: Record<string, unknown>): void {
     if (typeof loc.name === "string") loc.name = stripHtml(loc.name);
     if (typeof loc.address === "string") loc.address = stripHtml(loc.address);
   }
-  if (body.tags && Array.isArray(body.tags)) {
-    body.tags = (body.tags as string[]).map((t) => stripHtml(t));
+  if (body.tags !== undefined) {
+    if (!Array.isArray(body.tags)) {
+      body.tags = undefined;
+    } else {
+      body.tags = body.tags
+        .filter((tag): tag is string => typeof tag === "string")
+        .map((tag) => stripHtml(tag))
+        .filter(Boolean);
+    }
   }
 }
 

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -104,7 +104,7 @@ export function normalizeEventWriteInput(input: {
     ? (startDateTime || startDate)
     : startDate;
   const endValue = input.allowDateTimeFields
-    ? (endDateTime || endDate)
+    ? (endDateTime !== undefined ? endDateTime : endDate)
     : endDate;
   if (!startValue || !input.eventTimezone) return null;
 

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -94,7 +94,7 @@ export function normalizeEventWriteInput(input: {
   const normalizedStartDate = normalizeTemporalValue(input.startDate);
   const normalizedStartDateTime = normalizeTemporalValue(input.startDateTime);
   const normalizedEndDate = normalizeTemporalValue(input.endDate, { nullable: true });
-  const normalizedEndDateTime = normalizeTemporalValue(input.endDateTime, { nullable: true });
+  const normalizedEndDateTime = normalizeTemporalValue(input.endDateTime);
   if (
     normalizedStartDate.invalid
     || normalizedStartDateTime.invalid

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -107,13 +107,14 @@ export function normalizeEventWriteInput(input: {
   const startDateTime = normalizedStartDateTime.value ?? undefined;
   const endDate = normalizedEndDate.value;
   const endDateTime = normalizedEndDateTime.value;
+  const eventTimezone = input.eventTimezone?.trim() || undefined;
   const startValue = input.allowDateTimeFields
     ? (startDateTime || startDate)
     : startDate;
   const endValue = input.allowDateTimeFields
     ? (endDateTime !== undefined ? endDateTime : endDate)
     : endDate;
-  if (!startValue || !input.eventTimezone) return null;
+  if (!startValue || !eventTimezone) return null;
 
   const allDay = !!input.allDay;
   if (allDay) {
@@ -127,7 +128,7 @@ export function normalizeEventWriteInput(input: {
   return {
     startValue,
     endValue: endValue ?? null,
-    eventTimezone: input.eventTimezone,
+    eventTimezone,
     allDay,
   };
 }

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -1,0 +1,198 @@
+import { stripHtml, sanitizeHtml } from "./security.js";
+import {
+  datePartFromUtcInstantInTimezone,
+  deriveEventEndAtUtc,
+  deriveEventUtcRange,
+  deriveUtcFromTemporalInput,
+} from "./timezone.js";
+
+const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
+
+export type MaterialEventChange = {
+  field: "title" | "time" | "location";
+  before?: string;
+  after?: string;
+  beforeAllDay?: boolean;
+  afterAllDay?: boolean;
+};
+
+export type MaterialChangeSnapshot = {
+  title: string;
+  startDate: string;
+  endDate?: string | null;
+  allDay: boolean;
+  eventTimezone?: string | null;
+  startAtUtc?: string | null;
+  endAtUtc?: string | null;
+  locationName?: string | null;
+  locationAddress?: string | null;
+};
+
+export function sanitizeEventWriteFields(body: Record<string, unknown>): void {
+  if (typeof body.title === "string") body.title = stripHtml(body.title);
+  if (typeof body.description === "string") body.description = sanitizeHtml(body.description);
+  if (body.location && typeof body.location === "object") {
+    const loc = body.location as Record<string, unknown>;
+    if (typeof loc.name === "string") loc.name = stripHtml(loc.name);
+    if (typeof loc.address === "string") loc.address = stripHtml(loc.address);
+  }
+  if (body.tags && Array.isArray(body.tags)) {
+    body.tags = (body.tags as string[]).map((t) => stripHtml(t));
+  }
+}
+
+export function isDateOnly(value: string): boolean {
+  return DATE_ONLY.test(value);
+}
+
+export function deriveStoredDatePart(
+  rawValue: string | null | undefined,
+  utcValue: string | null | undefined,
+  options: { allDay: boolean; eventTimezone: string },
+): string | null {
+  if (!rawValue) return null;
+  const trimmed = rawValue.trim();
+  if (!trimmed) return null;
+  if (options.allDay || isDateOnly(trimmed)) return trimmed.slice(0, 10);
+  return datePartFromUtcInstantInTimezone(utcValue, options.eventTimezone) || trimmed.slice(0, 10);
+}
+
+export type NormalizedWriteInput = {
+  startValue: string;
+  endValue: string | null;
+  eventTimezone: string;
+  allDay: boolean;
+};
+
+export function normalizeEventWriteInput(input: {
+  startDate?: string;
+  startDateTime?: string;
+  endDate?: string | null;
+  endDateTime?: string | null;
+  eventTimezone?: string;
+  allDay?: boolean;
+  allowDateTimeFields: boolean;
+}): NormalizedWriteInput | null {
+  const startValue = input.allowDateTimeFields
+    ? (input.startDateTime ?? input.startDate)
+    : input.startDate;
+  const endValue = input.allowDateTimeFields
+    ? (input.endDateTime ?? input.endDate)
+    : input.endDate;
+  if (!startValue || !input.eventTimezone) return null;
+
+  const allDay = !!input.allDay;
+  if (allDay) {
+    if (input.allowDateTimeFields && (input.startDateTime !== undefined || input.endDateTime !== undefined)) {
+      return null;
+    }
+    if (!input.startDate || !isDateOnly(input.startDate)) return null;
+    if (input.endDate !== undefined && input.endDate !== null && !isDateOnly(input.endDate)) return null;
+  }
+
+  return {
+    startValue,
+    endValue: endValue ?? null,
+    eventTimezone: input.eventTimezone,
+    allDay,
+  };
+}
+
+export function deriveCanonicalTemporalFields(input: NormalizedWriteInput): {
+  startAtUtc: string | null;
+  endAtUtc: string | null;
+  startOn: string | null;
+  endOn: string | null;
+} {
+  const { startAtUtc, endAtUtc } = deriveEventUtcRange(
+    input.startValue,
+    input.endValue,
+    { allDay: input.allDay, eventTimezone: input.eventTimezone },
+  );
+  const startOn = deriveStoredDatePart(input.startValue, startAtUtc, {
+    allDay: input.allDay,
+    eventTimezone: input.eventTimezone,
+  }) || input.startValue.slice(0, 10);
+  const endOn = deriveStoredDatePart(input.endValue, endAtUtc, {
+    allDay: input.allDay,
+    eventTimezone: input.eventTimezone,
+  });
+  return { startAtUtc, endAtUtc, startOn, endOn };
+}
+
+export function deriveUpdateTemporalFields(input: {
+  nextStart?: string;
+  nextEnd?: string | null;
+  nextTimezone?: string;
+  nextAllDay: boolean;
+  existingStart: string;
+  existingEnd: string | null;
+  existingTimezone: string;
+  shouldRecomputeUtcForTimezoneChange: boolean;
+  shouldRecomputeAllDayEndBoundary: boolean;
+}): {
+  startForUtc: string | undefined;
+  endForUtc: string | null | undefined;
+  nextStartAtUtc: string | null;
+  nextEndAtUtc: string | null;
+  tzForConvert: string;
+} {
+  const tzForConvert = input.nextTimezone ?? input.existingTimezone;
+  const startForUtc = input.nextStart
+    ?? (input.shouldRecomputeUtcForTimezoneChange ? input.existingStart : undefined);
+  const endForUtc = input.nextEnd !== undefined
+    ? input.nextEnd
+    : ((input.shouldRecomputeUtcForTimezoneChange || input.shouldRecomputeAllDayEndBoundary) ? input.existingEnd : undefined);
+  const nextStartAtUtc = startForUtc !== undefined
+    ? deriveUtcFromTemporalInput(startForUtc, { allDay: input.nextAllDay, eventTimezone: tzForConvert })
+    : null;
+  const baseStartForAllDayEnd = input.nextStart ?? input.existingStart;
+  const nextEndAtUtc = endForUtc !== undefined
+    ? deriveEventEndAtUtc(endForUtc, {
+      allDay: input.nextAllDay,
+      eventTimezone: tzForConvert,
+      startValueForAllDay: baseStartForAllDayEnd,
+    })
+    : null;
+  return { startForUtc, endForUtc, nextStartAtUtc, nextEndAtUtc, tzForConvert };
+}
+
+function formatTimeChangeValue(start: string, end: string | null | undefined): string {
+  return [start, end || ""].filter(Boolean).join(" – ");
+}
+
+export function computeMaterialEventChanges(
+  before: MaterialChangeSnapshot,
+  after: MaterialChangeSnapshot,
+): MaterialEventChange[] {
+  const changes: MaterialEventChange[] = [];
+
+  if (before.title !== after.title) {
+    changes.push({ field: "title", before: before.title, after: after.title });
+  }
+
+  const beforeTime = formatTimeChangeValue(before.startDate, before.endDate);
+  const afterTime = formatTimeChangeValue(after.startDate, after.endDate);
+  const timeChanged = beforeTime !== afterTime
+    || before.allDay !== after.allDay
+    || (before.eventTimezone || "") !== (after.eventTimezone || "")
+    || (before.startAtUtc || "") !== (after.startAtUtc || "")
+    || (before.endAtUtc || "") !== (after.endAtUtc || "");
+  if (timeChanged) {
+    changes.push({
+      field: "time",
+      before: beforeTime,
+      after: afterTime,
+      beforeAllDay: before.allDay,
+      afterAllDay: after.allDay,
+    });
+  }
+
+  const beforeLocation = [before.locationName || "", before.locationAddress || ""].filter(Boolean).join(", ");
+  const afterLocation = [after.locationName || "", after.locationAddress || ""].filter(Boolean).join(", ");
+  if (beforeLocation !== afterLocation) {
+    changes.push({ field: "location", before: beforeLocation, after: afterLocation });
+  }
+
+  return changes;
+}

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -64,8 +64,8 @@ export type NormalizedWriteInput = {
   allDay: boolean;
 };
 
-function normalizeTemporalValue(value: string | null | undefined): string | undefined {
-  if (value === null || value === undefined) return undefined;
+function normalizeTemporalValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed || undefined;
 }

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1444,6 +1444,10 @@ export function eventRoutes(db: DB): Hono {
 
     sanitizeEventWriteFields(body as Record<string, unknown>);
 
+    if (body.title !== undefined && (typeof body.title !== "string" || !body.title.trim())) {
+      return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
+    }
+
     if ((body.startDate !== undefined && typeof body.startDate !== "string")
       || (body.startDateTime !== undefined && typeof body.startDateTime !== "string")
       || (body.endDate !== undefined && body.endDate !== null && typeof body.endDate !== "string")

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1492,7 +1492,7 @@ export function eventRoutes(db: DB): Hono {
       ? null
       : (body.endDate?.trim() || undefined);
     const normalizedEndDateTime = body.endDateTime === null
-      ? null
+      ? undefined
       : (body.endDateTime?.trim() || undefined);
     const normalizedTimezone = body.eventTimezone?.trim() || undefined;
     if (body.eventTimezone !== undefined && !normalizedTimezone) {

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -615,6 +615,7 @@ export function eventRoutes(db: DB): Hono {
       allDay: boolean;
       eventTimezone: string;
     }>();
+    const normalizedIncomingEvents: typeof body.events = [];
 
     for (const ev of body.events) {
       if (typeof ev.externalId !== "string"
@@ -648,15 +649,20 @@ export function eventRoutes(db: DB): Hono {
         || (endAtUtc && endAtUtc < startAtUtc)) {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
-      normalizedSyncTemporalByExternalId.set(ev.externalId, {
+      const normalizedExternalId = ev.externalId.trim();
+      normalizedSyncTemporalByExternalId.set(normalizedExternalId, {
         startDate: normalizedWrite.startValue,
         endDate: normalizedWrite.endValue,
         allDay: normalizedWrite.allDay,
         eventTimezone: normalizedWrite.eventTimezone,
       });
+      normalizedIncomingEvents.push({
+        ...ev,
+        externalId: normalizedExternalId,
+      });
     }
 
-    const deduped = [...new Map(body.events.map((ev) => [ev.externalId, ev])).values()];
+    const deduped = [...new Map(normalizedIncomingEvents.map((ev) => [ev.externalId, ev])).values()];
 
     for (const ev of deduped) {
       sanitizeEventWriteFields(ev as Record<string, unknown>);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -23,7 +23,6 @@ import {
   buildDateRangeFilter,
   DateQueryParamError,
 } from "../lib/date-query.js";
-import { stripHtml, sanitizeHtml } from "../lib/security.js";
 import { isValidVisibility, type EventVisibility } from "@everycal/core";
 import { getLocale, t } from "../lib/i18n.js";
 import { enqueueOgJob } from "../lib/og-job-queue.js";
@@ -33,10 +32,6 @@ import { fetchAP, resolveRemoteActor, validateFederationUrl } from "../lib/feder
 import { uniqueLocalEventSlug, uniqueRemoteEventSlug } from "../lib/slugs.js";
 import { upsertRemoteEvent } from "../lib/remote-events.js";
 import {
-  datePartFromUtcInstantInTimezone,
-  deriveEventEndAtUtc,
-  deriveEventUtcRange,
-  deriveUtcFromTemporalInput,
   isValidIanaTimezone,
   normalizeApTemporal,
 } from "../lib/timezone.js";
@@ -50,6 +45,15 @@ import {
 } from "../lib/actor-selection.js";
 import { serializeLocalEvent, serializeRemoteEvent } from "../lib/event-serializers.js";
 import { AP_CONTEXT, EVERYCAL_CONTEXT, buildApEventObject } from "../lib/activitypub-event.js";
+import {
+  computeMaterialEventChanges,
+  deriveCanonicalTemporalFields,
+  deriveStoredDatePart,
+  deriveUpdateTemporalFields,
+  isDateOnly,
+  normalizeEventWriteInput,
+  sanitizeEventWriteFields,
+} from "../lib/event-write.js";
 
 // ─── Reusable SQL fragments ─────────────────────────────────────────────────
 
@@ -66,23 +70,7 @@ const REMOTE_EVENT_SELECT = `
   FROM remote_events re
   LEFT JOIN remote_actors ra ON ra.uri = re.actor_uri`;
 
-const DATE_ONLY = /^\d{4}-\d{2}-\d{2}$/;
-
 // ─── Pure utility functions ─────────────────────────────────────────────────
-
-
-function sanitizeEventFields(body: Record<string, unknown>): void {
-  if (typeof body.title === "string") body.title = stripHtml(body.title);
-  if (typeof body.description === "string") body.description = sanitizeHtml(body.description);
-  if (body.location && typeof body.location === "object") {
-    const loc = body.location as Record<string, unknown>;
-    if (typeof loc.name === "string") loc.name = stripHtml(loc.name);
-    if (typeof loc.address === "string") loc.address = stripHtml(loc.address);
-  }
-  if (body.tags && Array.isArray(body.tags)) {
-    body.tags = (body.tags as string[]).map((t) => stripHtml(t));
-  }
-}
 
 /** Decode an event ID that may be URL-encoded into a URI. */
 function resolveEventUri(id: string): string {
@@ -94,25 +82,6 @@ function resolveEventUri(id: string): string {
   return id;
 }
 
-function formatTimeChangeValue(start: string, end: string | null | undefined): string {
-  return [start, end || ""].filter(Boolean).join(" – ");
-}
-
-function isDateOnly(value: string): boolean {
-  return DATE_ONLY.test(value);
-}
-
-function deriveStoredDatePart(
-  rawValue: string | null | undefined,
-  utcValue: string | null | undefined,
-  options: { allDay: boolean; eventTimezone: string },
-): string | null {
-  if (!rawValue) return null;
-  const trimmed = rawValue.trim();
-  if (!trimmed) return null;
-  if (options.allDay || isDateOnly(trimmed)) return trimmed.slice(0, 10);
-  return datePartFromUtcInstantInTimezone(utcValue, options.eventTimezone) || trimmed.slice(0, 10);
-}
 
 /** Check whether a user is allowed to view an event based on its visibility. */
 function canViewEvent(
@@ -644,16 +613,17 @@ export function eventRoutes(db: DB): Hono {
       if (!ev.externalId || !ev.title || !ev.startDate || !ev.eventTimezone || !isValidIanaTimezone(ev.eventTimezone)) {
         return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
       }
-      if (ev.allDay) {
-        if (!isDateOnly(ev.startDate) || (ev.endDate !== undefined && !isDateOnly(ev.endDate))) {
-          return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-        }
+      const normalizedWrite = normalizeEventWriteInput({
+        startDate: ev.startDate,
+        endDate: ev.endDate,
+        eventTimezone: ev.eventTimezone,
+        allDay: ev.allDay,
+        allowDateTimeFields: false,
+      });
+      if (!normalizedWrite) {
+        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
-      const { startAtUtc, endAtUtc } = deriveEventUtcRange(
-        ev.startDate,
-        ev.endDate,
-        { allDay: !!ev.allDay, eventTimezone: ev.eventTimezone },
-      );
+      const { startAtUtc, endAtUtc } = deriveCanonicalTemporalFields(normalizedWrite);
       if (!startAtUtc || (ev.allDay ? !endAtUtc : (ev.endDate && !endAtUtc)) || (endAtUtc && endAtUtc < startAtUtc)) {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
@@ -662,7 +632,7 @@ export function eventRoutes(db: DB): Hono {
     const deduped = [...new Map(body.events.map((ev) => [ev.externalId, ev])).values()];
 
     for (const ev of deduped) {
-      sanitizeEventFields(ev as Record<string, unknown>);
+      sanitizeEventWriteFields(ev as Record<string, unknown>);
     }
 
     const existing = db
@@ -814,44 +784,38 @@ export function eventRoutes(db: DB): Hono {
             }
 
             // Only material changes (title, time, location) trigger notifications
-            const changes: { field: "title" | "time" | "location"; before?: string; after?: string; beforeAllDay?: boolean; afterAllDay?: boolean }[] = [];
-            if (existingRow.title !== ev.title) {
-              changes.push({ field: "title", before: existingRow.title, after: ev.title });
-            }
             const oldAllDay = !!existingRow.all_day;
             const newAllDay = !!ev.allDay;
-            const oldTime = formatTimeChangeValue(existingRow.start_date, existingRow.end_date);
-            const newTime = formatTimeChangeValue(ev.startDate, ev.endDate || "");
-            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveEventUtcRange(
-              ev.startDate,
-              ev.endDate,
-              { allDay: !!ev.allDay, eventTimezone: ev.eventTimezone },
+            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
+              startValue: ev.startDate,
+              endValue: ev.endDate ?? null,
+              allDay: !!ev.allDay,
+              eventTimezone: ev.eventTimezone,
+            });
+            const changes = computeMaterialEventChanges(
+              {
+                title: existingRow.title,
+                startDate: existingRow.start_date,
+                endDate: existingRow.end_date,
+                allDay: oldAllDay,
+                eventTimezone: existingRow.event_timezone,
+                startAtUtc: existingRow.start_at_utc,
+                endAtUtc: existingRow.end_at_utc,
+                locationName: existingRow.location_name,
+                locationAddress: existingRow.location_address,
+              },
+              {
+                title: ev.title,
+                startDate: ev.startDate,
+                endDate: ev.endDate,
+                allDay: newAllDay,
+                eventTimezone: ev.eventTimezone,
+                startAtUtc: nextStartAtUtc,
+                endAtUtc: nextEndAtUtc,
+                locationName: ev.location?.name,
+                locationAddress: ev.location?.address,
+              },
             );
-            const existingEffectiveStart = existingRow.start_date;
-            const existingEffectiveEnd = existingRow.end_date;
-            const nextEffectiveStart = ev.startDate;
-            const nextEffectiveEnd = ev.endDate;
-            const oldTimezone = existingRow.event_timezone || "";
-            const newTimezone = ev.eventTimezone || "";
-            const oldStartAtUtc = existingRow.start_at_utc || "";
-            const oldEndAtUtc = existingRow.end_at_utc || "";
-            const newStartAtUtc = nextStartAtUtc || "";
-            const newEndAtUtc = nextEndAtUtc || "";
-            if (
-              existingEffectiveStart !== nextEffectiveStart
-              || (existingEffectiveEnd || "") !== (nextEffectiveEnd || "")
-              || oldAllDay !== newAllDay
-              || oldTimezone !== newTimezone
-              || oldStartAtUtc !== newStartAtUtc
-              || oldEndAtUtc !== newEndAtUtc
-            ) {
-              changes.push({ field: "time", before: oldTime, after: newTime, beforeAllDay: oldAllDay, afterAllDay: newAllDay });
-            }
-            const oldLoc = [existingRow.location_name || "", existingRow.location_address || ""].filter(Boolean).join(", ");
-            const newLoc = [ev.location?.name || "", ev.location?.address || ""].filter(Boolean).join(", ");
-            if (oldLoc !== newLoc) {
-              changes.push({ field: "location", before: oldLoc, after: newLoc });
-            }
 
             const evSlug = uniqueLocalEventSlug(db, user.id, ev.title, existingRow.id);
             const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
@@ -900,11 +864,12 @@ export function eventRoutes(db: DB): Hono {
           } else {
             const id = nanoid(16);
             const evSlug = uniqueLocalEventSlug(db, user.id, ev.title);
-            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveEventUtcRange(
-              ev.startDate,
-              ev.endDate,
-              { allDay: !!ev.allDay, eventTimezone: ev.eventTimezone },
-            );
+            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
+              startValue: ev.startDate,
+              endValue: ev.endDate ?? null,
+              allDay: !!ev.allDay,
+              eventTimezone: ev.eventTimezone,
+            });
             const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
               allDay: !!ev.allDay,
               eventTimezone: ev.eventTimezone,
@@ -1254,7 +1219,7 @@ export function eventRoutes(db: DB): Hono {
       }
     }
 
-    sanitizeEventFields(body as Record<string, unknown>);
+    sanitizeEventWriteFields(body as Record<string, unknown>);
 
     const postAsAccountId = body.postAsAccountId || user.id;
     const postingAccount = db
@@ -1296,11 +1261,19 @@ export function eventRoutes(db: DB): Hono {
     const imageAttributionJson = body.image?.attribution
       ? JSON.stringify(body.image.attribution)
       : null;
-    const { startAtUtc, endAtUtc } = deriveEventUtcRange(
-      startDateInput,
-      endDateInput,
-      { allDay: !!body.allDay, eventTimezone },
-    );
+    const normalizedWrite = normalizeEventWriteInput({
+      startDate: body.startDate,
+      startDateTime: body.startDateTime,
+      endDate: body.endDate,
+      endDateTime: body.endDateTime,
+      eventTimezone,
+      allDay: body.allDay,
+      allowDateTimeFields: true,
+    });
+    if (!normalizedWrite) {
+      return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
+    }
+    const { startAtUtc, endAtUtc, startOn, endOn } = deriveCanonicalTemporalFields(normalizedWrite);
     if (!startAtUtc) {
       return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
     }
@@ -1310,15 +1283,6 @@ export function eventRoutes(db: DB): Hono {
     if (endAtUtc && endAtUtc < startAtUtc) {
       return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
     }
-    const startOn = deriveStoredDatePart(startDateInput, startAtUtc, {
-      allDay: !!body.allDay,
-      eventTimezone,
-    }) || startDateInput.slice(0, 10);
-    const endOn = deriveStoredDatePart(endDateInput || null, endAtUtc, {
-      allDay: !!body.allDay,
-      eventTimezone,
-    });
-
     db.prepare(
       `INSERT INTO events (id, account_id, created_by_account_id, slug, title, description, start_date, end_date, all_day,
         start_at_utc, end_at_utc, event_timezone, start_on, end_on,
@@ -1432,7 +1396,7 @@ export function eventRoutes(db: DB): Hono {
       visibility?: string;
     }>();
 
-    sanitizeEventFields(body as Record<string, unknown>);
+    sanitizeEventWriteFields(body as Record<string, unknown>);
 
     const fields: string[] = [];
     const values: unknown[] = [];
@@ -1461,27 +1425,22 @@ export function eventRoutes(db: DB): Hono {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
     }
-    const tzForConvert = nextTimezone ?? existingTimezone;
     const shouldRecomputeUtcForTimezoneChange = nextTimezone !== undefined;
-    const startForUtc = nextStart ?? (shouldRecomputeUtcForTimezoneChange ? existing.start_date : undefined);
     const shouldRecomputeAllDayEndBoundary = nextAllDay && (nextStart !== undefined || body.allDay !== undefined);
-    const endForUtc = nextEnd !== undefined
-      ? nextEnd
-      : ((shouldRecomputeUtcForTimezoneChange || shouldRecomputeAllDayEndBoundary) ? existing.end_date : undefined);
-    const nextStartAtUtc = startForUtc !== undefined
-      ? deriveUtcFromTemporalInput(startForUtc, { allDay: nextAllDay, eventTimezone: tzForConvert })
-      : null;
+    const { startForUtc, endForUtc, nextStartAtUtc, nextEndAtUtc, tzForConvert } = deriveUpdateTemporalFields({
+      nextStart,
+      nextEnd,
+      nextTimezone,
+      nextAllDay,
+      existingStart: existing.start_date,
+      existingEnd: existing.end_date,
+      existingTimezone,
+      shouldRecomputeUtcForTimezoneChange,
+      shouldRecomputeAllDayEndBoundary,
+    });
     if (startForUtc !== undefined && !nextStartAtUtc) {
       return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
     }
-    const baseStartForAllDayEnd = nextStart ?? existing.start_date;
-    const nextEndAtUtc = endForUtc !== undefined
-      ? deriveEventEndAtUtc(endForUtc, {
-        allDay: nextAllDay,
-        eventTimezone: tzForConvert,
-        startValueForAllDay: baseStartForAllDayEnd,
-      })
-      : null;
     if (endForUtc !== undefined && (nextAllDay ? !nextEndAtUtc : (endForUtc !== null && !nextEndAtUtc))) {
       return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
     }
@@ -1560,33 +1519,33 @@ export function eventRoutes(db: DB): Hono {
 
     const oldAllDay = !!existing.all_day;
     const newAllDay = body.allDay !== undefined ? !!body.allDay : oldAllDay;
-    const oldTime = formatTimeChangeValue(existing.start_date, existing.end_date);
-    const newTime = formatTimeChangeValue(nextStart ?? existing.start_date, nextEnd !== undefined ? (nextEnd || "") : (existing.end_date || ""));
-    const oldTimezone = existingTimezone;
-    const newTimezone = body.eventTimezone !== undefined ? body.eventTimezone : oldTimezone;
-    const timeChanged = oldTime !== newTime || oldAllDay !== newAllDay || oldTimezone !== newTimezone;
-    const oldLoc = [existing.location_name || "", existing.location_address || ""].filter(Boolean).join(", ");
-    const newLoc = body.location === undefined
-      ? oldLoc
-      : body.location === null
-        ? ""
-        : [body.location.name || "", body.location.address || ""].filter(Boolean).join(", ");
-    const locationChanged = oldLoc !== newLoc;
-    const titleChanged = body.title !== undefined && existing.title !== body.title;
+    const materialChanges = computeMaterialEventChanges(
+      {
+        title: existing.title,
+        startDate: existing.start_date,
+        endDate: existing.end_date,
+        allDay: oldAllDay,
+        eventTimezone: existingTimezone,
+        locationName: existing.location_name,
+        locationAddress: existing.location_address,
+      },
+      {
+        title: body.title !== undefined ? body.title : existing.title,
+        startDate: nextStart ?? existing.start_date,
+        endDate: nextEnd !== undefined ? nextEnd : existing.end_date,
+        allDay: newAllDay,
+        eventTimezone: body.eventTimezone !== undefined ? body.eventTimezone : existingTimezone,
+        locationName: body.location === undefined ? existing.location_name : (body.location?.name ?? null),
+        locationAddress: body.location === undefined ? existing.location_address : (body.location?.address ?? null),
+      },
+    );
+    const titleChanged = materialChanges.some((change) => change.field === "title");
+    const timeChanged = materialChanges.some((change) => change.field === "time");
+    const locationChanged = materialChanges.some((change) => change.field === "location");
 
     if (fields.length > 0) {
       // Only material changes (title, time, location) trigger notifications
-      const changes: { field: "title" | "time" | "location"; before?: string; after?: string; beforeAllDay?: boolean; afterAllDay?: boolean }[] = [];
-      if (titleChanged) {
-        changes.push({ field: "title", before: existing.title, after: body.title });
-      }
-      if (timeChanged) {
-        changes.push({ field: "time", before: oldTime, after: newTime, beforeAllDay: oldAllDay, afterAllDay: newAllDay });
-      }
-      if (locationChanged) {
-        changes.push({ field: "location", before: oldLoc, after: newLoc });
-      }
-      if (changes.length > 0) {
+      if (materialChanges.length > 0) {
         const ev = readLocalEventById(id);
         if (ev) {
           notifyEventUpdated(db, id, {
@@ -1599,7 +1558,7 @@ export function eventRoutes(db: DB): Hono {
             allDay: ev.allDay as boolean,
             location: ev.location as { name?: string } | null,
             url: ev.url as string | null,
-          }, changes);
+          }, materialChanges);
         }
       }
     }

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -609,6 +609,13 @@ export function eventRoutes(db: DB): Hono {
       return c.json({ error: t(getLocale(c), "events.events_array_required") }, 400);
     }
 
+    const normalizedSyncTemporalByExternalId = new Map<string, {
+      startDate: string;
+      endDate: string | null;
+      allDay: boolean;
+      eventTimezone: string;
+    }>();
+
     for (const ev of body.events) {
       if (!ev.externalId || !ev.title || !ev.startDate || !ev.eventTimezone || !isValidIanaTimezone(ev.eventTimezone)) {
         return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
@@ -624,9 +631,17 @@ export function eventRoutes(db: DB): Hono {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
       const { startAtUtc, endAtUtc } = deriveCanonicalTemporalFields(normalizedWrite);
-      if (!startAtUtc || (ev.allDay ? !endAtUtc : (ev.endDate && !endAtUtc)) || (endAtUtc && endAtUtc < startAtUtc)) {
+      if (!startAtUtc
+        || (normalizedWrite.allDay ? !endAtUtc : (normalizedWrite.endValue !== null && !endAtUtc))
+        || (endAtUtc && endAtUtc < startAtUtc)) {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
+      normalizedSyncTemporalByExternalId.set(ev.externalId, {
+        startDate: normalizedWrite.startValue,
+        endDate: normalizedWrite.endValue,
+        allDay: normalizedWrite.allDay,
+        eventTimezone: normalizedWrite.eventTimezone,
+      });
     }
 
     const deduped = [...new Map(body.events.map((ev) => [ev.externalId, ev])).values()];
@@ -634,6 +649,24 @@ export function eventRoutes(db: DB): Hono {
     for (const ev of deduped) {
       sanitizeEventWriteFields(ev as Record<string, unknown>);
     }
+
+    type SyncEventInput = Omit<(typeof body.events)[number], "startDate" | "endDate" | "allDay" | "eventTimezone"> & {
+      startDate: string;
+      endDate: string | null;
+      allDay: boolean;
+      eventTimezone: string;
+    };
+    const syncEvents: SyncEventInput[] = deduped.map((ev) => {
+      const normalizedTemporal = normalizedSyncTemporalByExternalId.get(ev.externalId);
+      if (!normalizedTemporal) throw new Error("missing normalized sync temporal values");
+      return {
+        ...ev,
+        startDate: normalizedTemporal.startDate,
+        endDate: normalizedTemporal.endDate,
+        allDay: normalizedTemporal.allDay,
+        eventTimezone: normalizedTemporal.eventTimezone,
+      };
+    });
 
     const existing = db
       .prepare(
@@ -661,7 +694,7 @@ export function eventRoutes(db: DB): Hono {
     }[];
 
     const existingByExtId = new Map(existing.map((r) => [r.external_id, r]));
-    const incomingExtIds = new Set(deduped.map((e) => e.externalId));
+    const incomingExtIds = new Set(syncEvents.map((e) => e.externalId));
 
     let created = 0;
     let updated = 0;
@@ -671,7 +704,7 @@ export function eventRoutes(db: DB): Hono {
     const ogEventIdsToGenerate = new Set<string>();
     const ogEventIdsToClear = new Set<string>();
 
-    function eventHash(ev: (typeof body.events)[number]): string {
+    function eventHash(ev: SyncEventInput): string {
       const data = JSON.stringify([
         ev.title, ev.description || "", ev.startDate, ev.endDate || "", ev.eventTimezone,
         ev.allDay ? 1 : 0, ev.location?.name || "", ev.location?.address || "",
@@ -764,8 +797,8 @@ export function eventRoutes(db: DB): Hono {
 
     // Batch 2+: Upsert incoming events in chunks — skip unchanged events
     const BATCH_SIZE = 20;
-    for (let i = 0; i < deduped.length; i += BATCH_SIZE) {
-      const chunk = deduped.slice(i, i + BATCH_SIZE);
+    for (let i = 0; i < syncEvents.length; i += BATCH_SIZE) {
+      const chunk = syncEvents.slice(i, i + BATCH_SIZE);
 
       const upsertBatch = db.transaction((events: typeof chunk) => {
         for (const ev of events) {
@@ -904,7 +937,7 @@ export function eventRoutes(db: DB): Hono {
 
       upsertBatch(chunk);
 
-      if (i + BATCH_SIZE < deduped.length) {
+      if (i + BATCH_SIZE < syncEvents.length) {
         await yieldToEventLoop();
       }
     }
@@ -929,7 +962,7 @@ export function eventRoutes(db: DB): Hono {
       });
     }
 
-    return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: deduped.length });
+    return c.json({ ok: true, created, updated, unchanged, canceled, rotatedOutPast, total: syncEvents.length });
   });
 
   // ─── POST /:id/repost ──────────────────────────────────────────────────
@@ -1199,7 +1232,6 @@ export function eventRoutes(db: DB): Hono {
     }>();
 
     const startDateInput = body.startDateTime || body.startDate;
-    const endDateInput = body.endDateTime || body.endDate;
     const eventTimezone = body.eventTimezone;
     if (!body.title || !startDateInput) {
       return c.json({ error: t(getLocale(c), "events.title_startdate_required") }, 400);
@@ -1277,7 +1309,9 @@ export function eventRoutes(db: DB): Hono {
     if (!startAtUtc) {
       return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
     }
-    if ((body.allDay || endDateInput) && !endAtUtc) {
+    const startDateValue = normalizedWrite.startValue;
+    const endDateValue = normalizedWrite.endValue;
+    if ((normalizedWrite.allDay || endDateValue !== null) && !endAtUtc) {
       return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
     }
     if (endAtUtc && endAtUtc < startAtUtc) {
@@ -1291,7 +1325,7 @@ export function eventRoutes(db: DB): Hono {
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id, postingAccount.id, user.id, slug, body.title, body.description || null,
-      startDateInput, endDateInput || null, body.allDay ? 1 : 0,
+      startDateValue, endDateValue, body.allDay ? 1 : 0,
       startAtUtc,
       endAtUtc,
       eventTimezone,
@@ -1330,8 +1364,8 @@ export function eventRoutes(db: DB): Hono {
           to: ["https://www.w3.org/ns/activitystreams#Public"],
           cc: [`${actorUrl}/followers`],
           allDay: !!body.allDay,
-          startDate: startDateInput,
-          endDate: endDateInput || undefined,
+          startDate: startDateValue,
+          endDate: endDateValue || undefined,
           startAtUtc,
           endAtUtc,
           content: body.description || undefined,

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1435,6 +1435,30 @@ export function eventRoutes(db: DB): Hono {
 
     sanitizeEventWriteFields(body as Record<string, unknown>);
 
+    if ((body.startDate !== undefined && typeof body.startDate !== "string")
+      || (body.startDateTime !== undefined && typeof body.startDateTime !== "string")
+      || (body.endDate !== undefined && body.endDate !== null && typeof body.endDate !== "string")
+      || (body.endDateTime !== undefined && body.endDateTime !== null && typeof body.endDateTime !== "string")
+      || (body.allDay !== undefined && typeof body.allDay !== "boolean")) {
+      return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
+    }
+    if (body.eventTimezone !== undefined && typeof body.eventTimezone !== "string") {
+      return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
+    }
+
+    const normalizedStartDate = body.startDate?.trim() || undefined;
+    const normalizedStartDateTime = body.startDateTime?.trim() || undefined;
+    const normalizedEndDate = body.endDate === null
+      ? null
+      : (body.endDate?.trim() || undefined);
+    const normalizedEndDateTime = body.endDateTime === null
+      ? null
+      : (body.endDateTime?.trim() || undefined);
+    const normalizedTimezone = body.eventTimezone?.trim() || undefined;
+    if (body.eventTimezone !== undefined && !normalizedTimezone) {
+      return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
+    }
+
     const fields: string[] = [];
     const values: unknown[] = [];
 
@@ -1442,9 +1466,9 @@ export function eventRoutes(db: DB): Hono {
       fields.push("title = ?"); values.push(body.title);
     }
     if (body.description !== undefined) { fields.push("description = ?"); values.push(body.description || null); }
-    const nextStart = body.startDateTime ?? body.startDate;
-    const nextEnd = body.endDateTime ?? body.endDate;
-    const nextTimezone = body.eventTimezone;
+    const nextStart = normalizedStartDateTime ?? normalizedStartDate;
+    const nextEnd = normalizedEndDateTime ?? normalizedEndDate;
+    const nextTimezone = normalizedTimezone;
     if (nextTimezone !== undefined && !isValidIanaTimezone(nextTimezone)) {
       return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
     }
@@ -1453,11 +1477,11 @@ export function eventRoutes(db: DB): Hono {
       : "UTC";
     const nextAllDay = body.allDay ?? !!existing.all_day;
     if (nextAllDay) {
-      if (body.startDateTime !== undefined || body.endDateTime !== undefined) {
+      if (normalizedStartDateTime !== undefined || normalizedEndDateTime !== undefined) {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
-      const candidateStart = body.startDate ?? existing.start_date;
-      const candidateEnd = body.endDate !== undefined ? body.endDate : existing.end_date;
+      const candidateStart = normalizedStartDate ?? existing.start_date;
+      const candidateEnd = normalizedEndDate !== undefined ? normalizedEndDate : existing.end_date;
       if (!isDateOnly(candidateStart) || (candidateEnd !== null && candidateEnd !== undefined && !isDateOnly(candidateEnd))) {
         return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
@@ -1571,7 +1595,7 @@ export function eventRoutes(db: DB): Hono {
         startDate: nextStart ?? existing.start_date,
         endDate: nextEnd !== undefined ? nextEnd : existing.end_date,
         allDay: newAllDay,
-        eventTimezone: body.eventTimezone !== undefined ? body.eventTimezone : existingTimezone,
+        eventTimezone: nextTimezone !== undefined ? nextTimezone : existingTimezone,
         locationName: body.location === undefined ? existing.location_name : (body.location?.name ?? null),
         locationAddress: body.location === undefined ? existing.location_address : (body.location?.address ?? null),
       },

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -588,7 +588,7 @@ export function eventRoutes(db: DB): Hono {
 
   router.post("/sync", requireAuth(), async (c) => {
     const user = c.get("user")!;
-    const body = await c.req.json<{
+    type SyncRequestBody = {
       events: {
         externalId: string;
         title: string;
@@ -603,9 +603,19 @@ export function eventRoutes(db: DB): Hono {
         tags?: string[];
         visibility?: string;
       }[];
-    }>().catch(() => null);
+    };
+    let body: SyncRequestBody;
 
-    if (!body || !Array.isArray(body.events)) {
+    try {
+      body = await c.req.json<SyncRequestBody>();
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return c.json({ error: t(getLocale(c), "common.invalid_json") }, 400);
+      }
+      throw error;
+    }
+
+    if (!Array.isArray(body.events)) {
       return c.json({ error: t(getLocale(c), "events.events_array_required") }, 400);
     }
 

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -670,6 +670,9 @@ export function eventRoutes(db: DB): Hono {
 
     for (const ev of deduped) {
       sanitizeEventWriteFields(ev as Record<string, unknown>);
+      if (typeof ev.title !== "string" || !ev.title.trim()) {
+        return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
+      }
     }
 
     type SyncEventInput = Omit<(typeof body.events)[number], "startDate" | "endDate" | "allDay" | "eventTimezone"> & {

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -603,9 +603,9 @@ export function eventRoutes(db: DB): Hono {
         tags?: string[];
         visibility?: string;
       }[];
-    }>();
+    }>().catch(() => null);
 
-    if (!Array.isArray(body.events)) {
+    if (!body || !Array.isArray(body.events)) {
       return c.json({ error: t(getLocale(c), "events.events_array_required") }, 400);
     }
 
@@ -617,8 +617,20 @@ export function eventRoutes(db: DB): Hono {
     }>();
 
     for (const ev of body.events) {
-      if (!ev.externalId || !ev.title || !ev.startDate || !ev.eventTimezone || !isValidIanaTimezone(ev.eventTimezone)) {
+      if (typeof ev.externalId !== "string"
+        || !ev.externalId.trim()
+        || typeof ev.title !== "string"
+        || !ev.title.trim()
+        || typeof ev.startDate !== "string"
+        || !ev.startDate.trim()
+        || typeof ev.eventTimezone !== "string"
+        || !ev.eventTimezone.trim()
+        || !isValidIanaTimezone(ev.eventTimezone)) {
         return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
+      }
+      if ((ev.endDate !== undefined && ev.endDate !== null && typeof ev.endDate !== "string")
+        || (ev.allDay !== undefined && typeof ev.allDay !== "boolean")) {
+        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
       }
       const normalizedWrite = normalizeEventWriteInput({
         startDate: ev.startDate,
@@ -656,17 +668,20 @@ export function eventRoutes(db: DB): Hono {
       allDay: boolean;
       eventTimezone: string;
     };
-    const syncEvents: SyncEventInput[] = deduped.map((ev) => {
+    const syncEvents: SyncEventInput[] = [];
+    for (const ev of deduped) {
       const normalizedTemporal = normalizedSyncTemporalByExternalId.get(ev.externalId);
-      if (!normalizedTemporal) throw new Error("missing normalized sync temporal values");
-      return {
+      if (!normalizedTemporal) {
+        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
+      }
+      syncEvents.push({
         ...ev,
         startDate: normalizedTemporal.startDate,
         endDate: normalizedTemporal.endDate,
         allDay: normalizedTemporal.allDay,
         eventTimezone: normalizedTemporal.eventTimezone,
-      };
-    });
+      });
+    }
 
     const existing = db
       .prepare(

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -618,6 +618,9 @@ export function eventRoutes(db: DB): Hono {
     const normalizedIncomingEvents: typeof body.events = [];
 
     for (const ev of body.events) {
+      const normalizedTimezone = typeof ev.eventTimezone === "string"
+        ? ev.eventTimezone.trim()
+        : "";
       if (typeof ev.externalId !== "string"
         || !ev.externalId.trim()
         || typeof ev.title !== "string"
@@ -625,8 +628,8 @@ export function eventRoutes(db: DB): Hono {
         || typeof ev.startDate !== "string"
         || !ev.startDate.trim()
         || typeof ev.eventTimezone !== "string"
-        || !ev.eventTimezone.trim()
-        || !isValidIanaTimezone(ev.eventTimezone)) {
+        || !normalizedTimezone
+        || !isValidIanaTimezone(normalizedTimezone)) {
         return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
       }
       if ((ev.endDate !== undefined && ev.endDate !== null && typeof ev.endDate !== "string")
@@ -636,7 +639,7 @@ export function eventRoutes(db: DB): Hono {
       const normalizedWrite = normalizeEventWriteInput({
         startDate: ev.startDate,
         endDate: ev.endDate,
-        eventTimezone: ev.eventTimezone,
+        eventTimezone: normalizedTimezone,
         allDay: ev.allDay,
         allowDateTimeFields: false,
       });
@@ -659,6 +662,7 @@ export function eventRoutes(db: DB): Hono {
       normalizedIncomingEvents.push({
         ...ev,
         externalId: normalizedExternalId,
+        eventTimezone: normalizedWrite.eventTimezone,
       });
     }
 

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1464,6 +1464,12 @@ export function eventRoutes(db: DB): Hono {
       || (body.allDay !== undefined && typeof body.allDay !== "boolean")) {
       return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
     }
+    if ((body.startDate !== undefined && !body.startDate.trim())
+      || (body.startDateTime !== undefined && body.startDateTime !== null && !body.startDateTime.trim())
+      || (body.endDate !== undefined && body.endDate !== null && !body.endDate.trim())
+      || (body.endDateTime !== undefined && body.endDateTime !== null && !body.endDateTime.trim())) {
+      return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
+    }
     if (body.eventTimezone !== undefined && typeof body.eventTimezone !== "string") {
       return c.json({ error: t(getLocale(c), "common.requestFailed") }, 400);
     }

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1257,7 +1257,9 @@ export function eventRoutes(db: DB): Hono {
     const startDateInput = typeof body.startDateTime === "string"
       ? body.startDateTime.trim()
       : (typeof body.startDate === "string" ? body.startDate.trim() : "");
-    const eventTimezone = body.eventTimezone;
+    const eventTimezone = typeof body.eventTimezone === "string"
+      ? body.eventTimezone.trim()
+      : "";
     if (typeof body.title !== "string" || !body.title || !startDateInput) {
       return c.json({ error: t(getLocale(c), "events.title_startdate_required") }, 400);
     }

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1246,15 +1246,18 @@ export function eventRoutes(db: DB): Hono {
       postAsAccountId?: string;
     }>();
 
-    const startDateInput = body.startDateTime || body.startDate;
+    sanitizeEventWriteFields(body as Record<string, unknown>);
+
+    const startDateInput = typeof body.startDateTime === "string"
+      ? body.startDateTime.trim()
+      : (typeof body.startDate === "string" ? body.startDate.trim() : "");
     const eventTimezone = body.eventTimezone;
-    if (!body.title || !startDateInput) {
+    if (typeof body.title !== "string" || !body.title || !startDateInput) {
       return c.json({ error: t(getLocale(c), "events.title_startdate_required") }, 400);
     }
     if (!eventTimezone || !isValidIanaTimezone(eventTimezone)) {
       return c.json({ error: t(getLocale(c), "events.invalid_timezone") }, 400);
     }
-    sanitizeEventWriteFields(body as Record<string, unknown>);
 
     const postAsAccountId = body.postAsAccountId || user.id;
     const postingAccount = db

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1254,18 +1254,6 @@ export function eventRoutes(db: DB): Hono {
     if (!eventTimezone || !isValidIanaTimezone(eventTimezone)) {
       return c.json({ error: t(getLocale(c), "events.invalid_timezone") }, 400);
     }
-    if (body.allDay) {
-      if (body.startDateTime !== undefined || body.endDateTime !== undefined) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      if (!body.startDate || !isDateOnly(body.startDate)) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      if (body.endDate !== undefined && !isDateOnly(body.endDate)) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-    }
-
     sanitizeEventWriteFields(body as Record<string, unknown>);
 
     const postAsAccountId = body.postAsAccountId || user.id;
@@ -1340,7 +1328,7 @@ export function eventRoutes(db: DB): Hono {
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     ).run(
       id, postingAccount.id, user.id, slug, body.title, body.description || null,
-      startDateValue, endDateValue, body.allDay ? 1 : 0,
+      startDateValue, endDateValue, normalizedWrite.allDay ? 1 : 0,
       startAtUtc,
       endAtUtc,
       eventTimezone,

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1234,7 +1234,7 @@ export function eventRoutes(db: DB): Hono {
       description?: string;
       startDate: string;
       endDate?: string;
-      startDateTime?: string;
+      startDateTime?: string | null;
       endDateTime?: string;
       eventTimezone?: string;
       allDay?: boolean;
@@ -1430,7 +1430,7 @@ export function eventRoutes(db: DB): Hono {
       title?: string;
       description?: string;
       startDate?: string;
-      startDateTime?: string;
+      startDateTime?: string | null;
       endDate?: string | null;
       endDateTime?: string | null;
       eventTimezone?: string;
@@ -1449,7 +1449,7 @@ export function eventRoutes(db: DB): Hono {
     }
 
     if ((body.startDate !== undefined && typeof body.startDate !== "string")
-      || (body.startDateTime !== undefined && typeof body.startDateTime !== "string")
+      || (body.startDateTime !== undefined && body.startDateTime !== null && typeof body.startDateTime !== "string")
       || (body.endDate !== undefined && body.endDate !== null && typeof body.endDate !== "string")
       || (body.endDateTime !== undefined && body.endDateTime !== null && typeof body.endDateTime !== "string")
       || (body.allDay !== undefined && typeof body.allDay !== "boolean")) {
@@ -1460,7 +1460,9 @@ export function eventRoutes(db: DB): Hono {
     }
 
     const normalizedStartDate = body.startDate?.trim() || undefined;
-    const normalizedStartDateTime = body.startDateTime?.trim() || undefined;
+    const normalizedStartDateTime = body.startDateTime === null
+      ? undefined
+      : (body.startDateTime?.trim() || undefined);
     const normalizedEndDate = body.endDate === null
       ? null
       : (body.endDate?.trim() || undefined);

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -1261,9 +1261,9 @@ export function eventRoutes(db: DB): Hono {
 
     sanitizeEventWriteFields(body as Record<string, unknown>);
 
-    const startDateInput = typeof body.startDateTime === "string"
+    const startDateInput = (typeof body.startDateTime === "string"
       ? body.startDateTime.trim()
-      : (typeof body.startDate === "string" ? body.startDate.trim() : "");
+      : "") || (typeof body.startDate === "string" ? body.startDate.trim() : "");
     const eventTimezone = typeof body.eventTimezone === "string"
       ? body.eventTimezone.trim()
       : "";

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -101,6 +101,25 @@ describe("event write normalization", () => {
     });
   });
 
+  it("preserves explicit null endDateTime when datetime fields are allowed", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      startDateTime: "2026-01-10T10:30",
+      endDate: "2026-01-11",
+      endDateTime: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10T10:30",
+      endValue: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+    });
+  });
+
   it("returns null when startDateTime is present but not a string", () => {
     const normalized = normalizeEventWriteInput({
       startDate: "2026-01-10",

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -102,7 +102,7 @@ describe("event write normalization", () => {
     });
   });
 
-  it("preserves explicit null endDateTime when datetime fields are allowed", () => {
+  it("treats null endDateTime as omitted and falls back to endDate", () => {
     const normalized = normalizeEventWriteInput({
       startDate: "2026-01-10",
       startDateTime: "2026-01-10T10:30",
@@ -115,9 +115,27 @@ describe("event write normalization", () => {
 
     expect(normalized).toEqual({
       startValue: "2026-01-10T10:30",
-      endValue: null,
+      endValue: "2026-01-11",
       eventTimezone: "Europe/Vienna",
       allDay: false,
+    });
+  });
+
+  it("accepts all-day payloads when endDateTime is explicitly null", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      endDate: "2026-01-11",
+      endDateTime: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10",
+      endValue: "2026-01-11",
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
     });
   });
 

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -121,6 +121,23 @@ describe("event write normalization", () => {
     });
   });
 
+  it("treats null startDateTime as omitted and falls back to startDate", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      startDateTime: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10",
+      endValue: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+    });
+  });
+
   it("returns null when startDateTime is present but not a string", () => {
     const normalized = normalizeEventWriteInput({
       startDate: "2026-01-10",

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -5,6 +5,7 @@ import {
   deriveStoredDatePart,
   deriveUpdateTemporalFields,
   normalizeEventWriteInput,
+  sanitizeEventWriteFields,
 } from "../src/lib/event-write.js";
 
 describe("event write normalization", () => {
@@ -141,6 +142,34 @@ describe("event write normalization", () => {
     });
 
     expect(normalized).toBeNull();
+  });
+});
+
+describe("event write sanitization", () => {
+  it("drops non-array tag payloads", () => {
+    const body: Record<string, unknown> = { tags: "oops" };
+
+    sanitizeEventWriteFields(body);
+
+    expect(body.tags).toBeUndefined();
+  });
+
+  it("keeps only string tags and sanitizes HTML", () => {
+    const body: Record<string, unknown> = {
+      tags: ["  <b>music</b>  ", 123, "", null, "<i>art</i>", {}, "   "],
+    };
+
+    sanitizeEventWriteFields(body);
+
+    expect(body.tags).toEqual(["music", "art"]);
+  });
+
+  it("preserves explicit empty tag arrays", () => {
+    const body: Record<string, unknown> = { tags: [] };
+
+    sanitizeEventWriteFields(body);
+
+    expect(body.tags).toEqual([]);
   });
 });
 

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -100,6 +100,17 @@ describe("event write normalization", () => {
       allDay: true,
     });
   });
+
+  it("returns null for malformed non-string temporal payload values", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: 123 as unknown as string,
+      endDateTime: { bad: true } as unknown as string,
+      eventTimezone: "Europe/Vienna",
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toBeNull();
+  });
 });
 
 describe("event write canonical derivation", () => {

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -85,6 +85,33 @@ describe("event write normalization", () => {
     ).toBeNull();
   });
 
+  it("trims eventTimezone during normalization", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      eventTimezone: "  Europe/Vienna  ",
+      allDay: false,
+      allowDateTimeFields: false,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10",
+      endValue: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+    });
+  });
+
+  it("returns null when eventTimezone is whitespace only", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      eventTimezone: "   ",
+      allDay: false,
+      allowDateTimeFields: false,
+    });
+
+    expect(normalized).toBeNull();
+  });
+
   it("trims whitespace and normalizes empty end values to null", () => {
     const normalized = normalizeEventWriteInput({
       startDate: " 2026-01-10 ",

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeMaterialEventChanges,
+  deriveCanonicalTemporalFields,
+  deriveStoredDatePart,
+  deriveUpdateTemporalFields,
+  normalizeEventWriteInput,
+} from "../src/lib/event-write.js";
+
+describe("event write normalization", () => {
+  it("normalizes timed input using datetime fields when allowed", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      startDateTime: "2026-01-10T10:30",
+      endDate: "2026-01-10",
+      endDateTime: "2026-01-10T11:30",
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10T10:30",
+      endValue: "2026-01-10T11:30",
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+    });
+  });
+
+  it("ignores datetime fields when allowDateTimeFields is false", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      startDateTime: "2026-01-10T10:30",
+      endDate: "2026-01-11",
+      endDateTime: "2026-01-10T11:30",
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+      allowDateTimeFields: false,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10",
+      endValue: "2026-01-11",
+      eventTimezone: "Europe/Vienna",
+      allDay: false,
+    });
+  });
+
+  it("rejects all-day payloads with datetime values", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      startDateTime: "2026-01-10T10:30",
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toBeNull();
+  });
+
+  it("rejects all-day payloads with invalid date-only values", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10T10:30",
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+      allowDateTimeFields: false,
+    });
+
+    expect(normalized).toBeNull();
+  });
+
+  it("returns null when required start or timezone are missing", () => {
+    expect(
+      normalizeEventWriteInput({
+        eventTimezone: "Europe/Vienna",
+        allowDateTimeFields: false,
+      }),
+    ).toBeNull();
+    expect(
+      normalizeEventWriteInput({
+        startDate: "2026-01-10",
+        allowDateTimeFields: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("trims whitespace and normalizes empty end values to null", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: " 2026-01-10 ",
+      endDate: "   ",
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+      allowDateTimeFields: false,
+    });
+
+    expect(normalized).toEqual({
+      startValue: "2026-01-10",
+      endValue: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+    });
+  });
+});
+
+describe("event write canonical derivation", () => {
+  it("keeps date parts directly for all-day values", () => {
+    const startOn = deriveStoredDatePart("2026-08-10", "2026-08-09T22:00:00.000Z", {
+      allDay: true,
+      eventTimezone: "Europe/Vienna",
+    });
+
+    expect(startOn).toBe("2026-08-10");
+  });
+
+  it("derives local date part from UTC instant for timed values", () => {
+    const startOn = deriveStoredDatePart("2026-01-01T00:30:00.000Z", "2026-01-01T00:30:00.000Z", {
+      allDay: false,
+      eventTimezone: "America/Los_Angeles",
+    });
+
+    expect(startOn).toBe("2025-12-31");
+  });
+
+  it("falls back to raw date prefix when UTC conversion is unavailable", () => {
+    const startOn = deriveStoredDatePart("2026-01-01T10:00:00", null, {
+      allDay: false,
+      eventTimezone: "Europe/Vienna",
+    });
+
+    expect(startOn).toBe("2026-01-01");
+  });
+
+  it("derives canonical fields for all-day events with omitted end", () => {
+    const canonical = deriveCanonicalTemporalFields({
+      startValue: "2026-08-10",
+      endValue: null,
+      eventTimezone: "Europe/Vienna",
+      allDay: true,
+    });
+
+    expect(canonical).toEqual({
+      startAtUtc: "2026-08-09T22:00:00.000Z",
+      endAtUtc: "2026-08-10T22:00:00.000Z",
+      startOn: "2026-08-10",
+      endOn: null,
+    });
+  });
+});
+
+describe("event write update temporal derivation", () => {
+  it("recomputes UTC values when timezone changes", () => {
+    const result = deriveUpdateTemporalFields({
+      nextAllDay: false,
+      existingStart: "2026-04-10T10:00",
+      existingEnd: "2026-04-10T11:00",
+      existingTimezone: "Europe/Vienna",
+      nextTimezone: "UTC",
+      shouldRecomputeUtcForTimezoneChange: true,
+      shouldRecomputeAllDayEndBoundary: false,
+    });
+
+    expect(result.tzForConvert).toBe("UTC");
+    expect(result.startForUtc).toBe("2026-04-10T10:00");
+    expect(result.endForUtc).toBe("2026-04-10T11:00");
+    expect(result.nextStartAtUtc).toBe("2026-04-10T10:00:00.000Z");
+    expect(result.nextEndAtUtc).toBe("2026-04-10T11:00:00.000Z");
+  });
+
+  it("recomputes all-day end boundary when requested", () => {
+    const result = deriveUpdateTemporalFields({
+      nextAllDay: true,
+      existingStart: "2026-08-10",
+      existingEnd: null,
+      existingTimezone: "Europe/Vienna",
+      shouldRecomputeUtcForTimezoneChange: false,
+      shouldRecomputeAllDayEndBoundary: true,
+    });
+
+    expect(result.startForUtc).toBeUndefined();
+    expect(result.endForUtc).toBeNull();
+    expect(result.nextStartAtUtc).toBeNull();
+    expect(result.nextEndAtUtc).toBe("2026-08-10T22:00:00.000Z");
+  });
+
+  it("does not recompute untouched UTC values", () => {
+    const result = deriveUpdateTemporalFields({
+      nextAllDay: false,
+      existingStart: "2026-04-10T10:00",
+      existingEnd: "2026-04-10T11:00",
+      existingTimezone: "Europe/Vienna",
+      shouldRecomputeUtcForTimezoneChange: false,
+      shouldRecomputeAllDayEndBoundary: false,
+    });
+
+    expect(result.startForUtc).toBeUndefined();
+    expect(result.endForUtc).toBeUndefined();
+    expect(result.nextStartAtUtc).toBeNull();
+    expect(result.nextEndAtUtc).toBeNull();
+  });
+
+  it("treats explicit nextEnd null differently from undefined", () => {
+    const explicitNull = deriveUpdateTemporalFields({
+      nextAllDay: false,
+      existingStart: "2026-04-10T10:00",
+      existingEnd: "2026-04-10T11:00",
+      existingTimezone: "Europe/Vienna",
+      nextEnd: null,
+      shouldRecomputeUtcForTimezoneChange: false,
+      shouldRecomputeAllDayEndBoundary: false,
+    });
+    const implicitUndefined = deriveUpdateTemporalFields({
+      nextAllDay: false,
+      existingStart: "2026-04-10T10:00",
+      existingEnd: "2026-04-10T11:00",
+      existingTimezone: "Europe/Vienna",
+      shouldRecomputeUtcForTimezoneChange: false,
+      shouldRecomputeAllDayEndBoundary: false,
+    });
+
+    expect(explicitNull.endForUtc).toBeNull();
+    expect(implicitUndefined.endForUtc).toBeUndefined();
+  });
+});
+
+describe("material event change detection", () => {
+  it("returns empty list when snapshots are materially equivalent", () => {
+    const changes = computeMaterialEventChanges(
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: null,
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T22:00:00.000Z",
+        endAtUtc: "2026-04-10T22:00:00.000Z",
+        locationName: undefined,
+        locationAddress: null,
+      },
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: undefined,
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T22:00:00.000Z",
+        endAtUtc: "2026-04-10T22:00:00.000Z",
+        locationName: null,
+        locationAddress: undefined,
+      },
+    );
+
+    expect(changes).toEqual([]);
+  });
+
+  it("detects title, time and location changes independently", () => {
+    const changes = computeMaterialEventChanges(
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: "2026-04-11",
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T22:00:00.000Z",
+        endAtUtc: "2026-04-11T22:00:00.000Z",
+        locationName: "Room A",
+        locationAddress: "Main Street 1",
+      },
+      {
+        title: "City Forum",
+        startDate: "2026-04-10",
+        endDate: "2026-04-12",
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T22:00:00.000Z",
+        endAtUtc: "2026-04-12T22:00:00.000Z",
+        locationName: "Room B",
+        locationAddress: "Main Street 2",
+      },
+    );
+
+    expect(changes.map((change) => change.field)).toEqual(["title", "time", "location"]);
+  });
+
+  it("marks time change when timezone differs even with same date strings", () => {
+    const changes = computeMaterialEventChanges(
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: "2026-04-11",
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+      },
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: "2026-04-11",
+        allDay: true,
+        eventTimezone: "UTC",
+      },
+    );
+
+    expect(changes).toEqual([
+      {
+        field: "time",
+        before: "2026-04-10 – 2026-04-11",
+        after: "2026-04-10 – 2026-04-11",
+        beforeAllDay: true,
+        afterAllDay: true,
+      },
+    ]);
+  });
+
+  it("marks time change when only UTC instant changes", () => {
+    const changes = computeMaterialEventChanges(
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: null,
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T22:00:00.000Z",
+      },
+      {
+        title: "Town Hall",
+        startDate: "2026-04-10",
+        endDate: undefined,
+        allDay: true,
+        eventTimezone: "Europe/Vienna",
+        startAtUtc: "2026-04-09T23:00:00.000Z",
+      },
+    );
+
+    expect(changes).toEqual([
+      {
+        field: "time",
+        before: "2026-04-10",
+        after: "2026-04-10",
+        beforeAllDay: true,
+        afterAllDay: true,
+      },
+    ]);
+  });
+});

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -101,9 +101,21 @@ describe("event write normalization", () => {
     });
   });
 
-  it("returns null for malformed non-string temporal payload values", () => {
+  it("returns null when startDateTime is present but not a string", () => {
     const normalized = normalizeEventWriteInput({
-      startDate: 123 as unknown as string,
+      startDate: "2026-01-10",
+      startDateTime: 123 as unknown as string,
+      eventTimezone: "Europe/Vienna",
+      allowDateTimeFields: true,
+    });
+
+    expect(normalized).toBeNull();
+  });
+
+  it("returns null when endDateTime is present but not a string", () => {
+    const normalized = normalizeEventWriteInput({
+      startDate: "2026-01-10",
+      endDate: "2026-01-11",
       endDateTime: { bad: true } as unknown as string,
       eventTimezone: "Europe/Vienna",
       allowDateTimeFields: true,

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -779,6 +779,45 @@ describe("event slug canonical behavior", () => {
     expect(row.title).toBe("Original PUT HTML Title");
   });
 
+  it("rejects PUT update when temporal fields normalize to empty whitespace", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Temporal Whitespace",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const invalidUpdates: Array<Record<string, string>> = [
+      { startDate: "   " },
+      { startDateTime: "   " },
+      { endDate: "   " },
+      { endDateTime: "   " },
+    ];
+
+    for (const payload of invalidUpdates) {
+      const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      expect(update.status).toBe(400);
+    }
+
+    const row = db.prepare("SELECT start_date, end_date FROM events WHERE id = ?").get(created.id) as {
+      start_date: string;
+      end_date: string | null;
+    };
+    expect(row.start_date).toBe("2026-01-01T10:00:00");
+    expect(row.end_date).toBeNull();
+  });
+
   it("stores all-day sync end_at_utc using end-exclusive boundary", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -435,6 +435,38 @@ describe("event slug canonical behavior", () => {
     expect(update.status).toBe(400);
   });
 
+  it("accepts all-day update when endDateTime is explicitly null", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "All Day Null End DateTime",
+        allDay: true,
+        startDate: "2026-01-01",
+        endDate: "2026-01-02",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        allDay: true,
+        endDateTime: null,
+      }),
+    });
+
+    expect(update.status).toBe(200);
+
+    const row = db.prepare("SELECT end_date FROM events WHERE id = ?").get(created.id) as { end_date: string | null };
+    expect(row.end_date).toBe("2026-01-02");
+  });
+
   it("accepts switching to all-day when date-only fields are provided", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 
@@ -725,6 +757,36 @@ describe("event slug canonical behavior", () => {
 
     const row = db.prepare("SELECT start_date FROM events WHERE id = ?").get(created.id) as { start_date: string };
     expect(row.start_date).toBe("2026-01-01T12:00:00");
+  });
+
+  it("treats null endDateTime as omitted on update", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Null end datetime update",
+        startDate: "2026-01-01T10:00:00",
+        endDate: "2026-01-01T11:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        endDateTime: null,
+      }),
+    });
+
+    expect(update.status).toBe(200);
+
+    const row = db.prepare("SELECT end_date FROM events WHERE id = ?").get(created.id) as { end_date: string | null };
+    expect(row.end_date).toBe("2026-01-01T11:00:00");
   });
 
   it("rejects PUT title update when title normalizes to empty whitespace", async () => {

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -1171,6 +1171,31 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBeNull();
   });
 
+  it("accepts sync with whitespace-padded timezone and stores trimmed value", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "trimmed-sync-timezone-1",
+            title: "Trimmed Sync Timezone",
+            startDate: "2026-06-01T10:00:00",
+            eventTimezone: " UTC ",
+          },
+        ],
+      }),
+    });
+    expect(sync.status).toBe(200);
+
+    const row = db.prepare("SELECT event_timezone FROM events WHERE external_id = ?").get("trimmed-sync-timezone-1") as {
+      event_timezone: string;
+    };
+    expect(row.event_timezone).toBe("UTC");
+  });
+
   it("normalizes sync external IDs before dedupe and persistence", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -255,6 +255,36 @@ describe("event slug canonical behavior", () => {
     expect(row.end_on).toBe("2025-12-31");
   });
 
+  it("normalizes create temporal values before persistence", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Trimmed Timed Event",
+        startDate: "2026-01-01",
+        startDateTime: " 2026-01-01T10:00:00 ",
+        endDateTime: "   ",
+        eventTimezone: "UTC",
+      }),
+    });
+
+    const body = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const row = db.prepare("SELECT start_date, end_date, start_at_utc, end_at_utc FROM events WHERE id = ?").get(body.id) as {
+      start_date: string;
+      end_date: string | null;
+      start_at_utc: string;
+      end_at_utc: string | null;
+    };
+    expect(row.start_date).toBe("2026-01-01T10:00:00");
+    expect(row.end_date).toBeNull();
+    expect(row.start_at_utc).toBe("2026-01-01T10:00:00.000Z");
+    expect(row.end_at_utc).toBeNull();
+  });
+
   it("does not generate OG for private event creates", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 
@@ -896,6 +926,38 @@ describe("event slug canonical behavior", () => {
     expect(row.event_timezone).toBe("Europe/Vienna");
     expect(row.start_at_utc).toBe("2026-06-01T08:00:00.000Z");
     expect(row.end_at_utc).toBe("2026-06-01T09:00:00.000Z");
+  });
+
+  it("normalizes sync temporal values before persistence", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "trimmed-sync-1",
+            title: "Trimmed Sync Event",
+            startDate: " 2026-06-01T10:00:00 ",
+            endDate: "   ",
+            eventTimezone: "UTC",
+          },
+        ],
+      }),
+    });
+    expect(sync.status).toBe(200);
+
+    const row = db.prepare("SELECT start_date, end_date, start_at_utc, end_at_utc FROM events WHERE external_id = ?").get("trimmed-sync-1") as {
+      start_date: string;
+      end_date: string | null;
+      start_at_utc: string;
+      end_at_utc: string | null;
+    };
+    expect(row.start_date).toBe("2026-06-01T10:00:00");
+    expect(row.end_date).toBeNull();
+    expect(row.start_at_utc).toBe("2026-06-01T10:00:00.000Z");
+    expect(row.end_at_utc).toBeNull();
   });
 
   it("creates remote slug once and keeps it immutable on update", () => {

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -285,6 +285,42 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBeNull();
   });
 
+  it("rejects create when title normalizes to empty whitespace", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "   ",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+
+    expect(create.status).toBe(400);
+    const row = db.prepare("SELECT COUNT(*) as count FROM events").get() as { count: number };
+    expect(row.count).toBe(0);
+  });
+
+  it("rejects create when title normalizes to empty html", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "<b></b>",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+
+    expect(create.status).toBe(400);
+    const row = db.prepare("SELECT COUNT(*) as count FROM events").get() as { count: number };
+    expect(row.count).toBe(0);
+  });
+
   it("does not generate OG for private event creates", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -610,6 +610,58 @@ describe("event slug canonical behavior", () => {
     expect(typeof payload.error).toBe("string");
   });
 
+  it("rejects PUT title update when title normalizes to empty whitespace", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Original PUT Title",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "   " }),
+    });
+
+    expect(update.status).toBe(400);
+    const row = db.prepare("SELECT title FROM events WHERE id = ?").get(created.id) as { title: string };
+    expect(row.title).toBe("Original PUT Title");
+  });
+
+  it("rejects PUT title update when title normalizes to empty html", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Original PUT HTML Title",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "<b></b>" }),
+    });
+
+    expect(update.status).toBe(400);
+    const row = db.prepare("SELECT title FROM events WHERE id = ?").get(created.id) as { title: string };
+    expect(row.title).toBe("Original PUT HTML Title");
+  });
+
   it("stores all-day sync end_at_utc using end-exclusive boundary", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -285,6 +285,27 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBeNull();
   });
 
+  it("treats whitespace-only startDateTime as omitted on create", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Whitespace DateTime Fallback",
+        startDate: "2026-01-01T10:00:00",
+        startDateTime: "   ",
+        eventTimezone: "UTC",
+      }),
+    });
+
+    const body = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const row = db.prepare("SELECT start_date FROM events WHERE id = ?").get(body.id) as { start_date: string };
+    expect(row.start_date).toBe("2026-01-01T10:00:00");
+  });
+
   it("accepts create with whitespace-padded timezone and stores trimmed value", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -524,6 +524,29 @@ describe("event slug canonical behavior", () => {
     expect(sync.status).toBe(400);
   });
 
+  it("returns a safe 400 for malformed sync temporal field types", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "malformed-sync-1",
+            title: "Malformed Sync",
+            startDate: 123,
+            eventTimezone: "UTC",
+          },
+        ],
+      }),
+    });
+
+    const payload = await sync.json() as { error?: unknown };
+    expect(sync.status).toBe(400);
+    expect(typeof payload.error).toBe("string");
+  });
+
   it("stores all-day sync end_at_utc using end-exclusive boundary", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -285,6 +285,28 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBeNull();
   });
 
+  it("accepts create with whitespace-padded timezone and stores trimmed value", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Trimmed Timezone Create",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: " UTC ",
+      }),
+    });
+
+    const body = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const row = db.prepare("SELECT event_timezone FROM events WHERE id = ?").get(body.id) as {
+      event_timezone: string;
+    };
+    expect(row.event_timezone).toBe("UTC");
+  });
+
   it("rejects create when title normalizes to empty whitespace", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -1046,6 +1046,48 @@ describe("event slug canonical behavior", () => {
     expect(row.end_at_utc).toBeNull();
   });
 
+  it("normalizes sync external IDs before dedupe and persistence", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "sync-ext-trim",
+            title: "First Variant",
+            startDate: "2026-06-01T10:00:00",
+            eventTimezone: "UTC",
+          },
+          {
+            externalId: "  sync-ext-trim  ",
+            title: "Second Variant",
+            startDate: "2026-06-01T10:00:00",
+            eventTimezone: "UTC",
+          },
+        ],
+      }),
+    });
+    expect(sync.status).toBe(200);
+
+    const payload = await sync.json() as { total: number; created: number };
+    expect(payload.total).toBe(1);
+    expect(payload.created).toBe(1);
+
+    const row = db.prepare("SELECT external_id, title FROM events WHERE external_id = ?").get("sync-ext-trim") as {
+      external_id: string;
+      title: string;
+    };
+    expect(row.external_id).toBe("sync-ext-trim");
+    expect(row.title).toBe("Second Variant");
+
+    const countRow = db.prepare("SELECT COUNT(*) AS count FROM events WHERE external_id = ?").get("sync-ext-trim") as {
+      count: number;
+    };
+    expect(countRow.count).toBe(1);
+  });
+
   it("creates remote slug once and keeps it immutable on update", () => {
     db.prepare("INSERT INTO remote_actors (uri, preferred_username, inbox, domain) VALUES (?, ?, ?, ?)")
       .run("https://remote.example/users/alice", "alice", "https://remote.example/inbox", "remote.example");

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -610,6 +610,57 @@ describe("event slug canonical behavior", () => {
     expect(typeof payload.error).toBe("string");
   });
 
+  it("treats null startDateTime as omitted on create", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Null datetime create",
+        startDate: "2026-01-01T10:00:00",
+        startDateTime: null,
+        eventTimezone: "UTC",
+      }),
+    });
+
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const row = db.prepare("SELECT start_date FROM events WHERE id = ?").get(created.id) as { start_date: string };
+    expect(row.start_date).toBe("2026-01-01T10:00:00");
+  });
+
+  it("treats null startDateTime as omitted on update", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Null datetime update",
+        startDate: "2026-01-01T10:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        startDate: "2026-01-01T12:00:00",
+        startDateTime: null,
+      }),
+    });
+
+    expect(update.status).toBe(200);
+
+    const row = db.prepare("SELECT start_date FROM events WHERE id = ?").get(created.id) as { start_date: string };
+    expect(row.start_date).toBe("2026-01-01T12:00:00");
+  });
+
   it("rejects PUT title update when title normalizes to empty whitespace", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -547,6 +547,33 @@ describe("event slug canonical behavior", () => {
     expect(typeof payload.error).toBe("string");
   });
 
+  it("returns a safe 400 for malformed PUT temporal field types", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Malformed PUT",
+        startDate: "2026-01-01T10:00:00",
+        endDate: "2026-01-01T11:00:00",
+        eventTimezone: "UTC",
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ startDateTime: 123 }),
+    });
+
+    const payload = await update.json() as { error?: unknown };
+    expect(update.status).toBe(400);
+    expect(typeof payload.error).toBe("string");
+  });
+
   it("stores all-day sync end_at_utc using end-exclusive boundary", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -605,6 +605,29 @@ describe("event slug canonical behavior", () => {
     expect(typeof payload.error).toBe("string");
   });
 
+  it("rejects sync events when title sanitizes to empty html", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        events: [
+          {
+            externalId: "empty-title-sync",
+            title: "<b></b>",
+            startDate: "2026-01-01T10:00:00",
+            eventTimezone: "UTC",
+          },
+        ],
+      }),
+    });
+
+    expect(sync.status).toBe(400);
+    const row = db.prepare("SELECT id FROM events WHERE external_id = ?").get("empty-title-sync") as { id: string } | undefined;
+    expect(row).toBeUndefined();
+  });
+
   it("returns a safe 400 for malformed PUT temporal field types", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 


### PR DESCRIPTION
### Motivation
- Reduce duplication and centralize domain logic for event writes (validation, sanitization, temporal derivation, and material-change detection) currently scattered in `events.ts`.
- Make temporal computations (UTC instants and stored date parts) and material-change diffing reusable and easier to test/maintain.

### Description
- Add new module `packages/server/src/lib/event-write.ts` that provides: `sanitizeEventWriteFields`, `normalizeEventWriteInput`, `deriveCanonicalTemporalFields`, `deriveUpdateTemporalFields`, `deriveStoredDatePart`, `computeMaterialEventChanges`, and related types for normalized inputs and material-change snapshots.
- Replace inline write/temporal logic in `packages/server/src/routes/events.ts` with calls to the new helpers in the following routes: `POST /sync`, `POST /` (create), and `PUT /:id` (update), while preserving all SQL statements and side effects (notifications, federation delivery, OG generation/clear).
- Keep validation/error shape/status behavior aligned with the refactor intent, and replace ad-hoc change detection with `computeMaterialEventChanges` while canonicalizing temporal derivation via `deriveCanonicalTemporalFields` and `deriveUpdateTemporalFields`.
- No SQL was moved out of `events.ts`; only domain helpers were extracted and imported.

### API Behavior Notes
- Temporal write inputs are now normalized in shared helper paths before persistence/validation outcomes are finalized.
- For create/sync inputs, `startDate`, `startDateTime`, `endDate`, and `endDateTime` are trimmed; whitespace-only temporal end values are treated as omitted (`null`) instead of persisted as blank strings.
- This means some payloads can now be accepted/rejected differently than before normalization, and persisted temporal values may differ from raw input formatting.

### Testing
- Built dependent package with `pnpm --filter @everycal/og build` (succeeded).
- Ran TypeScript checks / lint for server with `pnpm --filter @everycal/server lint` (succeeded after building `@everycal/og`).
- Ran server test suite with `pnpm --filter @everycal/server test`; most tests passed but a subset of network-dependent Mobilizon federation tests failed due to `ENETUNREACH` when fetching `events.htu.at` in this environment (external network failure, not related to the refactor).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3cee2e3c8832183a2cf162f53445b)