### PR TITLE
Refactor event sync route into dedicated event-sync module

### DIFF
--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -210,34 +210,31 @@ function eventHash(ev: SyncEventInput): string {
   return createHash("sha256").update(data).digest("base64url").slice(0, 22);
 }
 
-export function applySyncBatch(
-  db: DB,
-  args: {
-    events: SyncEventInput[];
-    existingByExtId: Map<string, ExistingSyncEventRow>;
-    accountId: string;
-    username: string;
-    ogEventIdsToGenerate: Set<string>;
-    ogEventIdsToClear: Set<string>;
-    uniqueLocalEventSlug: (db: DB, accountId: string, title: string, excludeId?: string) => string;
-    isOgEligibleVisibility: (visibility: string) => boolean;
-    notifyEventUpdated: (eventId: string, event: {
-      id: string;
-      title: string;
-      slug: string;
-      account: { username: string };
-      startDate: string;
-      endDate: string | null;
-      allDay: boolean;
-      location: { name: string } | null;
-      url: string | null;
-    }, changes: ReturnType<typeof computeMaterialEventChanges>) => void;
-  },
-): { created: number; updated: number; unchanged: number } {
-  let created = 0;
-  let updated = 0;
-  let unchanged = 0;
+export type ApplySyncBatchArgs = {
+  events: SyncEventInput[];
+  existingByExtId: Map<string, ExistingSyncEventRow>;
+  accountId: string;
+  username: string;
+  ogEventIdsToGenerate: Set<string>;
+  ogEventIdsToClear: Set<string>;
+  uniqueLocalEventSlug: (db: DB, accountId: string, title: string, excludeId?: string) => string;
+  isOgEligibleVisibility: (visibility: string) => boolean;
+  notifyEventUpdated: (eventId: string, event: {
+    id: string;
+    title: string;
+    slug: string;
+    account: { username: string };
+    startDate: string;
+    endDate: string | null;
+    allDay: boolean;
+    location: { name: string } | null;
+    url: string | null;
+  }, changes: ReturnType<typeof computeMaterialEventChanges>) => void;
+};
 
+export function createSyncBatchApplier(
+  db: DB,
+): (args: ApplySyncBatchArgs) => { created: number; updated: number; unchanged: number } {
   const insertEvent = db.prepare(
     `INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, description, start_date, end_date, all_day, start_at_utc, end_at_utc, event_timezone, start_on, end_on,
       location_name, location_address, location_latitude, location_longitude, location_url,
@@ -260,8 +257,8 @@ export function applySyncBatch(
   const deleteTagsStmt = db.prepare("DELETE FROM event_tags WHERE event_id = ?");
   const insertTagStmt = db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?)");
 
-  const upsertBatch = db.transaction((events: SyncEventInput[]) => {
-    for (const ev of events) {
+  const upsertBatch = db.transaction((args: ApplySyncBatchArgs, counters: { created: number; updated: number; unchanged: number }) => {
+    for (const ev of args.events) {
       const visibility = ev.visibility || "public";
       if (!isValidVisibility(visibility)) continue;
       const hash = eventHash(ev);
@@ -272,7 +269,7 @@ export function applySyncBatch(
           if (existingRow.canceled || existingRow.missing_since) {
             restoreEventState.run(existingRow.id);
           }
-          unchanged++;
+          counters.unchanged++;
           continue;
         }
 
@@ -352,7 +349,7 @@ export function applySyncBatch(
             url: ev.url || null,
           }, changes);
         }
-        updated++;
+        counters.updated++;
       } else {
         const id = nanoid(16);
         const evSlug = args.uniqueLocalEventSlug(db, args.accountId, ev.title);
@@ -389,12 +386,21 @@ export function applySyncBatch(
         if (ev.tags) {
           for (const tag of ev.tags) insertTagStmt.run(id, tag.trim());
         }
-        created++;
+        counters.created++;
       }
     }
   });
 
-  upsertBatch(args.events);
+  return (args: ApplySyncBatchArgs) => {
+    const counters = { created: 0, updated: 0, unchanged: 0 };
+    upsertBatch(args, counters);
+    return counters;
+  };
+}
 
-  return { created, updated, unchanged };
+export function applySyncBatch(
+  db: DB,
+  args: ApplySyncBatchArgs,
+): { created: number; updated: number; unchanged: number } {
+  return createSyncBatchApplier(db)(args);
 }

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -213,7 +213,7 @@ function eventHash(ev: SyncEventInput): string {
 
 function normalizeTags(tags?: string[]): string[] {
   if (!tags) return [];
-  return tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
+  return Array.from(new Set(tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0)));
 }
 
 export type ApplySyncBatchArgs = {

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -1,0 +1,400 @@
+import { nanoid } from "nanoid";
+import { createHash } from "node:crypto";
+import type { DB } from "../db.js";
+import { isValidVisibility } from "@everycal/core";
+import { isValidIanaTimezone } from "./timezone.js";
+import {
+  computeMaterialEventChanges,
+  deriveCanonicalTemporalFields,
+  deriveStoredDatePart,
+  normalizeEventWriteInput,
+  sanitizeEventWriteFields,
+} from "./event-write.js";
+
+export type RawSyncEvent = {
+  externalId: string;
+  title: string;
+  description?: string;
+  startDate: string;
+  endDate?: string;
+  eventTimezone: string;
+  allDay?: boolean;
+  location?: { name: string; address?: string; latitude?: number; longitude?: number; url?: string };
+  image?: { url: string; mediaType?: string; alt?: string };
+  url?: string;
+  tags?: string[];
+  visibility?: string;
+};
+
+export type SyncEventInput = Omit<RawSyncEvent, "startDate" | "endDate" | "allDay" | "eventTimezone"> & {
+  startDate: string;
+  endDate: string | null;
+  allDay: boolean;
+  eventTimezone: string;
+};
+
+export type ExistingSyncEventRow = {
+  id: string;
+  slug: string | null;
+  external_id: string;
+  content_hash: string | null;
+  title: string;
+  start_date: string;
+  end_date: string | null;
+  start_at_utc: string;
+  end_at_utc: string | null;
+  all_day: number;
+  location_name: string | null;
+  location_address: string | null;
+  event_timezone: string | null;
+  url: string | null;
+  description: string | null;
+  visibility: string;
+  canceled: number;
+  missing_since: string | null;
+};
+
+export function normalizeSyncEvents(events: RawSyncEvent[]): { ok: true; syncEvents: SyncEventInput[] } | { ok: false; errorKey: string } {
+  const normalizedSyncTemporalByExternalId = new Map<string, {
+    startDate: string;
+    endDate: string | null;
+    allDay: boolean;
+    eventTimezone: string;
+  }>();
+  const normalizedIncomingEvents: RawSyncEvent[] = [];
+
+  for (const ev of events) {
+    const normalizedTimezone = typeof ev.eventTimezone === "string"
+      ? ev.eventTimezone.trim()
+      : "";
+    if (typeof ev.externalId !== "string"
+      || !ev.externalId.trim()
+      || typeof ev.title !== "string"
+      || !ev.title.trim()
+      || typeof ev.startDate !== "string"
+      || !ev.startDate.trim()
+      || typeof ev.eventTimezone !== "string"
+      || !normalizedTimezone
+      || !isValidIanaTimezone(normalizedTimezone)) {
+      return { ok: false, errorKey: "events.event_requires_fields" };
+    }
+    if ((ev.endDate !== undefined && ev.endDate !== null && typeof ev.endDate !== "string")
+      || (ev.allDay !== undefined && typeof ev.allDay !== "boolean")) {
+      return { ok: false, errorKey: "events.invalid_datetime" };
+    }
+    const normalizedWrite = normalizeEventWriteInput({
+      startDate: ev.startDate,
+      endDate: ev.endDate,
+      eventTimezone: normalizedTimezone,
+      allDay: ev.allDay,
+      allowDateTimeFields: false,
+    });
+    if (!normalizedWrite) {
+      return { ok: false, errorKey: "events.invalid_datetime" };
+    }
+    const { startAtUtc, endAtUtc } = deriveCanonicalTemporalFields(normalizedWrite);
+    if (!startAtUtc
+      || (normalizedWrite.allDay ? !endAtUtc : (normalizedWrite.endValue !== null && !endAtUtc))
+      || (endAtUtc && endAtUtc < startAtUtc)) {
+      return { ok: false, errorKey: "events.invalid_datetime" };
+    }
+    const normalizedExternalId = ev.externalId.trim();
+    normalizedSyncTemporalByExternalId.set(normalizedExternalId, {
+      startDate: normalizedWrite.startValue,
+      endDate: normalizedWrite.endValue,
+      allDay: normalizedWrite.allDay,
+      eventTimezone: normalizedWrite.eventTimezone,
+    });
+    normalizedIncomingEvents.push({
+      ...ev,
+      externalId: normalizedExternalId,
+      eventTimezone: normalizedWrite.eventTimezone,
+    });
+  }
+
+  const deduped = [...new Map(normalizedIncomingEvents.map((ev) => [ev.externalId, ev])).values()];
+
+  for (const ev of deduped) {
+    sanitizeEventWriteFields(ev as Record<string, unknown>);
+    if (typeof ev.title !== "string" || !ev.title.trim()) {
+      return { ok: false, errorKey: "events.event_requires_fields" };
+    }
+  }
+
+  const syncEvents: SyncEventInput[] = [];
+  for (const ev of deduped) {
+    const normalizedTemporal = normalizedSyncTemporalByExternalId.get(ev.externalId);
+    if (!normalizedTemporal) {
+      return { ok: false, errorKey: "events.invalid_datetime" };
+    }
+    syncEvents.push({
+      ...ev,
+      startDate: normalizedTemporal.startDate,
+      endDate: normalizedTemporal.endDate,
+      allDay: normalizedTemporal.allDay,
+      eventTimezone: normalizedTemporal.eventTimezone,
+    });
+  }
+
+  return { ok: true, syncEvents };
+}
+
+export function reconcileMissingEvents(
+  db: DB,
+  args: {
+    existing: ExistingSyncEventRow[];
+    incomingExtIds: Set<string>;
+    nowIso: string;
+  },
+ ): {
+  canceled: number;
+  rotatedOutPast: number;
+  missingCount: number;
+  notifications: ExistingSyncEventRow[];
+} {
+  let canceled = 0;
+  let rotatedOutPast = 0;
+  const notifications: ExistingSyncEventRow[] = [];
+
+  const missingRows = args.existing.filter((r) => !args.incomingExtIds.has(r.external_id));
+  if (missingRows.length === 0) {
+    return { canceled, rotatedOutPast, missingCount: 0, notifications };
+  }
+
+  const markMissingSeen = db.prepare("UPDATE events SET missing_since = COALESCE(missing_since, datetime('now')) WHERE id = ?");
+  const markCanceled = db.prepare("UPDATE events SET canceled = 1, missing_since = datetime('now'), updated_at = datetime('now') WHERE id = ?");
+  const clearMissingForPast = db.prepare("UPDATE events SET missing_since = NULL WHERE id = ?");
+
+  const missingBatch = db.transaction((rows: typeof missingRows) => {
+    for (const row of rows) {
+      if (row.start_at_utc < args.nowIso) {
+        clearMissingForPast.run(row.id);
+        rotatedOutPast++;
+        continue;
+      }
+
+      if (!row.missing_since) {
+        markMissingSeen.run(row.id);
+        continue;
+      }
+
+      if (!row.canceled) {
+        markCanceled.run(row.id);
+        canceled++;
+      } else {
+        markMissingSeen.run(row.id);
+      }
+    }
+  });
+
+  missingBatch(missingRows);
+
+  for (const row of missingRows) {
+    if (row.start_at_utc >= args.nowIso && row.missing_since && !row.canceled) {
+      notifications.push(row);
+    }
+  }
+
+  return { canceled, rotatedOutPast, missingCount: missingRows.length, notifications };
+}
+
+function eventHash(ev: SyncEventInput): string {
+  const data = JSON.stringify([
+    ev.title, ev.description || "", ev.startDate, ev.endDate || "", ev.eventTimezone,
+    ev.allDay ? 1 : 0, ev.location?.name || "", ev.location?.address || "",
+    ev.location?.latitude ?? "", ev.location?.longitude ?? "",
+    ev.location?.url || "", ev.image?.url || "", ev.image?.mediaType || "",
+    ev.image?.alt || "", ev.url || "", ev.visibility || "public",
+    (ev.tags || []).slice().sort().join(","),
+  ]);
+  return createHash("sha256").update(data).digest("base64url").slice(0, 22);
+}
+
+export function applySyncBatch(
+  db: DB,
+  args: {
+    events: SyncEventInput[];
+    existingByExtId: Map<string, ExistingSyncEventRow>;
+    accountId: string;
+    username: string;
+    ogEventIdsToGenerate: Set<string>;
+    ogEventIdsToClear: Set<string>;
+    uniqueLocalEventSlug: (db: DB, accountId: string, title: string, excludeId?: string) => string;
+    isOgEligibleVisibility: (visibility: string) => boolean;
+    notifyEventUpdated: (eventId: string, event: {
+      id: string;
+      title: string;
+      slug: string;
+      account: { username: string };
+      startDate: string;
+      endDate: string | null;
+      allDay: boolean;
+      location: { name: string } | null;
+      url: string | null;
+    }, changes: ReturnType<typeof computeMaterialEventChanges>) => void;
+  },
+): { created: number; updated: number; unchanged: number } {
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+
+  const insertEvent = db.prepare(
+    `INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, description, start_date, end_date, all_day, start_at_utc, end_at_utc, event_timezone, start_on, end_on,
+      location_name, location_address, location_latitude, location_longitude, location_url,
+      image_url, image_media_type, image_alt, url, visibility, content_hash)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  );
+
+  const updateEvent = db.prepare(
+    `UPDATE events SET title = ?, slug = ?, description = ?, start_date = ?, end_date = ?, all_day = ?, start_at_utc = ?, end_at_utc = ?, event_timezone = ?, start_on = ?, end_on = ?,
+      location_name = ?, location_address = ?, location_latitude = ?, location_longitude = ?, location_url = ?,
+      image_url = ?, image_media_type = ?, image_alt = ?, url = ?, visibility = ?,
+      content_hash = ?, canceled = 0, missing_since = NULL, updated_at = datetime('now')
+     WHERE id = ?`
+  );
+
+  const restoreEventState = db.prepare(
+    "UPDATE events SET canceled = 0, missing_since = NULL, updated_at = datetime('now') WHERE id = ?"
+  );
+
+  const deleteTagsStmt = db.prepare("DELETE FROM event_tags WHERE event_id = ?");
+  const insertTagStmt = db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?)");
+
+  const upsertBatch = db.transaction((events: SyncEventInput[]) => {
+    for (const ev of events) {
+      const visibility = ev.visibility || "public";
+      if (!isValidVisibility(visibility)) continue;
+      const hash = eventHash(ev);
+      const existingRow = args.existingByExtId.get(ev.externalId);
+
+      if (existingRow) {
+        if (existingRow.content_hash === hash) {
+          if (existingRow.canceled || existingRow.missing_since) {
+            restoreEventState.run(existingRow.id);
+          }
+          unchanged++;
+          continue;
+        }
+
+        const oldAllDay = !!existingRow.all_day;
+        const newAllDay = !!ev.allDay;
+        const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
+          startValue: ev.startDate,
+          endValue: ev.endDate ?? null,
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        });
+        const changes = computeMaterialEventChanges(
+          {
+            title: existingRow.title,
+            startDate: existingRow.start_date,
+            endDate: existingRow.end_date,
+            allDay: oldAllDay,
+            eventTimezone: existingRow.event_timezone,
+            startAtUtc: existingRow.start_at_utc,
+            endAtUtc: existingRow.end_at_utc,
+            locationName: existingRow.location_name,
+            locationAddress: existingRow.location_address,
+          },
+          {
+            title: ev.title,
+            startDate: ev.startDate,
+            endDate: ev.endDate,
+            allDay: newAllDay,
+            eventTimezone: ev.eventTimezone,
+            startAtUtc: nextStartAtUtc,
+            endAtUtc: nextEndAtUtc,
+            locationName: ev.location?.name,
+            locationAddress: ev.location?.address,
+          },
+        );
+
+        const evSlug = args.uniqueLocalEventSlug(db, args.accountId, ev.title, existingRow.id);
+        const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        }) || ev.startDate.slice(0, 10);
+        const nextEndOn = deriveStoredDatePart(ev.endDate ?? null, nextEndAtUtc, {
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        });
+        updateEvent.run(
+          ev.title, evSlug, ev.description || null,
+          ev.startDate, ev.endDate || null, ev.allDay ? 1 : 0,
+          nextStartAtUtc, nextEndAtUtc, ev.eventTimezone, nextStartOn, nextEndOn,
+          ev.location?.name || null, ev.location?.address || null,
+          ev.location?.latitude ?? null, ev.location?.longitude ?? null,
+          ev.location?.url || null,
+          ev.image?.url || null, ev.image?.mediaType || null, ev.image?.alt || null,
+          ev.url || null, visibility, hash, existingRow.id,
+        );
+
+        if (args.isOgEligibleVisibility(visibility)) {
+          args.ogEventIdsToGenerate.add(existingRow.id);
+        } else {
+          args.ogEventIdsToClear.add(existingRow.id);
+        }
+
+        deleteTagsStmt.run(existingRow.id);
+        if (ev.tags) {
+          for (const tag of ev.tags) insertTagStmt.run(existingRow.id, tag.trim());
+        }
+        if (changes.length > 0) {
+          args.notifyEventUpdated(existingRow.id, {
+            id: existingRow.id,
+            title: ev.title,
+            slug: evSlug,
+            account: { username: args.username },
+            startDate: ev.startDate,
+            endDate: ev.endDate || null,
+            allDay: ev.allDay ?? false,
+            location: ev.location ? { name: ev.location.name } : null,
+            url: ev.url || null,
+          }, changes);
+        }
+        updated++;
+      } else {
+        const id = nanoid(16);
+        const evSlug = args.uniqueLocalEventSlug(db, args.accountId, ev.title);
+        const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
+          startValue: ev.startDate,
+          endValue: ev.endDate ?? null,
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        });
+        const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        }) || ev.startDate.slice(0, 10);
+        const nextEndOn = deriveStoredDatePart(ev.endDate ?? null, nextEndAtUtc, {
+          allDay: !!ev.allDay,
+          eventTimezone: ev.eventTimezone,
+        });
+        insertEvent.run(
+          id, args.accountId, args.accountId, ev.externalId, evSlug,
+          ev.title, ev.description || null,
+          ev.startDate, ev.endDate || null, ev.allDay ? 1 : 0,
+          nextStartAtUtc, nextEndAtUtc, ev.eventTimezone, nextStartOn, nextEndOn,
+          ev.location?.name || null, ev.location?.address || null,
+          ev.location?.latitude ?? null, ev.location?.longitude ?? null,
+          ev.location?.url || null,
+          ev.image?.url || null, ev.image?.mediaType || null, ev.image?.alt || null,
+          ev.url || null, visibility, hash,
+        );
+
+        if (args.isOgEligibleVisibility(visibility)) {
+          args.ogEventIdsToGenerate.add(id);
+        }
+
+        if (ev.tags) {
+          for (const tag of ev.tags) insertTagStmt.run(id, tag.trim());
+        }
+        created++;
+      }
+    }
+  });
+
+  upsertBatch(args.events);
+
+  return { created, updated, unchanged };
+}

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -16,7 +16,7 @@ export type RawSyncEvent = {
   title: string;
   description?: string;
   startDate: string;
-  endDate?: string;
+  endDate?: string | null;
   eventTimezone: string;
   allDay?: boolean;
   location?: { name: string; address?: string; latitude?: number; longitude?: number; url?: string };

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -199,15 +199,21 @@ export function reconcileMissingEvents(
 }
 
 function eventHash(ev: SyncEventInput): string {
+  const normalizedTags = normalizeTags(ev.tags);
   const data = JSON.stringify([
     ev.title, ev.description || "", ev.startDate, ev.endDate || "", ev.eventTimezone,
     ev.allDay ? 1 : 0, ev.location?.name || "", ev.location?.address || "",
     ev.location?.latitude ?? "", ev.location?.longitude ?? "",
     ev.location?.url || "", ev.image?.url || "", ev.image?.mediaType || "",
     ev.image?.alt || "", ev.url || "", ev.visibility || "public",
-    (ev.tags || []).slice().sort().join(","),
+    normalizedTags.slice().sort().join(","),
   ]);
   return createHash("sha256").update(data).digest("base64url").slice(0, 22);
+}
+
+function normalizeTags(tags?: string[]): string[] {
+  if (!tags) return [];
+  return tags.map((tag) => tag.trim()).filter((tag) => tag.length > 0);
 }
 
 export type ApplySyncBatchArgs = {
@@ -333,9 +339,7 @@ export function createSyncBatchApplier(
         }
 
         deleteTagsStmt.run(existingRow.id);
-        if (ev.tags) {
-          for (const tag of ev.tags) insertTagStmt.run(existingRow.id, tag.trim());
-        }
+        for (const tag of normalizeTags(ev.tags)) insertTagStmt.run(existingRow.id, tag);
         if (changes.length > 0) {
           args.notifyEventUpdated(existingRow.id, {
             id: existingRow.id,
@@ -383,9 +387,7 @@ export function createSyncBatchApplier(
           args.ogEventIdsToGenerate.add(id);
         }
 
-        if (ev.tags) {
-          for (const tag of ev.tags) insertTagStmt.run(id, tag.trim());
-        }
+        for (const tag of normalizeTags(ev.tags)) insertTagStmt.run(id, tag);
         counters.created++;
       }
     }

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -110,6 +110,9 @@ export function normalizeSyncEvents(events: RawSyncEvent[]): { ok: true; syncEve
     });
     normalizedIncomingEvents.push({
       ...ev,
+      location: ev.location ? { ...ev.location } : undefined,
+      image: ev.image ? { ...ev.image } : undefined,
+      tags: ev.tags ? [...ev.tags] : undefined,
       externalId: normalizedExternalId,
       eventTimezone: normalizedWrite.eventTimezone,
     });

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -112,7 +112,7 @@ export function normalizeSyncEvents(events: RawSyncEvent[]): { ok: true; syncEve
       ...ev,
       location: ev.location ? { ...ev.location } : undefined,
       image: ev.image ? { ...ev.image } : undefined,
-      tags: ev.tags ? [...ev.tags] : undefined,
+      tags: Array.isArray(ev.tags) ? [...ev.tags] : ev.tags,
       externalId: normalizedExternalId,
       eventTimezone: normalizedWrite.eventTimezone,
     });

--- a/packages/server/src/lib/event-sync.ts
+++ b/packages/server/src/lib/event-sync.ts
@@ -64,6 +64,9 @@ export function normalizeSyncEvents(events: RawSyncEvent[]): { ok: true; syncEve
   const normalizedIncomingEvents: RawSyncEvent[] = [];
 
   for (const ev of events) {
+    if (!ev || typeof ev !== "object" || Array.isArray(ev)) {
+      return { ok: false, errorKey: "events.event_requires_fields" };
+    }
     const normalizedTimezone = typeof ev.eventTimezone === "string"
       ? ev.eventTimezone.trim()
       : "";

--- a/packages/server/src/lib/event-write.ts
+++ b/packages/server/src/lib/event-write.ts
@@ -41,10 +41,16 @@ export function sanitizeEventWriteFields(body: Record<string, unknown>): void {
     if (!Array.isArray(body.tags)) {
       body.tags = undefined;
     } else {
+      const seenTags = new Set<string>();
       body.tags = body.tags
         .filter((tag): tag is string => typeof tag === "string")
         .map((tag) => stripHtml(tag))
-        .filter(Boolean);
+        .map((tag) => tag.trim())
+        .filter((tag) => {
+          if (!tag || seenTags.has(tag)) return false;
+          seenTags.add(tag);
+          return true;
+        });
     }
   }
 }

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -251,7 +251,11 @@ export function eventRoutes(db: DB): Hono {
   /** Insert tags for an event. */
   function saveTags(eventId: string, tags: string[]): void {
     const stmt = db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?)");
-    for (const tag of tags) stmt.run(eventId, tag.trim());
+    for (const tag of tags) {
+      const trimmed = tag.trim();
+      if (!trimmed) continue;
+      stmt.run(eventId, trimmed);
+    }
   }
 
   /** Delete then re-insert tags for an event. */

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -53,7 +53,7 @@ import {
   sanitizeEventWriteFields,
 } from "../lib/event-write.js";
 import {
-  applySyncBatch,
+  createSyncBatchApplier,
   normalizeSyncEvents,
   reconcileMissingEvents,
   type ExistingSyncEventRow,
@@ -676,9 +676,10 @@ export function eventRoutes(db: DB): Hono {
     }
 
     const BATCH_SIZE = 20;
+    const applySyncBatch = createSyncBatchApplier(db);
     for (let i = 0; i < syncEvents.length; i += BATCH_SIZE) {
       const chunk = syncEvents.slice(i, i + BATCH_SIZE);
-      const result = applySyncBatch(db, {
+      const result = applySyncBatch({
         events: chunk,
         existingByExtId,
         accountId: user.id,

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -250,7 +250,7 @@ export function eventRoutes(db: DB): Hono {
 
   /** Insert tags for an event. */
   function saveTags(eventId: string, tags: string[]): void {
-    const stmt = db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?)");
+    const stmt = db.prepare("INSERT OR IGNORE INTO event_tags (event_id, tag) VALUES (?, ?)");
     for (const tag of tags) {
       const trimmed = tag.trim();
       if (!trimmed) continue;

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -13,7 +13,6 @@
 
 import { Hono } from "hono";
 import { nanoid } from "nanoid";
-import { createHash } from "node:crypto";
 import type { DB } from "../db.js";
 import { requireAuth } from "../middleware/auth.js";
 import { deliverToFollowers } from "../lib/federation.js";
@@ -53,6 +52,13 @@ import {
   normalizeEventWriteInput,
   sanitizeEventWriteFields,
 } from "../lib/event-write.js";
+import {
+  applySyncBatch,
+  normalizeSyncEvents,
+  reconcileMissingEvents,
+  type ExistingSyncEventRow,
+  type RawSyncEvent,
+} from "../lib/event-sync.js";
 
 // ─── Reusable SQL fragments ─────────────────────────────────────────────────
 
@@ -618,117 +624,17 @@ export function eventRoutes(db: DB): Hono {
       return c.json({ error: t(getLocale(c), "events.events_array_required") }, 400);
     }
 
-    const normalizedSyncTemporalByExternalId = new Map<string, {
-      startDate: string;
-      endDate: string | null;
-      allDay: boolean;
-      eventTimezone: string;
-    }>();
-    const normalizedIncomingEvents: typeof body.events = [];
-
-    for (const ev of body.events) {
-      const normalizedTimezone = typeof ev.eventTimezone === "string"
-        ? ev.eventTimezone.trim()
-        : "";
-      if (typeof ev.externalId !== "string"
-        || !ev.externalId.trim()
-        || typeof ev.title !== "string"
-        || !ev.title.trim()
-        || typeof ev.startDate !== "string"
-        || !ev.startDate.trim()
-        || typeof ev.eventTimezone !== "string"
-        || !normalizedTimezone
-        || !isValidIanaTimezone(normalizedTimezone)) {
-        return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
-      }
-      if ((ev.endDate !== undefined && ev.endDate !== null && typeof ev.endDate !== "string")
-        || (ev.allDay !== undefined && typeof ev.allDay !== "boolean")) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      const normalizedWrite = normalizeEventWriteInput({
-        startDate: ev.startDate,
-        endDate: ev.endDate,
-        eventTimezone: normalizedTimezone,
-        allDay: ev.allDay,
-        allowDateTimeFields: false,
-      });
-      if (!normalizedWrite) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      const { startAtUtc, endAtUtc } = deriveCanonicalTemporalFields(normalizedWrite);
-      if (!startAtUtc
-        || (normalizedWrite.allDay ? !endAtUtc : (normalizedWrite.endValue !== null && !endAtUtc))
-        || (endAtUtc && endAtUtc < startAtUtc)) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      const normalizedExternalId = ev.externalId.trim();
-      normalizedSyncTemporalByExternalId.set(normalizedExternalId, {
-        startDate: normalizedWrite.startValue,
-        endDate: normalizedWrite.endValue,
-        allDay: normalizedWrite.allDay,
-        eventTimezone: normalizedWrite.eventTimezone,
-      });
-      normalizedIncomingEvents.push({
-        ...ev,
-        externalId: normalizedExternalId,
-        eventTimezone: normalizedWrite.eventTimezone,
-      });
+    const normalizationResult = normalizeSyncEvents(body.events as RawSyncEvent[]);
+    if (!normalizationResult.ok) {
+      return c.json({ error: t(getLocale(c), normalizationResult.errorKey) }, 400);
     }
-
-    const deduped = [...new Map(normalizedIncomingEvents.map((ev) => [ev.externalId, ev])).values()];
-
-    for (const ev of deduped) {
-      sanitizeEventWriteFields(ev as Record<string, unknown>);
-      if (typeof ev.title !== "string" || !ev.title.trim()) {
-        return c.json({ error: t(getLocale(c), "events.event_requires_fields") }, 400);
-      }
-    }
-
-    type SyncEventInput = Omit<(typeof body.events)[number], "startDate" | "endDate" | "allDay" | "eventTimezone"> & {
-      startDate: string;
-      endDate: string | null;
-      allDay: boolean;
-      eventTimezone: string;
-    };
-    const syncEvents: SyncEventInput[] = [];
-    for (const ev of deduped) {
-      const normalizedTemporal = normalizedSyncTemporalByExternalId.get(ev.externalId);
-      if (!normalizedTemporal) {
-        return c.json({ error: t(getLocale(c), "events.invalid_datetime") }, 400);
-      }
-      syncEvents.push({
-        ...ev,
-        startDate: normalizedTemporal.startDate,
-        endDate: normalizedTemporal.endDate,
-        allDay: normalizedTemporal.allDay,
-        eventTimezone: normalizedTemporal.eventTimezone,
-      });
-    }
+    const syncEvents = normalizationResult.syncEvents;
 
     const existing = db
       .prepare(
         "SELECT id, slug, external_id, content_hash, title, start_date, end_date, start_at_utc, end_at_utc, event_timezone, all_day, location_name, location_address, url, description, visibility, canceled, missing_since FROM events WHERE account_id = ? AND external_id IS NOT NULL"
       )
-      .all(user.id) as {
-      id: string;
-      slug: string | null;
-      external_id: string;
-      content_hash: string | null;
-      title: string;
-      start_date: string;
-      end_date: string | null;
-      start_at_utc: string;
-      end_at_utc: string | null;
-      all_day: number;
-      location_name: string | null;
-      location_address: string | null;
-      event_timezone: string | null;
-      url: string | null;
-      description: string | null;
-      visibility: string;
-      canceled: number;
-      missing_since: string | null;
-    }[];
+      .all(user.id) as ExistingSyncEventRow[];
 
     const existingByExtId = new Map(existing.map((r) => [r.external_id, r]));
     const incomingExtIds = new Set(syncEvents.map((e) => e.externalId));
@@ -741,238 +647,51 @@ export function eventRoutes(db: DB): Hono {
     const ogEventIdsToGenerate = new Set<string>();
     const ogEventIdsToClear = new Set<string>();
 
-    function eventHash(ev: SyncEventInput): string {
-      const data = JSON.stringify([
-        ev.title, ev.description || "", ev.startDate, ev.endDate || "", ev.eventTimezone,
-        ev.allDay ? 1 : 0, ev.location?.name || "", ev.location?.address || "",
-        ev.location?.latitude ?? "", ev.location?.longitude ?? "",
-        ev.location?.url || "", ev.image?.url || "", ev.image?.mediaType || "",
-        ev.image?.alt || "", ev.url || "", ev.visibility || "public",
-        (ev.tags || []).slice().sort().join(","),
-      ]);
-      return createHash("sha256").update(data).digest("base64url").slice(0, 22);
-    }
-
-    const insertEvent = db.prepare(
-      `INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, description, start_date, end_date, all_day, start_at_utc, end_at_utc, event_timezone, start_on, end_on,
-        location_name, location_address, location_latitude, location_longitude, location_url,
-        image_url, image_media_type, image_alt, url, visibility, content_hash)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-    );
-
-    const updateEvent = db.prepare(
-      `UPDATE events SET title = ?, slug = ?, description = ?, start_date = ?, end_date = ?, all_day = ?, start_at_utc = ?, end_at_utc = ?, event_timezone = ?, start_on = ?, end_on = ?,
-        location_name = ?, location_address = ?, location_latitude = ?, location_longitude = ?, location_url = ?,
-        image_url = ?, image_media_type = ?, image_alt = ?, url = ?, visibility = ?,
-        content_hash = ?, canceled = 0, missing_since = NULL, updated_at = datetime('now')
-       WHERE id = ?`
-    );
-
-    const restoreEventState = db.prepare(
-      "UPDATE events SET canceled = 0, missing_since = NULL, updated_at = datetime('now') WHERE id = ?"
-    );
-
-    const deleteTagsStmt = db.prepare("DELETE FROM event_tags WHERE event_id = ?");
-    const insertTagStmt = db.prepare("INSERT INTO event_tags (event_id, tag) VALUES (?, ?)");
-
     const yieldToEventLoop = () => new Promise<void>((r) => setImmediate(r));
 
-    // Batch 1: Handle events no longer present in the scraped set.
-    // Policy:
-    // - Past events are kept as-is (rotated out of source listing).
-    // - Future events are marked canceled (never deleted), but only after
-    //   they are missing in two consecutive syncs to avoid accidental cancels
-    //   from transient scrape issues.
     const nowIso = new Date().toISOString();
-    const missingRows = existing.filter((r) => !incomingExtIds.has(r.external_id));
-    if (missingRows.length > 0) {
-      const markMissingSeen = db.prepare("UPDATE events SET missing_since = COALESCE(missing_since, datetime('now')) WHERE id = ?");
-      const markCanceled = db.prepare("UPDATE events SET canceled = 1, missing_since = datetime('now'), updated_at = datetime('now') WHERE id = ?");
-      const clearMissingForPast = db.prepare("UPDATE events SET missing_since = NULL WHERE id = ?");
+    const missingReconciliation = reconcileMissingEvents(db, {
+      existing,
+      incomingExtIds,
+      nowIso,
+    });
+    canceled += missingReconciliation.canceled;
+    rotatedOutPast += missingReconciliation.rotatedOutPast;
 
-      const missingBatch = db.transaction((rows: typeof missingRows) => {
-        for (const row of rows) {
-          if (row.start_at_utc < nowIso) {
-            clearMissingForPast.run(row.id);
-            rotatedOutPast++;
-            continue;
-          }
-
-          if (!row.missing_since) {
-            markMissingSeen.run(row.id);
-            continue;
-          }
-
-          if (!row.canceled) {
-            markCanceled.run(row.id);
-            canceled++;
-          } else {
-            markMissingSeen.run(row.id);
-          }
-        }
+    for (const row of missingReconciliation.notifications) {
+      notifyEventCancelled(db, row.id, {
+        id: row.id,
+        title: row.title,
+        slug: row.slug || row.id,
+        account: { username: user.username },
+        startDate: row.start_date,
+        endDate: row.end_date,
+        allDay: !!row.all_day,
+        location: row.location_name ? { name: row.location_name } : null,
+        url: row.url,
       });
-
-      missingBatch(missingRows);
-
-      for (const row of missingRows) {
-        if (row.start_at_utc >= nowIso && row.missing_since && !row.canceled) {
-          notifyEventCancelled(db, row.id, {
-            id: row.id,
-            title: row.title,
-            slug: row.slug || row.id,
-            account: { username: user.username },
-            startDate: row.start_date,
-            endDate: row.end_date,
-            allDay: !!row.all_day,
-            location: row.location_name ? { name: row.location_name } : null,
-            url: row.url,
-          });
-        }
-      }
+    }
+    if (missingReconciliation.missingCount > 0) {
       await yieldToEventLoop();
     }
 
-    // Batch 2+: Upsert incoming events in chunks — skip unchanged events
     const BATCH_SIZE = 20;
     for (let i = 0; i < syncEvents.length; i += BATCH_SIZE) {
       const chunk = syncEvents.slice(i, i + BATCH_SIZE);
-
-      const upsertBatch = db.transaction((events: typeof chunk) => {
-        for (const ev of events) {
-          const visibility = ev.visibility || "public";
-          if (!isValidVisibility(visibility)) continue;
-          const hash = eventHash(ev);
-          const existingRow = existingByExtId.get(ev.externalId);
-
-          if (existingRow) {
-            if (existingRow.content_hash === hash) {
-              if (existingRow.canceled || existingRow.missing_since) {
-                restoreEventState.run(existingRow.id);
-              }
-              unchanged++;
-              continue;
-            }
-
-            // Only material changes (title, time, location) trigger notifications
-            const oldAllDay = !!existingRow.all_day;
-            const newAllDay = !!ev.allDay;
-            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
-              startValue: ev.startDate,
-              endValue: ev.endDate ?? null,
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            });
-            const changes = computeMaterialEventChanges(
-              {
-                title: existingRow.title,
-                startDate: existingRow.start_date,
-                endDate: existingRow.end_date,
-                allDay: oldAllDay,
-                eventTimezone: existingRow.event_timezone,
-                startAtUtc: existingRow.start_at_utc,
-                endAtUtc: existingRow.end_at_utc,
-                locationName: existingRow.location_name,
-                locationAddress: existingRow.location_address,
-              },
-              {
-                title: ev.title,
-                startDate: ev.startDate,
-                endDate: ev.endDate,
-                allDay: newAllDay,
-                eventTimezone: ev.eventTimezone,
-                startAtUtc: nextStartAtUtc,
-                endAtUtc: nextEndAtUtc,
-                locationName: ev.location?.name,
-                locationAddress: ev.location?.address,
-              },
-            );
-
-            const evSlug = uniqueLocalEventSlug(db, user.id, ev.title, existingRow.id);
-            const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            }) || ev.startDate.slice(0, 10);
-            const nextEndOn = deriveStoredDatePart(ev.endDate ?? null, nextEndAtUtc, {
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            });
-            updateEvent.run(
-              ev.title, evSlug, ev.description || null,
-              ev.startDate, ev.endDate || null, ev.allDay ? 1 : 0,
-              nextStartAtUtc, nextEndAtUtc, ev.eventTimezone, nextStartOn, nextEndOn,
-              ev.location?.name || null, ev.location?.address || null,
-              ev.location?.latitude ?? null, ev.location?.longitude ?? null,
-              ev.location?.url || null,
-              ev.image?.url || null, ev.image?.mediaType || null, ev.image?.alt || null,
-              ev.url || null, visibility, hash, existingRow.id,
-            );
-
-            if (isOgEligibleVisibility(visibility)) {
-              ogEventIdsToGenerate.add(existingRow.id);
-            } else {
-              ogEventIdsToClear.add(existingRow.id);
-            }
-
-            deleteTagsStmt.run(existingRow.id);
-            if (ev.tags) {
-              for (const tag of ev.tags) insertTagStmt.run(existingRow.id, tag.trim());
-            }
-            if (changes.length > 0) {
-              notifyEventUpdated(db, existingRow.id, {
-                id: existingRow.id,
-                title: ev.title,
-                slug: evSlug,
-                account: { username: user.username },
-                startDate: ev.startDate,
-                endDate: ev.endDate || null,
-                allDay: ev.allDay ?? false,
-                location: ev.location ? { name: ev.location.name } : null,
-                url: ev.url || null,
-              }, changes);
-            }
-            updated++;
-          } else {
-            const id = nanoid(16);
-            const evSlug = uniqueLocalEventSlug(db, user.id, ev.title);
-            const { startAtUtc: nextStartAtUtc, endAtUtc: nextEndAtUtc } = deriveCanonicalTemporalFields({
-              startValue: ev.startDate,
-              endValue: ev.endDate ?? null,
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            });
-            const nextStartOn = deriveStoredDatePart(ev.startDate, nextStartAtUtc, {
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            }) || ev.startDate.slice(0, 10);
-            const nextEndOn = deriveStoredDatePart(ev.endDate ?? null, nextEndAtUtc, {
-              allDay: !!ev.allDay,
-              eventTimezone: ev.eventTimezone,
-            });
-            insertEvent.run(
-              id, user.id, user.id, ev.externalId, evSlug,
-              ev.title, ev.description || null,
-              ev.startDate, ev.endDate || null, ev.allDay ? 1 : 0,
-              nextStartAtUtc, nextEndAtUtc, ev.eventTimezone, nextStartOn, nextEndOn,
-              ev.location?.name || null, ev.location?.address || null,
-              ev.location?.latitude ?? null, ev.location?.longitude ?? null,
-              ev.location?.url || null,
-              ev.image?.url || null, ev.image?.mediaType || null, ev.image?.alt || null,
-              ev.url || null, visibility, hash,
-            );
-
-            if (isOgEligibleVisibility(visibility)) {
-              ogEventIdsToGenerate.add(id);
-            }
-
-            if (ev.tags) {
-              for (const tag of ev.tags) insertTagStmt.run(id, tag.trim());
-            }
-            created++;
-          }
-        }
+      const result = applySyncBatch(db, {
+        events: chunk,
+        existingByExtId,
+        accountId: user.id,
+        username: user.username,
+        ogEventIdsToGenerate,
+        ogEventIdsToClear,
+        uniqueLocalEventSlug,
+        isOgEligibleVisibility,
+        notifyEventUpdated: (eventId, event, changes) => notifyEventUpdated(db, eventId, event, changes),
       });
-
-      upsertBatch(chunk);
+      created += result.created;
+      updated += result.updated;
+      unchanged += result.unchanged;
 
       if (i + BATCH_SIZE < syncEvents.length) {
         await yieldToEventLoop();

--- a/packages/server/src/routes/events.ts
+++ b/packages/server/src/routes/events.ts
@@ -599,7 +599,7 @@ export function eventRoutes(db: DB): Hono {
         title: string;
         description?: string;
         startDate: string;
-        endDate?: string;
+        endDate?: string | null;
         eventTimezone: string;
         allDay?: boolean;
         location?: { name: string; address?: string; latitude?: number; longitude?: number; url?: string };

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -134,7 +134,7 @@ describe("applySyncBatch", () => {
       endDate: null,
       eventTimezone: "UTC",
       allDay: true,
-      tags: ["music"],
+      tags: ["  music  ", "   "],
       visibility: "public",
     };
 
@@ -153,7 +153,7 @@ describe("applySyncBatch", () => {
 
     const existingByExtId = new Map(readExisting(db).map((row) => [row.external_id, row]));
     const second = applySyncBatch(db, {
-      events: [{ ...seed, title: "Seed updated", tags: ["art"], visibility: "followers_only" }],
+      events: [{ ...seed, title: "Seed updated", tags: [" art ", "   "], visibility: "followers_only" }],
       existingByExtId,
       accountId: "u1",
       username: "alice",
@@ -167,7 +167,7 @@ describe("applySyncBatch", () => {
 
     const existingAfterUpdate = new Map(readExisting(db).map((row) => [row.external_id, row]));
     const third = applySyncBatch(db, {
-      events: [{ ...seed, title: "Seed updated", tags: ["art"], visibility: "followers_only" }],
+      events: [{ ...seed, title: "Seed updated", tags: ["  art  ", "   "], visibility: "followers_only" }],
       existingByExtId: existingAfterUpdate,
       accountId: "u1",
       username: "alice",

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -68,6 +68,25 @@ describe("normalizeSyncEvents", () => {
 
     expect(result).toEqual({ ok: false, errorKey: "events.event_requires_fields" });
   });
+
+  it("accepts null endDate values", () => {
+    const input: RawSyncEvent[] = [
+      {
+        externalId: "ext-null-end",
+        title: "No explicit end",
+        startDate: "2026-01-01",
+        endDate: null,
+        eventTimezone: "UTC",
+        allDay: true,
+      },
+    ];
+
+    const result = normalizeSyncEvents(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.syncEvents[0]?.endDate).toBeNull();
+  });
 });
 
 describe("reconcileMissingEvents", () => {

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it, vi } from "vitest";
+import { initDatabase } from "../src/db.js";
+import {
+  applySyncBatch,
+  normalizeSyncEvents,
+  reconcileMissingEvents,
+  type ExistingSyncEventRow,
+  type RawSyncEvent,
+  type SyncEventInput,
+} from "../src/lib/event-sync.js";
+
+function makeDb() {
+  const db = initDatabase(":memory:");
+  db.prepare("INSERT INTO accounts (id, username, account_type) VALUES (?, ?, 'person')").run("u1", "alice");
+  return db;
+}
+
+function readExisting(db: ReturnType<typeof makeDb>): ExistingSyncEventRow[] {
+  return db.prepare(
+    "SELECT id, slug, external_id, content_hash, title, start_date, end_date, start_at_utc, end_at_utc, event_timezone, all_day, location_name, location_address, url, description, visibility, canceled, missing_since FROM events WHERE account_id = ? AND external_id IS NOT NULL"
+  ).all("u1") as ExistingSyncEventRow[];
+}
+
+describe("normalizeSyncEvents", () => {
+  it("validates, sanitizes, canonicalizes, and dedupes by externalId", () => {
+    const input: RawSyncEvent[] = [
+      {
+        externalId: " ext-1 ",
+        title: "First",
+        startDate: "2026-06-01",
+        eventTimezone: " UTC ",
+        allDay: true,
+        tags: ["<b>a</b>", "   ", "two"],
+      },
+      {
+        externalId: "ext-1",
+        title: "Second wins",
+        startDate: "2026-06-02",
+        eventTimezone: "UTC",
+        allDay: true,
+      },
+    ];
+
+    const result = normalizeSyncEvents(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.syncEvents).toHaveLength(1);
+    expect(result.syncEvents[0]).toMatchObject({
+      externalId: "ext-1",
+      title: "Second wins",
+      startDate: "2026-06-02",
+      endDate: null,
+      allDay: true,
+      eventTimezone: "UTC",
+    });
+  });
+
+  it("returns expected error key for invalid timezone", () => {
+    const result = normalizeSyncEvents([
+      {
+        externalId: "x",
+        title: "Bad",
+        startDate: "2026-01-01",
+        eventTimezone: "Not/AZone",
+      },
+    ]);
+
+    expect(result).toEqual({ ok: false, errorKey: "events.event_requires_fields" });
+  });
+});
+
+describe("reconcileMissingEvents", () => {
+  it("marks first missing as seen, second missing as canceled, and past as rotated out", () => {
+    const db = makeDb();
+    db.prepare(
+      "INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, start_date, all_day, start_at_utc, event_timezone, visibility) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ).run("future-first", "u1", "u1", "future-first", "future-first", "Future First", "2026-12-01", 1, "2026-12-01T00:00:00.000Z", "UTC", "public");
+    db.prepare(
+      "INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, start_date, all_day, start_at_utc, event_timezone, visibility, missing_since) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))"
+    ).run("future-second", "u1", "u1", "future-second", "future-second", "Future Second", "2026-12-02", 1, "2026-12-02T00:00:00.000Z", "UTC", "public");
+    db.prepare(
+      "INSERT INTO events (id, account_id, created_by_account_id, external_id, slug, title, start_date, all_day, start_at_utc, event_timezone, visibility, missing_since) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))"
+    ).run("past", "u1", "u1", "past", "past", "Past", "2025-01-01", 1, "2025-01-01T00:00:00.000Z", "UTC", "public");
+
+    const existing = readExisting(db);
+    const result = reconcileMissingEvents(db, {
+      existing,
+      incomingExtIds: new Set<string>(),
+      nowIso: "2026-06-01T00:00:00.000Z",
+    });
+
+    expect(result.canceled).toBe(1);
+    expect(result.rotatedOutPast).toBe(1);
+    expect(result.missingCount).toBe(3);
+    expect(result.notifications.map((r) => r.id)).toEqual(["future-second"]);
+  });
+});
+
+describe("applySyncBatch", () => {
+  it("creates, updates, and marks unchanged while preserving tag + OG behavior", () => {
+    const db = makeDb();
+    const slugger = vi.fn((_: unknown, __: string, title: string, excludeId?: string) =>
+      `${title.toLowerCase().replace(/\s+/g, "-")}${excludeId ? "-updated" : ""}`,
+    );
+    const notifyUpdated = vi.fn();
+    const ogGenerate = new Set<string>();
+    const ogClear = new Set<string>();
+
+    const seed: SyncEventInput = {
+      externalId: "ext-1",
+      title: "Seed",
+      description: "A",
+      startDate: "2026-06-10",
+      endDate: null,
+      eventTimezone: "UTC",
+      allDay: true,
+      tags: ["music"],
+      visibility: "public",
+    };
+
+    const first = applySyncBatch(db, {
+      events: [seed],
+      existingByExtId: new Map(),
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: ogGenerate,
+      ogEventIdsToClear: ogClear,
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: notifyUpdated,
+    });
+    expect(first).toEqual({ created: 1, updated: 0, unchanged: 0 });
+
+    const existingByExtId = new Map(readExisting(db).map((row) => [row.external_id, row]));
+    const second = applySyncBatch(db, {
+      events: [{ ...seed, title: "Seed updated", tags: ["art"], visibility: "followers_only" }],
+      existingByExtId,
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: ogGenerate,
+      ogEventIdsToClear: ogClear,
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: notifyUpdated,
+    });
+    expect(second).toEqual({ created: 0, updated: 1, unchanged: 0 });
+
+    const existingAfterUpdate = new Map(readExisting(db).map((row) => [row.external_id, row]));
+    const third = applySyncBatch(db, {
+      events: [{ ...seed, title: "Seed updated", tags: ["art"], visibility: "followers_only" }],
+      existingByExtId: existingAfterUpdate,
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: ogGenerate,
+      ogEventIdsToClear: ogClear,
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: notifyUpdated,
+    });
+    expect(third).toEqual({ created: 0, updated: 0, unchanged: 1 });
+
+    expect(notifyUpdated).toHaveBeenCalledTimes(1);
+    expect(ogGenerate.size).toBeGreaterThan(0);
+    expect(ogClear.size).toBe(1);
+
+    const row = db.prepare("SELECT title, visibility FROM events WHERE external_id = ?").get("ext-1") as { title: string; visibility: string };
+    const tags = db.prepare("SELECT tag FROM event_tags WHERE event_id = (SELECT id FROM events WHERE external_id = ?)").all("ext-1") as Array<{ tag: string }>;
+    expect(row).toEqual({ title: "Seed updated", visibility: "followers_only" });
+    expect(tags.map((t) => t.tag)).toEqual(["art"]);
+  });
+});

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -69,6 +69,14 @@ describe("normalizeSyncEvents", () => {
     expect(result).toEqual({ ok: false, errorKey: "events.event_requires_fields" });
   });
 
+  it("returns expected error key when an event is not an object", () => {
+    const nullResult = normalizeSyncEvents([null as unknown as RawSyncEvent]);
+    const primitiveResult = normalizeSyncEvents([123 as unknown as RawSyncEvent]);
+
+    expect(nullResult).toEqual({ ok: false, errorKey: "events.event_requires_fields" });
+    expect(primitiveResult).toEqual({ ok: false, errorKey: "events.event_requires_fields" });
+  });
+
   it("accepts null endDate values", () => {
     const input: RawSyncEvent[] = [
       {

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -188,4 +188,61 @@ describe("applySyncBatch", () => {
     expect(row).toEqual({ title: "Seed updated", visibility: "followers_only" });
     expect(tags.map((t) => t.tag)).toEqual(["art"]);
   });
+
+  it("treats canonical-equivalent tags as unchanged", () => {
+    const db = makeDb();
+    const slugger = vi.fn((_: unknown, __: string, title: string, excludeId?: string) =>
+      `${title.toLowerCase().replace(/\s+/g, "-")}${excludeId ? "-updated" : ""}`,
+    );
+    const notifyUpdated = vi.fn();
+    const ogGenerate = new Set<string>();
+    const ogClear = new Set<string>();
+
+    const first = applySyncBatch(db, {
+      events: [{
+        externalId: "ext-canonical-tags",
+        title: "Canonical tags",
+        startDate: "2026-07-01",
+        endDate: null,
+        eventTimezone: "UTC",
+        allDay: true,
+        visibility: "public",
+        tags: ["two", " one ", "", "   "],
+      }],
+      existingByExtId: new Map(),
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: ogGenerate,
+      ogEventIdsToClear: ogClear,
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: notifyUpdated,
+    });
+    expect(first).toEqual({ created: 1, updated: 0, unchanged: 0 });
+
+    const existingByExtId = new Map(readExisting(db).map((row) => [row.external_id, row]));
+    const second = applySyncBatch(db, {
+      events: [{
+        externalId: "ext-canonical-tags",
+        title: "Canonical tags",
+        startDate: "2026-07-01",
+        endDate: null,
+        eventTimezone: "UTC",
+        allDay: true,
+        visibility: "public",
+        tags: ["one", "two"],
+      }],
+      existingByExtId,
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: ogGenerate,
+      ogEventIdsToClear: ogClear,
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: notifyUpdated,
+    });
+
+    expect(second).toEqual({ created: 0, updated: 0, unchanged: 1 });
+    expect(notifyUpdated).not.toHaveBeenCalled();
+  });
 });

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -245,4 +245,36 @@ describe("applySyncBatch", () => {
     expect(second).toEqual({ created: 0, updated: 0, unchanged: 1 });
     expect(notifyUpdated).not.toHaveBeenCalled();
   });
+
+  it("dedupes duplicate tags before insert", () => {
+    const db = makeDb();
+    const slugger = vi.fn((_: unknown, __: string, title: string) => title.toLowerCase().replace(/\s+/g, "-"));
+
+    const result = applySyncBatch(db, {
+      events: [{
+        externalId: "ext-dup-tags",
+        title: "Duplicate tags",
+        startDate: "2026-07-10",
+        endDate: null,
+        eventTimezone: "UTC",
+        allDay: true,
+        visibility: "public",
+        tags: ["art", " art ", "", "  ", "music", "music"],
+      }],
+      existingByExtId: new Map(),
+      accountId: "u1",
+      username: "alice",
+      ogEventIdsToGenerate: new Set<string>(),
+      ogEventIdsToClear: new Set<string>(),
+      uniqueLocalEventSlug: slugger,
+      isOgEligibleVisibility: (v) => v === "public" || v === "unlisted",
+      notifyEventUpdated: vi.fn(),
+    });
+
+    expect(result).toEqual({ created: 1, updated: 0, unchanged: 0 });
+    const tags = db.prepare(
+      "SELECT tag FROM event_tags WHERE event_id = (SELECT id FROM events WHERE external_id = ?) ORDER BY tag"
+    ).all("ext-dup-tags") as Array<{ tag: string }>;
+    expect(tags.map((t) => t.tag)).toEqual(["art", "music"]);
+  });
 });

--- a/packages/server/tests/event-sync.test.ts
+++ b/packages/server/tests/event-sync.test.ts
@@ -95,6 +95,36 @@ describe("normalizeSyncEvents", () => {
     if (!result.ok) return;
     expect(result.syncEvents[0]?.endDate).toBeNull();
   });
+
+  it("does not mutate nested input objects while sanitizing", () => {
+    const input: RawSyncEvent[] = [
+      {
+        externalId: "ext-nested",
+        title: "Nested",
+        startDate: "2026-08-01",
+        eventTimezone: "UTC",
+        allDay: true,
+        location: {
+          name: "<b>Venue</b>",
+          address: "<i>Main Street</i>",
+        },
+      },
+    ];
+
+    const result = normalizeSyncEvents(input);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.syncEvents[0]?.location).toEqual({
+      name: "Venue",
+      address: "Main Street",
+    });
+    expect(input[0]?.location).toEqual({
+      name: "<b>Venue</b>",
+      address: "<i>Main Street</i>",
+    });
+  });
 });
 
 describe("reconcileMissingEvents", () => {

--- a/packages/server/tests/event-write.test.ts
+++ b/packages/server/tests/event-write.test.ts
@@ -217,9 +217,9 @@ describe("event write sanitization", () => {
     expect(body.tags).toBeUndefined();
   });
 
-  it("keeps only string tags and sanitizes HTML", () => {
+  it("keeps only unique string tags and sanitizes HTML", () => {
     const body: Record<string, unknown> = {
-      tags: ["  <b>music</b>  ", 123, "", null, "<i>art</i>", {}, "   "],
+      tags: ["  <b>music</b>  ", 123, "", null, "music", "<i>art</i>", " art ", {}, "   "],
     };
 
     sanitizeEventWriteFields(body);

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -752,6 +752,20 @@ describe("event slug canonical behavior", () => {
     expect(typeof payload.error).toBe("string");
   });
 
+  it("returns a safe 400 when sync events include non-object values", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const sync = await app.request("http://localhost/api/v1/events/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ events: [null] }),
+    });
+
+    const payload = await sync.json() as { error?: unknown };
+    expect(sync.status).toBe(400);
+    expect(typeof payload.error).toBe("string");
+  });
+
   it("rejects sync events when title sanitizes to empty html", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -97,6 +97,53 @@ describe("event slug canonical behavior", () => {
     expect(updated.slug).toBe(created.slug);
   });
 
+  it("accepts duplicate normalized tags on create without 500", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Duplicate Tag Create",
+        startDate: "2026-01-01T10:00:00Z",
+        eventTimezone: "UTC",
+        tags: ["art", " art ", "music", "music"],
+      }),
+    });
+    const created = await create.json() as { id: string };
+
+    expect(create.status).toBe(201);
+    const tags = db.prepare("SELECT tag FROM event_tags WHERE event_id = ? ORDER BY tag").all(created.id) as Array<{ tag: string }>;
+    expect(tags.map((row) => row.tag)).toEqual(["art", "music"]);
+  });
+
+  it("accepts duplicate normalized tags on update without 500", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Duplicate Tag Update",
+        startDate: "2026-01-01T10:00:00Z",
+        eventTimezone: "UTC",
+        tags: ["first"],
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tags: ["art", " art ", "music", "music"] }),
+    });
+
+    expect(update.status).toBe(200);
+    const tags = db.prepare("SELECT tag FROM event_tags WHERE event_id = ? ORDER BY tag").all(created.id) as Array<{ tag: string }>;
+    expect(tags.map((row) => row.tag)).toEqual(["art", "music"]);
+  });
+
   it("detects time change and regenerates OG when PUT uses datetime fields", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -144,6 +144,53 @@ describe("event slug canonical behavior", () => {
     expect(tags.map((row) => row.tag)).toEqual(["art", "music"]);
   });
 
+  it("skips whitespace-only tags on create", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Whitespace Tag Create",
+        startDate: "2026-01-01T10:00:00Z",
+        eventTimezone: "UTC",
+        tags: ["   ", " art ", "art", "music", "\t\n"],
+      }),
+    });
+    const created = await create.json() as { id: string };
+
+    expect(create.status).toBe(201);
+    const tags = db.prepare("SELECT tag FROM event_tags WHERE event_id = ? ORDER BY tag").all(created.id) as Array<{ tag: string }>;
+    expect(tags.map((row) => row.tag)).toEqual(["art", "music"]);
+  });
+
+  it("skips whitespace-only tags on update", async () => {
+    const app = makeApp(db, { id: "u1", username: "alice" });
+
+    const create = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Whitespace Tag Update",
+        startDate: "2026-01-01T10:00:00Z",
+        eventTimezone: "UTC",
+        tags: ["seed"],
+      }),
+    });
+    const created = await create.json() as { id: string };
+    expect(create.status).toBe(201);
+
+    const update = await app.request(`http://localhost/api/v1/events/${created.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ tags: ["  ", " art ", "art", "music", "\n\t"] }),
+    });
+
+    expect(update.status).toBe(200);
+    const tags = db.prepare("SELECT tag FROM event_tags WHERE event_id = ? ORDER BY tag").all(created.id) as Array<{ tag: string }>;
+    expect(tags.map((row) => row.tag)).toEqual(["art", "music"]);
+  });
+
   it("detects time change and regenerates OG when PUT uses datetime fields", async () => {
     const app = makeApp(db, { id: "u1", username: "alice" });
 


### PR DESCRIPTION
### Motivation
- The `/api/v1/events/sync` handler contained a large, self-contained sync flow (validation, missing-event reconciliation, transactional upsert) that obscured the route and made targeted testing harder.
- Extracting the sync internals into a dedicated module enables focused unit tests and improves separation of concerns.

### Description
- Moved the sync logic from `packages/server/src/routes/events.ts` into a new module `packages/server/src/lib/event-sync.ts` and exported helper APIs: `normalizeSyncEvents`, `reconcileMissingEvents`, `createSyncBatchApplier`, and `applySyncBatch` (convenience wrapper).
- Updated `packages/server/src/routes/events.ts` to delegate to these helpers while keeping the sync route contract, response payload shape, status codes, SQL semantics, notifications, OG queue behavior, and counters (`created`, `updated`, `unchanged`, `canceled`, `rotatedOutPast`, `total`) unchanged.
- The route now uses `createSyncBatchApplier` so prepared statements are created once per request and reused across chunk iterations; `applySyncBatch` remains available as a convenience wrapper.
- Preserved the original sync SQL and side-effect logic as-is where possible (dedupe/temporal normalization, missing/cancel/rotated-out policy, transactional upserts with tag updates, hash comparison, material-change detection and notification calls).
- Added focused unit tests in `packages/server/tests/event-sync.test.ts` that exercise `normalizeSyncEvents`, `reconcileMissingEvents`, and `applySyncBatch` (happy paths and edge cases such as dedupe, validation error keys, missing reconciliation behavior, create/update/unchanged flows, tag handling, OG set/clear behavior, and notification invocation).
- No DB schema changes or unrelated refactors were made; existing translation/error keys were preserved.

### Breaking changes (intentional)
- `eventHash()` now canonicalizes tags before hashing (trim values, drop empty tags, and hash sorted tags), rather than hashing raw tag strings.
- `saveTags()` in `packages/server/src/routes/events.ts` now skips whitespace-only tags after trimming instead of persisting them as an empty-string tag.
- The second change affects local create/update routes (`POST /api/v1/events` and `PUT /api/v1/events/:id`) in addition to sync-related paths.
- This is intentional in this PR to avoid persisting empty tags and to align tag normalization semantics across write paths.
- Behavior impact: what counts as `updated` vs `unchanged` can differ from previous behavior, and write paths no longer store empty-string tags when tag values are whitespace-only.
- Added/updated test coverage in `packages/server/tests/event-sync.test.ts` to codify canonical tag behavior (`treats canonical-equivalent tags as unchanged`).

### Testing
- Added `packages/server/tests/event-sync.test.ts` covering the extracted sync helpers and their key edge cases; these tests exercise the in-memory SQLite DB and notification/OG interactions via injected hooks.
- Ran `pnpm --filter @everycal/server test tests/event-sync.test.ts` successfully.
- Ran full workspace checks successfully: `pnpm lint`, `pnpm test`, and `pnpm build`.

Summary of moved code: core validation/normalization and dedupe logic (now `normalizeSyncEvents`), missing-event marking/cancel/rotated-out policy (now `reconcileMissingEvents`), and the chunked transactional upsert including content-hash computation, tag replacement, OG enqueue decisions, and material-change notification (driven by `createSyncBatchApplier`, with `applySyncBatch` as a convenience wrapper) were relocated from the sync route into `packages/server/src/lib/event-sync.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e48a3d5470832193f212c0b34488ad)