### PR TITLE
Enforce strict DB versioning and runtime schema validation

### DIFF
--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -127,13 +127,13 @@ export function validateMigrationConfiguration(): void {
         `Invalid migration configuration: migration "${migration.name}" has version ${migration.version}, expected a positive integer.`
       );
     }
+    if (seen.has(migration.version)) {
+      throw new Error(`Invalid migration configuration: duplicate migration version ${migration.version}.`);
+    }
     if (migration.version <= previousVersion) {
       throw new Error(
         `Invalid migration configuration: migration versions must be strictly increasing; got ${migration.version} after ${previousVersion}.`
       );
-    }
-    if (seen.has(migration.version)) {
-      throw new Error(`Invalid migration configuration: duplicate migration version ${migration.version}.`);
     }
     seen.add(migration.version);
     previousVersion = migration.version;

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -22,7 +22,7 @@ function hasTable(db: DB, tableName: string): boolean {
 }
 
 function hasColumn(db: DB, tableName: string, columnName: string): boolean {
-  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as Array<{ name: string }>;
   return rows.some((row) => row.name === columnName);
 }
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -26,11 +26,95 @@ function hasColumn(db: DB, tableName: string, columnName: string): boolean {
   return rows.some((row) => row.name === columnName);
 }
 
-function hasIndex(db: DB, indexName: string): boolean {
-  const row = db
-    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'index' AND name = ? LIMIT 1")
-    .get(indexName) as { ok: number } | undefined;
-  return !!row?.ok;
+type RequiredIndex = {
+  table: string;
+  name: string;
+  unique: boolean;
+  columns: string[];
+  where?: string;
+};
+
+function quoteIdentifier(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+function normalizeSqlFragment(fragment: string): string {
+  return fragment.replace(/;\s*$/g, "").trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function extractWhereClause(indexSql: string): string | null {
+  const whereMatch = /\bwhere\b([\s\S]*)$/i.exec(indexSql);
+  if (!whereMatch) return null;
+  const clause = normalizeSqlFragment(whereMatch[1] ?? "");
+  return clause.length > 0 ? clause : null;
+}
+
+function validateIndexDefinition(db: DB, requiredIndex: RequiredIndex): { ok: boolean; reason?: string } {
+  const indexList = db.prepare(`PRAGMA index_list(${quoteIdentifier(requiredIndex.table)})`).all() as Array<{
+    name: string;
+    unique: number;
+    partial: number;
+  }>;
+
+  const indexMeta = indexList.find((row) => row.name === requiredIndex.name);
+  if (!indexMeta) {
+    return { ok: false, reason: "missing" };
+  }
+
+  if (!!indexMeta.unique !== requiredIndex.unique) {
+    return {
+      ok: false,
+      reason: `expected unique=${requiredIndex.unique ? 1 : 0} but found unique=${indexMeta.unique ? 1 : 0}`,
+    };
+  }
+
+  if (!!requiredIndex.where !== !!indexMeta.partial) {
+    return {
+      ok: false,
+      reason: `expected partial=${requiredIndex.where ? 1 : 0} but found partial=${indexMeta.partial ? 1 : 0}`,
+    };
+  }
+
+  const indexColumns = db.prepare(`PRAGMA index_xinfo(${quoteIdentifier(requiredIndex.name)})`).all() as Array<{
+    seqno: number;
+    name: string | null;
+    key: number;
+  }>;
+  const actualColumns = indexColumns
+    .filter((row) => row.key === 1)
+    .sort((a, b) => a.seqno - b.seqno)
+    .map((row) => row.name)
+    .filter((name): name is string => typeof name === "string");
+
+  if (
+    actualColumns.length !== requiredIndex.columns.length ||
+    actualColumns.some((column, idx) => column !== requiredIndex.columns[idx])
+  ) {
+    return {
+      ok: false,
+      reason: `expected columns (${requiredIndex.columns.join(", ")}) but found (${actualColumns.join(", ")})`,
+    };
+  }
+
+  if (requiredIndex.where) {
+    const row = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = ? AND name = ? LIMIT 1")
+      .get(requiredIndex.table, requiredIndex.name) as { sql: string | null } | undefined;
+    const indexSql = row?.sql;
+    if (!indexSql) {
+      return { ok: false, reason: "missing index SQL definition in sqlite_master" };
+    }
+    const actualWhere = extractWhereClause(indexSql);
+    const expectedWhere = normalizeSqlFragment(requiredIndex.where);
+    if (actualWhere !== expectedWhere) {
+      return {
+        ok: false,
+        reason: `expected WHERE ${requiredIndex.where} but found ${actualWhere ? `WHERE ${actualWhere}` : "none"}`,
+      };
+    }
+  }
+
+  return { ok: true };
 }
 
 export function validateMigrationConfiguration(): void {
@@ -82,10 +166,28 @@ export function validateSchema(db: DB): void {
     }
   }
 
-  const requiredIndexes = ["idx_events_slug", "idx_remote_events_actor_slug"];
+  const requiredIndexes: RequiredIndex[] = [
+    {
+      table: "events",
+      name: "idx_events_slug",
+      unique: true,
+      columns: ["account_id", "slug"],
+      where: "slug IS NOT NULL",
+    },
+    {
+      table: "remote_events",
+      name: "idx_remote_events_actor_slug",
+      unique: true,
+      columns: ["actor_uri", "slug"],
+      where: "slug IS NOT NULL",
+    },
+  ];
   for (const index of requiredIndexes) {
-    if (!hasIndex(db, index)) {
-      throw new Error(`Database schema validation failed: missing required index "${index}".`);
+    const result = validateIndexDefinition(db, index);
+    if (!result.ok) {
+      throw new Error(
+        `Database schema validation failed: invalid required index "${index.name}" on table "${index.table}" (${result.reason}).`
+      );
     }
   }
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -110,32 +110,37 @@ function applyPendingMigrations(db: DB, fromVersion: number): void {
 
 export function initDatabase(path: string): DB {
   const db = new Database(path);
-  validateMigrationConfiguration();
+  try {
+    validateMigrationConfiguration();
 
-  db.pragma("journal_mode = WAL");
-  db.pragma("foreign_keys = ON");
+    db.pragma("journal_mode = WAL");
+    db.pragma("foreign_keys = ON");
 
-  const currentVersion = db.pragma("user_version", { simple: true }) as number;
-  if (currentVersion < 0) {
-    throw new Error(`Invalid SQLite user_version: ${currentVersion}`);
-  }
-  if (currentVersion > CURRENT_SCHEMA_VERSION) {
-    throw new Error(
-      `Database schema version ${currentVersion} is newer than this server supports (${CURRENT_SCHEMA_VERSION}).`
-    );
-  }
-
-  if (currentVersion === 0) {
-    if (!hasUserTables(db)) {
-      applyPendingMigrations(db, 0);
-    } else {
+    const currentVersion = db.pragma("user_version", { simple: true }) as number;
+    if (currentVersion < 0) {
+      throw new Error(`Invalid SQLite user_version: ${currentVersion}`);
+    }
+    if (currentVersion > CURRENT_SCHEMA_VERSION) {
       throw new Error(
-        "Unsupported unversioned database detected (user_version=0 with existing tables). Start from an empty database or migrate using a versioned EveryCal database."
+        `Database schema version ${currentVersion} is newer than this server supports (${CURRENT_SCHEMA_VERSION}).`
       );
     }
-  } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
-    applyPendingMigrations(db, currentVersion);
+
+    if (currentVersion === 0) {
+      if (!hasUserTables(db)) {
+        applyPendingMigrations(db, 0);
+      } else {
+        throw new Error(
+          "Unsupported unversioned database detected (user_version=0 with existing tables). Start from an empty database or migrate using a versioned EveryCal database."
+        );
+      }
+    } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
+      applyPendingMigrations(db, currentVersion);
+    }
+    validateSchema(db);
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
   }
-  validateSchema(db);
-  return db;
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -21,11 +21,6 @@ function hasTable(db: DB, tableName: string): boolean {
   return !!row?.ok;
 }
 
-function hasColumn(db: DB, tableName: string, columnName: string): boolean {
-  const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(tableName)})`).all() as Array<{ name: string }>;
-  return rows.some((row) => row.name === columnName);
-}
-
 type RequiredIndex = {
   table: string;
   name: string;
@@ -429,9 +424,19 @@ export function validateSchema(db: DB): void {
     }
   }
 
+  const tableColumns = new Map<string, Set<string>>();
+  for (const table of requiredTables) {
+    const rows = db.prepare(`PRAGMA table_info(${quoteIdentifier(table)})`).all() as Array<{ name: string }>;
+    tableColumns.set(
+      table,
+      new Set(rows.map((row) => row.name))
+    );
+  }
+
   for (const [table, columns] of Object.entries(REQUIRED_TABLE_COLUMNS)) {
+    const columnsForTable = tableColumns.get(table) ?? new Set<string>();
     for (const column of columns) {
-      if (!hasColumn(db, table, column)) {
+      if (!columnsForTable.has(column)) {
         throw new Error(`Database schema validation failed: missing required column "${table}.${column}".`);
       }
     }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -158,9 +158,22 @@ export function validateSchema(db: DB): void {
   }
 
   const requiredColumns: Array<{ table: string; column: string }> = [
+    { table: "accounts", column: "id" },
     { table: "accounts", column: "theme_preference" },
+    { table: "events", column: "id" },
+    { table: "events", column: "account_id" },
+    { table: "events", column: "slug" },
     { table: "events", column: "og_image_url" },
+    { table: "remote_events", column: "uri" },
+    { table: "remote_events", column: "actor_uri" },
+    { table: "remote_events", column: "slug" },
     { table: "remote_events", column: "og_image_url" },
+    { table: "sessions", column: "token" },
+    { table: "sessions", column: "account_id" },
+    { table: "sessions", column: "expires_at" },
+    { table: "api_keys", column: "id" },
+    { table: "api_keys", column: "account_id" },
+    { table: "api_keys", column: "key_hash" },
   ];
   for (const { table, column } of requiredColumns) {
     if (!hasColumn(db, table, column)) {

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -14,6 +14,82 @@ function hasUserTables(db: DB): boolean {
   return !!row?.ok;
 }
 
+function hasTable(db: DB, tableName: string): boolean {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'table' AND name = ? LIMIT 1")
+    .get(tableName) as { ok: number } | undefined;
+  return !!row?.ok;
+}
+
+function hasColumn(db: DB, tableName: string, columnName: string): boolean {
+  const rows = db.prepare(`PRAGMA table_info(${tableName})`).all() as Array<{ name: string }>;
+  return rows.some((row) => row.name === columnName);
+}
+
+function hasIndex(db: DB, indexName: string): boolean {
+  const row = db
+    .prepare("SELECT 1 AS ok FROM sqlite_master WHERE type = 'index' AND name = ? LIMIT 1")
+    .get(indexName) as { ok: number } | undefined;
+  return !!row?.ok;
+}
+
+export function validateMigrationConfiguration(): void {
+  const seen = new Set<number>();
+  let previousVersion = 0;
+
+  for (const migration of MIGRATIONS) {
+    if (!Number.isInteger(migration.version) || migration.version <= 0) {
+      throw new Error(
+        `Invalid migration configuration: migration "${migration.name}" has version ${migration.version}, expected a positive integer.`
+      );
+    }
+    if (migration.version <= previousVersion) {
+      throw new Error(
+        `Invalid migration configuration: migration versions must be strictly increasing; got ${migration.version} after ${previousVersion}.`
+      );
+    }
+    if (seen.has(migration.version)) {
+      throw new Error(`Invalid migration configuration: duplicate migration version ${migration.version}.`);
+    }
+    seen.add(migration.version);
+    previousVersion = migration.version;
+  }
+
+  const expectedCurrentVersion = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;
+  if (CURRENT_SCHEMA_VERSION !== expectedCurrentVersion) {
+    throw new Error(
+      `Invalid migration configuration: CURRENT_SCHEMA_VERSION (${CURRENT_SCHEMA_VERSION}) must equal latest migration version (${expectedCurrentVersion}).`
+    );
+  }
+}
+
+export function validateSchema(db: DB): void {
+  const requiredTables = ["accounts", "events", "remote_events", "sessions", "api_keys"];
+  for (const table of requiredTables) {
+    if (!hasTable(db, table)) {
+      throw new Error(`Database schema validation failed: missing required table "${table}".`);
+    }
+  }
+
+  const requiredColumns: Array<{ table: string; column: string }> = [
+    { table: "accounts", column: "theme_preference" },
+    { table: "events", column: "og_image_url" },
+    { table: "remote_events", column: "og_image_url" },
+  ];
+  for (const { table, column } of requiredColumns) {
+    if (!hasColumn(db, table, column)) {
+      throw new Error(`Database schema validation failed: missing required column "${table}.${column}".`);
+    }
+  }
+
+  const requiredIndexes = ["idx_events_slug", "idx_remote_events_actor_slug"];
+  for (const index of requiredIndexes) {
+    if (!hasIndex(db, index)) {
+      throw new Error(`Database schema validation failed: missing required index "${index}".`);
+    }
+  }
+}
+
 function applyPendingMigrations(db: DB, fromVersion: number): void {
   for (const migration of MIGRATIONS) {
     if (migration.version <= fromVersion) continue;
@@ -34,6 +110,7 @@ function applyPendingMigrations(db: DB, fromVersion: number): void {
 
 export function initDatabase(path: string): DB {
   const db = new Database(path);
+  validateMigrationConfiguration();
 
   db.pragma("journal_mode = WAL");
   db.pragma("foreign_keys = ON");
@@ -52,10 +129,13 @@ export function initDatabase(path: string): DB {
     if (!hasUserTables(db)) {
       applyPendingMigrations(db, 0);
     } else {
-      db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
+      throw new Error(
+        "Unsupported unversioned database detected (user_version=0 with existing tables). Start from an empty database or migrate using a versioned EveryCal database."
+      );
     }
   } else if (currentVersion < CURRENT_SCHEMA_VERSION) {
     applyPendingMigrations(db, currentVersion);
   }
+  validateSchema(db);
   return db;
 }

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -147,6 +147,8 @@ export function validateMigrationConfiguration(): void {
   }
 }
 
+validateMigrationConfiguration();
+
 export function validateSchema(db: DB): void {
   const requiredTables = ["accounts", "events", "remote_events", "sessions", "api_keys"];
   for (const table of requiredTables) {
@@ -213,8 +215,6 @@ function applyPendingMigrations(db: DB, fromVersion: number): void {
 export function initDatabase(path: string): DB {
   const db = new Database(path);
   try {
-    validateMigrationConfiguration();
-
     db.pragma("journal_mode = WAL");
     db.pragma("foreign_keys = ON");
 

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -30,9 +30,273 @@ type RequiredIndex = {
   table: string;
   name: string;
   unique: boolean;
-  columns: string[];
+  columns: Array<{ name: string; desc?: boolean }>;
   where?: string;
 };
+
+const REQUIRED_TABLE_COLUMNS: Record<string, string[]> = {
+  accounts: [
+    "id",
+    "username",
+    "account_type",
+    "display_name",
+    "bio",
+    "avatar_url",
+    "password_hash",
+    "private_key",
+    "public_key",
+    "is_bot",
+    "discoverable",
+    "timezone",
+    "date_time_locale",
+    "theme_preference",
+    "default_event_visibility",
+    "created_at",
+    "updated_at",
+    "website",
+    "city",
+    "city_lat",
+    "city_lng",
+    "email",
+    "email_verified",
+    "email_verified_at",
+    "preferred_language",
+  ],
+  sessions: ["token", "account_id", "created_at", "expires_at"],
+  api_keys: ["id", "account_id", "key_hash", "label", "last_used_at", "created_at", "key_prefix"],
+  events: [
+    "id",
+    "account_id",
+    "created_by_account_id",
+    "external_id",
+    "slug",
+    "title",
+    "description",
+    "start_date",
+    "end_date",
+    "start_at_utc",
+    "end_at_utc",
+    "event_timezone",
+    "start_on",
+    "end_on",
+    "all_day",
+    "location_name",
+    "location_address",
+    "location_latitude",
+    "location_longitude",
+    "location_url",
+    "image_url",
+    "image_media_type",
+    "image_alt",
+    "image_attribution",
+    "og_image_url",
+    "url",
+    "visibility",
+    "content_hash",
+    "canceled",
+    "missing_since",
+    "created_at",
+    "updated_at",
+  ],
+  event_tags: ["event_id", "tag"],
+  follows: ["follower_id", "following_id", "created_at"],
+  identity_memberships: ["identity_account_id", "member_account_id", "role", "created_at"],
+  remote_follows: ["account_id", "follower_actor_uri", "follower_inbox", "follower_shared_inbox", "created_at"],
+  remote_actors: [
+    "uri",
+    "type",
+    "preferred_username",
+    "display_name",
+    "summary",
+    "inbox",
+    "outbox",
+    "shared_inbox",
+    "followers_url",
+    "following_url",
+    "icon_url",
+    "image_url",
+    "public_key_id",
+    "public_key_pem",
+    "domain",
+    "followers_count",
+    "following_count",
+    "last_fetched_at",
+    "fetch_status",
+    "last_error",
+    "next_retry_at",
+    "gone_at",
+    "created_at",
+  ],
+  remote_events: [
+    "uri",
+    "actor_uri",
+    "slug",
+    "title",
+    "description",
+    "start_date",
+    "end_date",
+    "all_day",
+    "start_at_utc",
+    "end_at_utc",
+    "start_on",
+    "end_on",
+    "event_timezone",
+    "timezone_quality",
+    "location_name",
+    "location_address",
+    "location_latitude",
+    "location_longitude",
+    "image_url",
+    "image_media_type",
+    "image_alt",
+    "image_attribution",
+    "url",
+    "tags",
+    "raw_json",
+    "published",
+    "updated",
+    "fetched_at",
+    "canceled",
+    "og_image_url",
+  ],
+  remote_following: ["account_id", "actor_uri", "actor_inbox", "follow_activity_id", "follow_object_uri", "created_at"],
+  domain_discovery: ["domain", "last_discovered_at", "software_type"],
+  event_rsvps: ["account_id", "event_uri", "status", "created_at"],
+  reposts: ["account_id", "event_id", "created_at"],
+  auto_reposts: ["account_id", "source_account_id", "created_at"],
+  actor_selection_operations: [
+    "id",
+    "action_kind",
+    "target_type",
+    "target_id",
+    "initiated_by_account_id",
+    "status",
+    "created_at",
+    "completed_at",
+  ],
+  actor_selection_operation_items: [
+    "operation_id",
+    "account_id",
+    "before_state",
+    "after_state",
+    "status",
+    "remote_status",
+    "message",
+    "created_at",
+  ],
+  login_attempts: ["username", "attempts", "locked_until", "last_attempt"],
+  calendar_feed_tokens: ["account_id", "token", "created_at"],
+  saved_locations: ["id", "account_id", "name", "address", "latitude", "longitude", "used_at"],
+  email_verification_tokens: ["account_id", "token", "expires_at"],
+  password_reset_tokens: ["account_id", "token", "expires_at"],
+  account_notification_prefs: [
+    "account_id",
+    "reminder_enabled",
+    "reminder_hours_before",
+    "event_updated_enabled",
+    "event_cancelled_enabled",
+    "onboarding_completed",
+  ],
+  email_change_requests: ["account_id", "new_email", "token", "expires_at"],
+  event_reminder_sent: ["account_id", "event_uri", "reminder_type", "sent_at"],
+};
+
+const REQUIRED_INDEXES: RequiredIndex[] = [
+  { table: "sessions", name: "idx_sessions_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "sessions", name: "idx_sessions_expires", unique: false, columns: [{ name: "expires_at" }] },
+  { table: "api_keys", name: "idx_api_keys_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "api_keys", name: "idx_api_keys_prefix", unique: false, columns: [{ name: "key_prefix" }] },
+  { table: "events", name: "idx_events_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "events", name: "idx_events_visibility", unique: false, columns: [{ name: "visibility" }] },
+  {
+    table: "events",
+    name: "idx_events_external",
+    unique: true,
+    columns: [{ name: "account_id" }, { name: "external_id" }],
+    where: "external_id IS NOT NULL",
+  },
+  {
+    table: "events",
+    name: "idx_events_slug",
+    unique: true,
+    columns: [{ name: "account_id" }, { name: "slug" }],
+    where: "slug IS NOT NULL",
+  },
+  { table: "events", name: "idx_events_start_at_utc", unique: false, columns: [{ name: "start_at_utc" }] },
+  { table: "events", name: "idx_events_start_on", unique: false, columns: [{ name: "start_on" }] },
+  { table: "follows", name: "idx_follows_follower", unique: false, columns: [{ name: "follower_id" }] },
+  { table: "follows", name: "idx_follows_following", unique: false, columns: [{ name: "following_id" }] },
+  {
+    table: "identity_memberships",
+    name: "idx_identity_memberships_member",
+    unique: false,
+    columns: [{ name: "member_account_id" }],
+  },
+  {
+    table: "identity_memberships",
+    name: "idx_identity_memberships_identity_role",
+    unique: false,
+    columns: [{ name: "identity_account_id" }, { name: "role" }],
+  },
+  { table: "remote_actors", name: "idx_remote_actors_domain", unique: false, columns: [{ name: "domain" }] },
+  {
+    table: "remote_actors",
+    name: "idx_remote_actors_username",
+    unique: false,
+    columns: [{ name: "preferred_username" }, { name: "domain" }],
+  },
+  { table: "remote_events", name: "idx_remote_events_actor", unique: false, columns: [{ name: "actor_uri" }] },
+  {
+    table: "remote_events",
+    name: "idx_remote_events_actor_slug",
+    unique: true,
+    columns: [{ name: "actor_uri" }, { name: "slug" }],
+    where: "slug IS NOT NULL",
+  },
+  {
+    table: "remote_events",
+    name: "idx_remote_events_start_at_utc",
+    unique: false,
+    columns: [{ name: "start_at_utc" }],
+  },
+  { table: "remote_events", name: "idx_remote_events_start_on", unique: false, columns: [{ name: "start_on" }] },
+  {
+    table: "remote_following",
+    name: "idx_remote_following_account",
+    unique: false,
+    columns: [{ name: "account_id" }],
+  },
+  { table: "event_rsvps", name: "idx_event_rsvps_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "event_rsvps", name: "idx_event_rsvps_event", unique: false, columns: [{ name: "event_uri" }] },
+  { table: "reposts", name: "idx_reposts_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "reposts", name: "idx_reposts_event", unique: false, columns: [{ name: "event_id" }] },
+  { table: "auto_reposts", name: "idx_auto_reposts_account", unique: false, columns: [{ name: "account_id" }] },
+  { table: "auto_reposts", name: "idx_auto_reposts_source", unique: false, columns: [{ name: "source_account_id" }] },
+  {
+    table: "actor_selection_operations",
+    name: "idx_actor_selection_ops_initiated_by",
+    unique: false,
+    columns: [{ name: "initiated_by_account_id" }, { name: "created_at" }],
+  },
+  {
+    table: "actor_selection_operation_items",
+    name: "idx_actor_selection_items_operation",
+    unique: false,
+    columns: [{ name: "operation_id" }],
+  },
+  {
+    table: "saved_locations",
+    name: "idx_saved_locations_account",
+    unique: false,
+    columns: [{ name: "account_id" }, { name: "used_at", desc: true }],
+  },
+  {
+    table: "event_reminder_sent",
+    name: "idx_event_reminder_sent_account",
+    unique: false,
+    columns: [{ name: "account_id" }],
+  },
+];
 
 function quoteIdentifier(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
@@ -79,20 +343,28 @@ function validateIndexDefinition(db: DB, requiredIndex: RequiredIndex): { ok: bo
     seqno: number;
     name: string | null;
     key: number;
+    desc: number;
   }>;
   const actualColumns = indexColumns
     .filter((row) => row.key === 1)
     .sort((a, b) => a.seqno - b.seqno)
-    .map((row) => row.name)
-    .filter((name): name is string => typeof name === "string");
+    .map((row) => ({ name: row.name, desc: !!row.desc }))
+    .filter((column): column is { name: string; desc: boolean } => typeof column.name === "string");
+
+  const expectedColumns = requiredIndex.columns.map((column) => ({ name: column.name, desc: !!column.desc }));
 
   if (
-    actualColumns.length !== requiredIndex.columns.length ||
-    actualColumns.some((column, idx) => column !== requiredIndex.columns[idx])
+    actualColumns.length !== expectedColumns.length ||
+    actualColumns.some((column, idx) => {
+      const expected = expectedColumns[idx];
+      return !expected || column.name !== expected.name || column.desc !== expected.desc;
+    })
   ) {
+    const formatColumnList = (columns: Array<{ name: string; desc: boolean }>) =>
+      columns.map((column) => `${column.name}${column.desc ? " DESC" : ""}`).join(", ");
     return {
       ok: false,
-      reason: `expected columns (${requiredIndex.columns.join(", ")}) but found (${actualColumns.join(", ")})`,
+      reason: `expected columns (${formatColumnList(expectedColumns)}) but found (${formatColumnList(actualColumns)})`,
     };
   }
 
@@ -150,54 +422,22 @@ export function validateMigrationConfiguration(): void {
 validateMigrationConfiguration();
 
 export function validateSchema(db: DB): void {
-  const requiredTables = ["accounts", "events", "remote_events", "sessions", "api_keys"];
+  const requiredTables = Object.keys(REQUIRED_TABLE_COLUMNS);
   for (const table of requiredTables) {
     if (!hasTable(db, table)) {
       throw new Error(`Database schema validation failed: missing required table "${table}".`);
     }
   }
 
-  const requiredColumns: Array<{ table: string; column: string }> = [
-    { table: "accounts", column: "id" },
-    { table: "accounts", column: "theme_preference" },
-    { table: "events", column: "id" },
-    { table: "events", column: "account_id" },
-    { table: "events", column: "slug" },
-    { table: "events", column: "og_image_url" },
-    { table: "remote_events", column: "uri" },
-    { table: "remote_events", column: "actor_uri" },
-    { table: "remote_events", column: "slug" },
-    { table: "remote_events", column: "og_image_url" },
-    { table: "sessions", column: "token" },
-    { table: "sessions", column: "account_id" },
-    { table: "sessions", column: "expires_at" },
-    { table: "api_keys", column: "id" },
-    { table: "api_keys", column: "account_id" },
-    { table: "api_keys", column: "key_hash" },
-  ];
-  for (const { table, column } of requiredColumns) {
-    if (!hasColumn(db, table, column)) {
-      throw new Error(`Database schema validation failed: missing required column "${table}.${column}".`);
+  for (const [table, columns] of Object.entries(REQUIRED_TABLE_COLUMNS)) {
+    for (const column of columns) {
+      if (!hasColumn(db, table, column)) {
+        throw new Error(`Database schema validation failed: missing required column "${table}.${column}".`);
+      }
     }
   }
 
-  const requiredIndexes: RequiredIndex[] = [
-    {
-      table: "events",
-      name: "idx_events_slug",
-      unique: true,
-      columns: ["account_id", "slug"],
-      where: "slug IS NOT NULL",
-    },
-    {
-      table: "remote_events",
-      name: "idx_remote_events_actor_slug",
-      unique: true,
-      columns: ["actor_uri", "slug"],
-      where: "slug IS NOT NULL",
-    },
-  ];
-  for (const index of requiredIndexes) {
+  for (const index of REQUIRED_INDEXES) {
     const result = validateIndexDefinition(db, index);
     if (!result.ok) {
       throw new Error(

--- a/packages/server/src/db.ts
+++ b/packages/server/src/db.ts
@@ -233,7 +233,7 @@ export function initDatabase(path: string): DB {
         applyPendingMigrations(db, 0);
       } else {
         throw new Error(
-          "Unsupported unversioned database detected (user_version=0 with existing tables). Start from an empty database or migrate using a versioned EveryCal database."
+          `Unsupported unversioned database detected at path "${path}" (user_version=0 with existing tables). Start from an empty database or migrate using a versioned EveryCal database.`
         );
       }
     } else if (currentVersion < CURRENT_SCHEMA_VERSION) {

--- a/packages/server/src/db/migrations.ts
+++ b/packages/server/src/db/migrations.ts
@@ -355,4 +355,4 @@ export const MIGRATIONS: Migration[] = [
   },
 ];
 
-export const CURRENT_SCHEMA_VERSION = MIGRATIONS[MIGRATIONS.length - 1]?.version ?? 0;
+export const CURRENT_SCHEMA_VERSION = 2;

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -13,10 +13,6 @@ import { validateFederationUrl } from "../lib/federation.js";
 const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
 const REMOTE_OG_FILENAME_RE = /^remote-[a-f0-9]{64}\.png$/;
 
-function isNoSuchColumnError(err: unknown): boolean {
-  return err instanceof Error && err.message.toLowerCase().includes("no such column");
-}
-
 function normalizeRecipients(input: unknown): string[] {
   if (typeof input === "string") return [input];
   if (!Array.isArray(input)) return [];
@@ -53,14 +49,7 @@ export function isRemoteActivityOgEligible(
 }
 
 function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | null): void {
-  try {
-    db.prepare("UPDATE events SET og_image_url = ? WHERE id = ?").run(ogImageUrl, eventId);
-  } catch (err) {
-    if (isNoSuchColumnError(err)) {
-      return;
-    }
-    throw err;
-  }
+  db.prepare("UPDATE events SET og_image_url = ? WHERE id = ?").run(ogImageUrl, eventId);
 }
 
 function updateRemoteOgImageUrl(db: DB, eventUri: string, ogImageUrl: string | null): void {
@@ -88,17 +77,9 @@ function localOgFilenameFromUrl(ogImageUrl: string, eventId: string): string | n
 }
 
 export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> {
-  let row: { og_image_url: string | null } | undefined;
-  try {
-    row = db.prepare("SELECT og_image_url FROM events WHERE id = ?").get(eventId) as {
-      og_image_url: string | null;
-    } | undefined;
-  } catch (err) {
-    if (isNoSuchColumnError(err)) {
-      return;
-    }
-    throw err;
-  }
+  const row = db.prepare("SELECT og_image_url FROM events WHERE id = ?").get(eventId) as
+    | { og_image_url: string | null }
+    | undefined;
 
   updateLocalOgImageUrl(db, eventId, null);
 

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -12,30 +12,9 @@ import { validateFederationUrl } from "../lib/federation.js";
 
 const PUBLIC_ADDRESS = "https://www.w3.org/ns/activitystreams#Public";
 const REMOTE_OG_FILENAME_RE = /^remote-[a-f0-9]{64}\.png$/;
-const remoteEventsOgImageColumnCache = new WeakMap<DB, boolean>();
-const warnedMissingRemoteEventsOgImageColumn = new WeakSet<DB>();
 
 function isNoSuchColumnError(err: unknown): boolean {
   return err instanceof Error && err.message.toLowerCase().includes("no such column");
-}
-
-function warnMissingRemoteEventsOgImageColumnOnce(db: DB): void {
-  if (warnedMissingRemoteEventsOgImageColumn.has(db)) return;
-  warnedMissingRemoteEventsOgImageColumn.add(db);
-  console.warn("[OG] Skipping remote OG image persistence: remote_events.og_image_url column is missing");
-}
-
-function hasRemoteEventsOgImageColumn(db: DB): boolean {
-  const cached = remoteEventsOgImageColumnCache.get(db);
-  if (cached !== undefined) return cached;
-
-  const columns = db.prepare("PRAGMA table_info(remote_events)").all() as Array<{ name: string }>;
-  const hasColumn = columns.some((column) => column.name === "og_image_url");
-  remoteEventsOgImageColumnCache.set(db, hasColumn);
-  if (!hasColumn) {
-    warnMissingRemoteEventsOgImageColumnOnce(db);
-  }
-  return hasColumn;
 }
 
 function normalizeRecipients(input: unknown): string[] {
@@ -85,20 +64,7 @@ function updateLocalOgImageUrl(db: DB, eventId: string, ogImageUrl: string | nul
 }
 
 function updateRemoteOgImageUrl(db: DB, eventUri: string, ogImageUrl: string | null): void {
-  if (!hasRemoteEventsOgImageColumn(db)) {
-    return;
-  }
-
-  try {
-    db.prepare("UPDATE remote_events SET og_image_url = ? WHERE uri = ?").run(ogImageUrl, eventUri);
-  } catch (err) {
-    if (isNoSuchColumnError(err)) {
-      remoteEventsOgImageColumnCache.set(db, false);
-      warnMissingRemoteEventsOgImageColumnOnce(db);
-      return;
-    }
-    throw err;
-  }
+  db.prepare("UPDATE remote_events SET og_image_url = ? WHERE uri = ?").run(ogImageUrl, eventUri);
 }
 
 function remoteOgFilenameFromUrl(ogImageUrl: string): string | null {
@@ -153,23 +119,10 @@ export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> 
 }
 
 export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void> {
-  if (!hasRemoteEventsOgImageColumn(db)) {
-    return;
-  }
-
   let row: { og_image_url: string | null } | undefined;
-  try {
-    row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
-      og_image_url: string | null;
-    } | undefined;
-  } catch (err) {
-    if (isNoSuchColumnError(err)) {
-      remoteEventsOgImageColumnCache.set(db, false);
-      warnMissingRemoteEventsOgImageColumnOnce(db);
-      return;
-    }
-    throw err;
-  }
+  row = db.prepare("SELECT og_image_url FROM remote_events WHERE uri = ?").get(eventUri) as {
+    og_image_url: string | null;
+  } | undefined;
 
   updateRemoteOgImageUrl(db, eventUri, null);
 
@@ -306,8 +259,6 @@ function getRemoteOgFilename(eventUri: string): string {
 }
 
 export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Promise<string | null> {
-  if (!hasRemoteEventsOgImageColumn(db)) return null;
-
   const { writeFile } = await import("node:fs/promises");
   const { existsSync, mkdirSync } = await import("node:fs");
 

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { initDatabase } from "../src/db.js";
-import { CURRENT_SCHEMA_VERSION } from "../src/db/migrations.js";
+import { CURRENT_SCHEMA_VERSION, MIGRATIONS } from "../src/db/migrations.js";
 
 describe("account timezone/locale defaults", () => {
   it("defaults new accounts to system timezone, locale, and theme", () => {
@@ -55,52 +55,11 @@ describe("account timezone/locale defaults", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "versioned-old.sqlite");
     const versioned = new Database(dbPath);
-    versioned.exec(`
-      CREATE TABLE accounts (
-        id TEXT PRIMARY KEY,
-        username TEXT NOT NULL UNIQUE,
-        timezone TEXT NOT NULL DEFAULT 'system',
-        date_time_locale TEXT NOT NULL DEFAULT 'system',
-        theme_preference TEXT NOT NULL DEFAULT 'system'
-      );
-      CREATE TABLE sessions (
-        token TEXT PRIMARY KEY,
-        account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        expires_at TEXT NOT NULL
-      );
-      CREATE TABLE api_keys (
-        id TEXT PRIMARY KEY,
-        account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-        key_hash TEXT NOT NULL,
-        label TEXT NOT NULL DEFAULT '',
-        last_used_at TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        key_prefix TEXT
-      );
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT NOT NULL REFERENCES accounts(id),
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        event_timezone TEXT NOT NULL,
-        visibility TEXT NOT NULL DEFAULT 'public',
-        og_image_url TEXT
-      );
-      CREATE TABLE remote_events (
-        uri TEXT PRIMARY KEY,
-        actor_uri TEXT NOT NULL,
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        timezone_quality TEXT NOT NULL
-      );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
-      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
-    `);
+    const baselineMigration = MIGRATIONS.find((migration) => migration.version === 1);
+    if (!baselineMigration) {
+      throw new Error("Missing baseline migration");
+    }
+    baselineMigration.up(versioned);
     versioned.pragma("user_version = 1");
     versioned.close();
 
@@ -117,34 +76,10 @@ describe("account timezone/locale defaults", () => {
   it("fails startup when a required schema column is missing", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "missing-column.sqlite");
+    const initialized = initDatabase(dbPath);
+    initialized.close();
     const db = new Database(dbPath);
-    db.exec(`
-      CREATE TABLE accounts (id TEXT PRIMARY KEY, username TEXT NOT NULL UNIQUE, theme_preference TEXT NOT NULL);
-      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL);
-      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, key_hash TEXT NOT NULL);
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT NOT NULL,
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        event_timezone TEXT NOT NULL
-      );
-      CREATE TABLE remote_events (
-        uri TEXT PRIMARY KEY,
-        actor_uri TEXT NOT NULL,
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        timezone_quality TEXT NOT NULL,
-        og_image_url TEXT
-      );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
-      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
-    `);
-    db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
+    db.exec("ALTER TABLE events DROP COLUMN og_image_url");
     db.close();
 
     expect(() => initDatabase(dbPath)).toThrow(/missing required column "events.og_image_url"/);
@@ -154,34 +89,10 @@ describe("account timezone/locale defaults", () => {
   it("fails startup when a required schema index is missing", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "missing-index.sqlite");
+    const initialized = initDatabase(dbPath);
+    initialized.close();
     const db = new Database(dbPath);
-    db.exec(`
-      CREATE TABLE accounts (id TEXT PRIMARY KEY, username TEXT NOT NULL UNIQUE, theme_preference TEXT NOT NULL);
-      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL);
-      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, key_hash TEXT NOT NULL);
-      CREATE TABLE events (
-        id TEXT PRIMARY KEY,
-        account_id TEXT NOT NULL,
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        event_timezone TEXT NOT NULL,
-        og_image_url TEXT
-      );
-      CREATE TABLE remote_events (
-        uri TEXT PRIMARY KEY,
-        actor_uri TEXT NOT NULL,
-        slug TEXT,
-        title TEXT NOT NULL,
-        start_date TEXT NOT NULL,
-        start_at_utc TEXT NOT NULL,
-        timezone_quality TEXT NOT NULL,
-        og_image_url TEXT
-      );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
-    `);
-    db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
+    db.exec("DROP INDEX idx_remote_events_actor_slug");
     db.close();
 
     expect(() => initDatabase(dbPath)).toThrow(/invalid required index "idx_remote_events_actor_slug".*\(missing\)/);

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -81,6 +81,7 @@ describe("account timezone/locale defaults", () => {
       CREATE TABLE events (
         id TEXT PRIMARY KEY,
         account_id TEXT NOT NULL REFERENCES accounts(id),
+        slug TEXT,
         title TEXT NOT NULL,
         start_date TEXT NOT NULL,
         start_at_utc TEXT NOT NULL,
@@ -97,7 +98,7 @@ describe("account timezone/locale defaults", () => {
         start_at_utc TEXT NOT NULL,
         timezone_quality TEXT NOT NULL
       );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
       CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
     versioned.pragma("user_version = 1");
@@ -124,6 +125,7 @@ describe("account timezone/locale defaults", () => {
       CREATE TABLE events (
         id TEXT PRIMARY KEY,
         account_id TEXT NOT NULL,
+        slug TEXT,
         title TEXT NOT NULL,
         start_date TEXT NOT NULL,
         start_at_utc TEXT NOT NULL,
@@ -139,7 +141,7 @@ describe("account timezone/locale defaults", () => {
         timezone_quality TEXT NOT NULL,
         og_image_url TEXT
       );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
       CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
     db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
@@ -160,6 +162,7 @@ describe("account timezone/locale defaults", () => {
       CREATE TABLE events (
         id TEXT PRIMARY KEY,
         account_id TEXT NOT NULL,
+        slug TEXT,
         title TEXT NOT NULL,
         start_date TEXT NOT NULL,
         start_at_utc TEXT NOT NULL,
@@ -176,12 +179,12 @@ describe("account timezone/locale defaults", () => {
         timezone_quality TEXT NOT NULL,
         og_image_url TEXT
       );
-      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
     `);
     db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
     db.close();
 
-    expect(() => initDatabase(dbPath)).toThrow(/missing required index "idx_remote_events_actor_slug"/);
+    expect(() => initDatabase(dbPath)).toThrow(/invalid required index "idx_remote_events_actor_slug".*\(missing\)/);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/server/tests/account-timezone-locale-defaults.test.ts
+++ b/packages/server/tests/account-timezone-locale-defaults.test.ts
@@ -21,22 +21,18 @@ describe("account timezone/locale defaults", () => {
     expect(row.theme_preference).toBe("system");
   });
 
-  it("adopts the schema version marker for already-current schema", () => {
+  it("initializes a fresh empty database to the current schema version", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "current.sqlite");
-    const initial = initDatabase(dbPath);
-    initial.pragma("user_version = 0");
-    initial.close();
-
-    const reopened = initDatabase(dbPath);
-    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    const dbPath = join(dir, "fresh.sqlite");
+    const db = initDatabase(dbPath);
+    const userVersion = db.pragma("user_version", { simple: true }) as number;
     expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
 
-    reopened.close();
+    db.close();
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("assumes legacy account schemas are current and marks schema version", () => {
+  it("rejects unversioned non-empty legacy schemas", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -50,64 +46,142 @@ describe("account timezone/locale defaults", () => {
     `);
     legacy.close();
 
-    const reopened = initDatabase(dbPath);
-    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
-    reopened.close();
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported unversioned database detected/);
 
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("assumes calendar_feed_tokens schemas missing token are current", () => {
+  it("migrates a versioned database forward to current schema version", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-calendar-feed-tokens.sqlite");
-    const db = initDatabase(dbPath);
-    db.exec(`
-      CREATE TABLE calendar_feed_tokens_new (
-        account_id TEXT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
-        token_hash TEXT NOT NULL UNIQUE,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    const dbPath = join(dir, "versioned-old.sqlite");
+    const versioned = new Database(dbPath);
+    versioned.exec(`
+      CREATE TABLE accounts (
+        id TEXT PRIMARY KEY,
+        username TEXT NOT NULL UNIQUE,
+        timezone TEXT NOT NULL DEFAULT 'system',
+        date_time_locale TEXT NOT NULL DEFAULT 'system',
+        theme_preference TEXT NOT NULL DEFAULT 'system'
       );
-      INSERT INTO calendar_feed_tokens_new (account_id, token_hash, created_at)
-      SELECT account_id, token, created_at FROM calendar_feed_tokens;
-      DROP TABLE calendar_feed_tokens;
-      ALTER TABLE calendar_feed_tokens_new RENAME TO calendar_feed_tokens;
-    `);
-    db.close();
-
-    const reopened = initDatabase(dbPath);
-    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
-    reopened.close();
-
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  it("assumes legacy event_rsvps status values are current", () => {
-    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "legacy-event-rsvps-status.sqlite");
-    const db = initDatabase(dbPath);
-    db.prepare("INSERT INTO accounts (id, username) VALUES (?, ?)").run("u1", "user1");
-    db.exec(`
-      CREATE TABLE event_rsvps_new (
+      CREATE TABLE sessions (
+        token TEXT PRIMARY KEY,
         account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
-        event_uri TEXT NOT NULL,
-        status TEXT NOT NULL,
         created_at TEXT NOT NULL DEFAULT (datetime('now')),
-        PRIMARY KEY (account_id, event_uri)
+        expires_at TEXT NOT NULL
       );
-      DROP TABLE event_rsvps;
-      ALTER TABLE event_rsvps_new RENAME TO event_rsvps;
+      CREATE TABLE api_keys (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+        key_hash TEXT NOT NULL,
+        label TEXT NOT NULL DEFAULT '',
+        last_used_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        key_prefix TEXT
+      );
+      CREATE TABLE events (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL REFERENCES accounts(id),
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        event_timezone TEXT NOT NULL,
+        visibility TEXT NOT NULL DEFAULT 'public',
+        og_image_url TEXT
+      );
+      CREATE TABLE remote_events (
+        uri TEXT PRIMARY KEY,
+        actor_uri TEXT NOT NULL,
+        slug TEXT,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        timezone_quality TEXT NOT NULL
+      );
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
-    db.prepare("INSERT INTO event_rsvps (account_id, event_uri, status) VALUES (?, ?, ?)")
-      .run("u1", "event:1", "interested");
-    db.close();
+    versioned.pragma("user_version = 1");
+    versioned.close();
 
     const reopened = initDatabase(dbPath);
     const userVersion = reopened.pragma("user_version", { simple: true }) as number;
     expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
+    const columns = reopened.prepare("PRAGMA table_info(remote_events)").all() as Array<{ name: string }>;
+    expect(columns.some((column) => column.name === "og_image_url")).toBe(true);
     reopened.close();
 
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails startup when a required schema column is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "missing-column.sqlite");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE accounts (id TEXT PRIMARY KEY, username TEXT NOT NULL UNIQUE, theme_preference TEXT NOT NULL);
+      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL);
+      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, key_hash TEXT NOT NULL);
+      CREATE TABLE events (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        event_timezone TEXT NOT NULL
+      );
+      CREATE TABLE remote_events (
+        uri TEXT PRIMARY KEY,
+        actor_uri TEXT NOT NULL,
+        slug TEXT,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        timezone_quality TEXT NOT NULL,
+        og_image_url TEXT
+      );
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+    `);
+    db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
+    db.close();
+
+    expect(() => initDatabase(dbPath)).toThrow(/missing required column "events.og_image_url"/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails startup when a required schema index is missing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
+    const dbPath = join(dir, "missing-index.sqlite");
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE accounts (id TEXT PRIMARY KEY, username TEXT NOT NULL UNIQUE, theme_preference TEXT NOT NULL);
+      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL);
+      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT NOT NULL, key_hash TEXT NOT NULL);
+      CREATE TABLE events (
+        id TEXT PRIMARY KEY,
+        account_id TEXT NOT NULL,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        event_timezone TEXT NOT NULL,
+        og_image_url TEXT
+      );
+      CREATE TABLE remote_events (
+        uri TEXT PRIMARY KEY,
+        actor_uri TEXT NOT NULL,
+        slug TEXT,
+        title TEXT NOT NULL,
+        start_date TEXT NOT NULL,
+        start_at_utc TEXT NOT NULL,
+        timezone_quality TEXT NOT NULL,
+        og_image_url TEXT
+      );
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, id);
+    `);
+    db.pragma(`user_version = ${CURRENT_SCHEMA_VERSION}`);
+    db.close();
+
+    expect(() => initDatabase(dbPath)).toThrow(/missing required index "idx_remote_events_actor_slug"/);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/server/tests/db-schema-validation.test.ts
+++ b/packages/server/tests/db-schema-validation.test.ts
@@ -1,22 +1,12 @@
 import { afterEach, describe, expect, it } from "vitest";
 import Database from "better-sqlite3";
 import { validateSchema, type DB } from "../src/db.js";
+import { MIGRATIONS } from "../src/db/migrations.js";
 
 function createBaseSchema(db: DB): void {
-  db.exec(`
-    CREATE TABLE accounts (id TEXT PRIMARY KEY, theme_preference TEXT);
-    CREATE TABLE events (id TEXT PRIMARY KEY, account_id TEXT, slug TEXT, og_image_url TEXT);
-    CREATE TABLE remote_events (uri TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
-    CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
-    CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_hash TEXT, key_prefix TEXT);
-  `);
-}
-
-function createRequiredIndexes(db: DB): void {
-  db.exec(`
-    CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
-    CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
-  `);
+  for (const migration of MIGRATIONS) {
+    migration.up(db);
+  }
 }
 
 describe("schema index definition validation", () => {
@@ -29,7 +19,6 @@ describe("schema index definition validation", () => {
   it("accepts required indexes when definitions match", () => {
     db = new Database(":memory:");
     createBaseSchema(db);
-    createRequiredIndexes(db);
 
     expect(() => validateSchema(db)).not.toThrow();
   });
@@ -38,8 +27,8 @@ describe("schema index definition validation", () => {
     db = new Database(":memory:");
     createBaseSchema(db);
     db.exec(`
+      DROP INDEX idx_events_slug;
       CREATE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
-      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
 
     expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
@@ -50,8 +39,8 @@ describe("schema index definition validation", () => {
     db = new Database(":memory:");
     createBaseSchema(db);
     db.exec(`
+      DROP INDEX idx_events_slug;
       CREATE UNIQUE INDEX idx_events_slug ON events(slug, account_id) WHERE slug IS NOT NULL;
-      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
 
     expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
@@ -62,25 +51,31 @@ describe("schema index definition validation", () => {
     db = new Database(":memory:");
     createBaseSchema(db);
     db.exec(`
+      DROP INDEX idx_events_slug;
       CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug);
-      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
     `);
 
     expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
     expect(() => validateSchema(db)).toThrow(/expected partial=1 but found partial=0/);
   });
 
-  it("rejects required key columns when schema drifts", () => {
+  it("rejects required columns when schema drifts", () => {
     db = new Database(":memory:");
-    db.exec(`
-      CREATE TABLE accounts (id TEXT PRIMARY KEY, theme_preference TEXT);
-      CREATE TABLE events (id TEXT PRIMARY KEY, account_id TEXT, slug TEXT, og_image_url TEXT);
-      CREATE TABLE remote_events (id TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
-      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
-      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_hash TEXT, key_prefix TEXT);
-    `);
-    createRequiredIndexes(db);
+    createBaseSchema(db);
+    db.exec("ALTER TABLE remote_events DROP COLUMN title;");
 
-    expect(() => validateSchema(db)).toThrow(/missing required column "remote_events.uri"/);
+    expect(() => validateSchema(db)).toThrow(/missing required column "remote_events.title"/);
+  });
+
+  it("rejects required index when sort order drifts", () => {
+    db = new Database(":memory:");
+    createBaseSchema(db);
+    db.exec(`
+      DROP INDEX idx_saved_locations_account;
+      CREATE INDEX idx_saved_locations_account ON saved_locations(account_id, used_at);
+    `);
+
+    expect(() => validateSchema(db)).toThrow(/invalid required index "idx_saved_locations_account"/);
+    expect(() => validateSchema(db)).toThrow(/expected columns \(account_id, used_at DESC\) but found \(account_id, used_at\)/);
   });
 });

--- a/packages/server/tests/db-schema-validation.test.ts
+++ b/packages/server/tests/db-schema-validation.test.ts
@@ -6,9 +6,9 @@ function createBaseSchema(db: DB): void {
   db.exec(`
     CREATE TABLE accounts (id TEXT PRIMARY KEY, theme_preference TEXT);
     CREATE TABLE events (id TEXT PRIMARY KEY, account_id TEXT, slug TEXT, og_image_url TEXT);
-    CREATE TABLE remote_events (id TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
-    CREATE TABLE sessions (id TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
-    CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_prefix TEXT);
+    CREATE TABLE remote_events (uri TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
+    CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
+    CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_hash TEXT, key_prefix TEXT);
   `);
 }
 
@@ -68,5 +68,19 @@ describe("schema index definition validation", () => {
 
     expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
     expect(() => validateSchema(db)).toThrow(/expected partial=1 but found partial=0/);
+  });
+
+  it("rejects required key columns when schema drifts", () => {
+    db = new Database(":memory:");
+    db.exec(`
+      CREATE TABLE accounts (id TEXT PRIMARY KEY, theme_preference TEXT);
+      CREATE TABLE events (id TEXT PRIMARY KEY, account_id TEXT, slug TEXT, og_image_url TEXT);
+      CREATE TABLE remote_events (id TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
+      CREATE TABLE sessions (token TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
+      CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_hash TEXT, key_prefix TEXT);
+    `);
+    createRequiredIndexes(db);
+
+    expect(() => validateSchema(db)).toThrow(/missing required column "remote_events.uri"/);
   });
 });

--- a/packages/server/tests/db-schema-validation.test.ts
+++ b/packages/server/tests/db-schema-validation.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { validateSchema, type DB } from "../src/db.js";
+
+function createBaseSchema(db: DB): void {
+  db.exec(`
+    CREATE TABLE accounts (id TEXT PRIMARY KEY, theme_preference TEXT);
+    CREATE TABLE events (id TEXT PRIMARY KEY, account_id TEXT, slug TEXT, og_image_url TEXT);
+    CREATE TABLE remote_events (id TEXT PRIMARY KEY, actor_uri TEXT, slug TEXT, og_image_url TEXT);
+    CREATE TABLE sessions (id TEXT PRIMARY KEY, account_id TEXT, expires_at TEXT);
+    CREATE TABLE api_keys (id TEXT PRIMARY KEY, account_id TEXT, key_prefix TEXT);
+  `);
+}
+
+function createRequiredIndexes(db: DB): void {
+  db.exec(`
+    CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
+    CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+  `);
+}
+
+describe("schema index definition validation", () => {
+  let db: DB | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("accepts required indexes when definitions match", () => {
+    db = new Database(":memory:");
+    createBaseSchema(db);
+    createRequiredIndexes(db);
+
+    expect(() => validateSchema(db)).not.toThrow();
+  });
+
+  it("rejects required index when unique flag drifts", () => {
+    db = new Database(":memory:");
+    createBaseSchema(db);
+    db.exec(`
+      CREATE INDEX idx_events_slug ON events(account_id, slug) WHERE slug IS NOT NULL;
+      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+    `);
+
+    expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
+    expect(() => validateSchema(db)).toThrow(/expected unique=1 but found unique=0/);
+  });
+
+  it("rejects required index when column order drifts", () => {
+    db = new Database(":memory:");
+    createBaseSchema(db);
+    db.exec(`
+      CREATE UNIQUE INDEX idx_events_slug ON events(slug, account_id) WHERE slug IS NOT NULL;
+      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+    `);
+
+    expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
+    expect(() => validateSchema(db)).toThrow(/expected columns \(account_id, slug\) but found \(slug, account_id\)/);
+  });
+
+  it("rejects required index when WHERE predicate drifts", () => {
+    db = new Database(":memory:");
+    createBaseSchema(db);
+    db.exec(`
+      CREATE UNIQUE INDEX idx_events_slug ON events(account_id, slug);
+      CREATE UNIQUE INDEX idx_remote_events_actor_slug ON remote_events(actor_uri, slug) WHERE slug IS NOT NULL;
+    `);
+
+    expect(() => validateSchema(db)).toThrow(/invalid required index "idx_events_slug"/);
+    expect(() => validateSchema(db)).toThrow(/expected partial=1 but found partial=0/);
+  });
+});

--- a/packages/server/tests/events-slugs.test.ts
+++ b/packages/server/tests/events-slugs.test.ts
@@ -1912,22 +1912,18 @@ describe("event slug canonical behavior", () => {
     expect(res.status).toBe(404);
   });
 
-  it("adopts the schema version marker for an already-current database", () => {
+  it("initializes an empty database to current schema version", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
-    const dbPath = join(dir, "current.sqlite");
-    const initial = initDatabase(dbPath);
-    initial.pragma("user_version = 0");
-    initial.close();
-
-    const reopened = initDatabase(dbPath);
-    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
+    const dbPath = join(dir, "fresh.sqlite");
+    const db = initDatabase(dbPath);
+    const userVersion = db.pragma("user_version", { simple: true }) as number;
     expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
 
-    reopened.close();
+    db.close();
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it("assumes unsupported legacy schemas are current and marks schema version", () => {
+  it("rejects unsupported unversioned legacy schemas", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy.sqlite");
     const legacy = new Database(dbPath);
@@ -1941,10 +1937,7 @@ describe("event slug canonical behavior", () => {
     `);
     legacy.close();
 
-    const reopened = initDatabase(dbPath);
-    const userVersion = reopened.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
-    reopened.close();
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported unversioned database detected/);
     rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/packages/server/tests/og-images.test.ts
+++ b/packages/server/tests/og-images.test.ts
@@ -427,7 +427,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
     expect(unlinkMock).not.toHaveBeenCalled();
   });
 
-  it("no-ops when legacy remote_events schema has no og_image_url column", async () => {
+  it("fails init for unversioned legacy remote_events schema", () => {
     const dir = mkdtempSync(join(tmpdir(), "everycal-db-"));
     const dbPath = join(dir, "legacy-og.sqlite");
     const legacy = new Database(dbPath);
@@ -448,19 +448,7 @@ describe("generateAndSaveOgImage temporal payload", () => {
       );
     legacy.close();
 
-    const db = initDatabase(dbPath);
-    const userVersion = db.pragma("user_version", { simple: true }) as number;
-    expect(userVersion).toBe(CURRENT_SCHEMA_VERSION);
-
-    const generated = await generateAndSaveRemoteOgImage(db, "https://remote.example/events/legacy");
-    expect(generated).toBeNull();
-    expect(generateOgImageMock).not.toHaveBeenCalled();
-    expect(writeFileMock).not.toHaveBeenCalled();
-
-    await expect(clearRemoteOgImage(db, "https://remote.example/events/legacy")).resolves.toBeUndefined();
-    expect(unlinkMock).not.toHaveBeenCalled();
-
-    db.close();
+    expect(() => initDatabase(dbPath)).toThrow(/Unsupported unversioned database detected/);
     rmSync(dir, { recursive: true, force: true });
   });
 


### PR DESCRIPTION
### Motivation
- Remove the legacy behavior that silently marked non-empty `user_version=0` databases as current so upgrades are migration-only and unversioned legacy DBs are unsupported.
- Ensure migration metadata is authoritative and validated at runtime to avoid silent schema drift or misconfigured migrations.
- Fail fast on schema or version mismatches so startup does not continue with an unsupported or partially incompatible database.
- Remove unreachable remote OG-image schema fallback logic now that startup schema validation always requires `remote_events.og_image_url`.

### Description
- Replace the `user_version === 0` non-empty fallback in `initDatabase` with a hard error and keep the existing migration path for versioned DBs and the hard-fail for future versions (`packages/server/src/db.ts`).
- Add `validateMigrationConfiguration()` at startup to assert migrations have positive integer, strictly increasing, non-duplicated versions and that `CURRENT_SCHEMA_VERSION` equals the last migration version (`packages/server/src/db.ts`).
- Add `validateSchema(db)` and run schema validation after migrations (and on current DBs) to require critical tables, columns, and indexes used by the app, including `remote_events.og_image_url` (`packages/server/src/db.ts`).
- Remove legacy remote OG fallback checks/warnings for missing `remote_events.og_image_url` and make remote OG persistence/cleanup follow strict-schema assumptions (`packages/server/src/routes/og-images.ts`).
- Keep migrations as the only schema-changing runtime path; no implicit schema healing outside migration execution.
- Update server tests for strict versioning/schema-validation expectations in `packages/server/tests`.

### Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`