### PR TITLE
Fix duplicate email verification calls in web flow

### DIFF
--- a/packages/web/src/hooks/useAuth.tsx
+++ b/packages/web/src/hooks/useAuth.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { AppBootstrap } from "@everycal/core";
 import { bootstrapViewerToUser } from "@everycal/core";
 import { auth as authApi, type User, type AuthResponse } from "../lib/api";
@@ -63,7 +63,7 @@ export function AuthProvider({
     return { status: initialUser ? "authenticated" : "anonymous", user: initialUser ?? null };
   });
 
-  const refreshUser = async () => {
+  const refreshUser = useCallback(async () => {
     try {
       const u = await authApi.me();
       setAuthState({ status: "authenticated", user: u });
@@ -71,7 +71,7 @@ export function AuthProvider({
     } catch {
       setAuthState({ status: "anonymous", user: null });
     }
-  };
+  }, []);
 
   const previousUserIdRef = useRef<string | null>(authState.user?.id ?? null);
   useEffect(() => {
@@ -103,16 +103,16 @@ export function AuthProvider({
 
     refreshUser().catch(() => {});
     return undefined;
-  }, []);
+  }, [hasBootstrap, refreshUser]);
 
-  const login = async (username: string, password: string) => {
+  const login = useCallback(async (username: string, password: string) => {
     const res = await authApi.login(username, password);
     setAuthState({ status: "authenticated", user: res.user });
     syncLanguageFromUser(res.user.preferredLanguage);
     return res.user;
-  };
+  }, []);
 
-  const register = async (
+  const register = useCallback(async (
     username: string,
     password: string,
     displayName?: string,
@@ -127,9 +127,9 @@ export function AuthProvider({
     }
     setAuthState({ status: "authenticated", user: (res as AuthResponse).user });
     return undefined;
-  };
+  }, []);
 
-  const logout = async () => {
+  const logout = useCallback(async () => {
     try {
       await authApi.logout();
     } catch {
@@ -137,20 +137,20 @@ export function AuthProvider({
     }
     // Server clears HttpOnly cookie
     setAuthState({ status: "anonymous", user: null });
-  };
+  }, []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user: authState.user,
+    loading: authState.status === "unknown",
+    authStatus: authState.status,
+    login,
+    register,
+    logout,
+    refreshUser,
+  }), [authState.user, authState.status, login, register, logout, refreshUser]);
 
   return (
-    <AuthContext.Provider
-      value={{
-        user: authState.user,
-        loading: authState.status === "unknown",
-        authStatus: authState.status,
-        login,
-        register,
-        logout,
-        refreshUser,
-      }}
-    >
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/web/src/lib/api.ts
+++ b/packages/web/src/lib/api.ts
@@ -205,6 +205,22 @@ export interface AuthResponse {
   expiresAt: string;
 }
 
+export interface VerifyEmailRegistrationResponse extends AuthResponse {
+  redirectTo?: string;
+  ok?: false;
+  emailChanged?: false;
+}
+
+export interface VerifyEmailChangeResponse {
+  ok: true;
+  emailChanged: true;
+  redirectTo?: string;
+  user?: never;
+  expiresAt?: never;
+}
+
+export type VerifyEmailResponse = VerifyEmailRegistrationResponse | VerifyEmailChangeResponse;
+
 export const auth = {
   register(
     username: string,
@@ -222,7 +238,7 @@ export const auth = {
   },
 
   verifyEmail(token: string) {
-    return request<AuthResponse & { redirectTo?: string; ok?: boolean; emailChanged?: boolean }>(
+    return request<VerifyEmailResponse>(
       "/auth/verify-email?token=" + encodeURIComponent(token)
     );
   },

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -37,6 +37,15 @@ import { VerifyEmailPage } from "./VerifyEmailPage";
 import { auth as authApi } from "../lib/api";
 
 describe("VerifyEmailPage", () => {
+  const settleVerification = async () => {
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+  };
+
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
@@ -82,40 +91,52 @@ describe("VerifyEmailPage", () => {
   });
 
   it("uses server-provided redirect destination", async () => {
+    vi.useFakeTimers();
     mocks.search = "?token=token-email-change";
     vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: false, redirectTo: "/settings" } as any);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     render(<VerifyEmailPage />);
 
-    expect(await screen.findByText("emailVerified")).toBeTruthy();
-    await waitFor(() => {
-      expect(mocks.refreshUser).toHaveBeenCalled();
-    });
+    await settleVerification();
+    expect(screen.getByText("emailVerified")).toBeTruthy();
+    expect(mocks.refreshUser).toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2500);
+    expect(mocks.navigate).not.toHaveBeenCalled();
 
-    const redirectTimeoutCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 2500);
-    const callback = redirectTimeoutCall?.[0] as (() => void) | undefined;
-    expect(callback).toBeTypeOf("function");
-    callback?.();
+    act(() => {
+      vi.advanceTimersByTime(2499);
+    });
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(mocks.navigate).toHaveBeenCalledWith("/settings");
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
   });
 
   it("falls back to emailChanged redirect when server redirect is missing", async () => {
+    vi.useFakeTimers();
     mocks.search = "?token=token-email-change-fallback";
     vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: true } as any);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     render(<VerifyEmailPage />);
 
-    expect(await screen.findByText("emailUpdated")).toBeTruthy();
-    await waitFor(() => {
-      expect(mocks.refreshUser).toHaveBeenCalled();
-    });
+    await settleVerification();
+    expect(screen.getByText("emailUpdated")).toBeTruthy();
+    expect(mocks.refreshUser).toHaveBeenCalled();
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2500);
+    expect(mocks.navigate).not.toHaveBeenCalled();
 
-    const redirectTimeoutCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 2500);
-    const callback = redirectTimeoutCall?.[0] as (() => void) | undefined;
-    expect(callback).toBeTypeOf("function");
-    callback?.();
+    act(() => {
+      vi.advanceTimersByTime(2499);
+    });
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
     expect(mocks.navigate).toHaveBeenCalledWith("/settings");
+    expect(mocks.navigate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -158,4 +158,27 @@ describe("VerifyEmailPage", () => {
     expect(mocks.navigate).toHaveBeenCalledWith("/settings");
     expect(mocks.navigate).toHaveBeenCalledTimes(1);
   });
+
+  it("only reuses the most recent successful token", async () => {
+    vi.mocked(authApi.verifyEmail).mockResolvedValue(registrationResponse());
+
+    mocks.search = "?token=token-a";
+    const firstRender = render(<VerifyEmailPage />);
+    await settleVerification();
+    firstRender.unmount();
+
+    mocks.search = "?token=token-b";
+    const secondRender = render(<VerifyEmailPage />);
+    await settleVerification();
+    secondRender.unmount();
+
+    mocks.search = "?token=token-a";
+    render(<VerifyEmailPage />);
+    await settleVerification();
+
+    expect(authApi.verifyEmail).toHaveBeenCalledTimes(3);
+    expect(vi.mocked(authApi.verifyEmail)).toHaveBeenNthCalledWith(1, "token-a");
+    expect(vi.mocked(authApi.verifyEmail)).toHaveBeenNthCalledWith(2, "token-b");
+    expect(vi.mocked(authApi.verifyEmail)).toHaveBeenNthCalledWith(3, "token-a");
+  });
 });

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -80,8 +80,27 @@ describe("VerifyEmailPage", () => {
     expect(await screen.findAllByText("emailVerified")).toHaveLength(2);
   });
 
-  it("redirects to settings after email change verification", async () => {
+  it("uses server-provided redirect destination", async () => {
     mocks.search = "?token=token-email-change";
+    vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: false, redirectTo: "/settings" } as any);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    render(<VerifyEmailPage />);
+
+    expect(await screen.findByText("emailVerified")).toBeTruthy();
+    await waitFor(() => {
+      expect(mocks.refreshUser).toHaveBeenCalled();
+    });
+
+    const redirectTimeoutCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 2500);
+    const callback = redirectTimeoutCall?.[0] as (() => void) | undefined;
+    expect(callback).toBeTypeOf("function");
+    callback?.();
+    expect(mocks.navigate).toHaveBeenCalledWith("/settings");
+  });
+
+  it("falls back to emailChanged redirect when server redirect is missing", async () => {
+    mocks.search = "?token=token-email-change-fallback";
     vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: true } as any);
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  refreshUser: vi.fn(async () => {}),
+  verifyEmail: vi.fn(),
+  search: "?token=token-default",
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("wouter", () => ({
+  useLocation: () => ["/verify-email", mocks.navigate],
+  useSearch: () => mocks.search,
+}));
+
+vi.mock("../hooks/useAuth", () => ({
+  useAuth: () => ({
+    refreshUser: mocks.refreshUser,
+  }),
+}));
+
+vi.mock("../lib/api", () => ({
+  auth: {
+    verifyEmail: mocks.verifyEmail,
+  },
+}));
+
+import { VerifyEmailPage } from "./VerifyEmailPage";
+import { auth as authApi } from "../lib/api";
+
+describe("VerifyEmailPage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.search = "?token=token-default";
+  });
+
+  it("shows an error when token is missing", async () => {
+    mocks.search = "";
+
+    render(<VerifyEmailPage />);
+
+    expect(await screen.findByText("missingToken")).toBeTruthy();
+    expect(authApi.verifyEmail).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent verification requests for the same token", async () => {
+    mocks.search = "?token=token-dedupe";
+    let resolveVerify: ((value: any) => void) | undefined;
+    vi.mocked(authApi.verifyEmail).mockImplementation(() => new Promise((resolve) => {
+      resolveVerify = resolve;
+    }) as Promise<any>);
+
+    render(
+      <>
+        <VerifyEmailPage />
+        <VerifyEmailPage />
+      </>
+    );
+
+    await waitFor(() => {
+      expect(authApi.verifyEmail).toHaveBeenCalledTimes(1);
+    });
+
+    if (!resolveVerify) throw new Error("Expected verify resolver to be set");
+    resolveVerify({ emailChanged: false });
+
+    expect(await screen.findAllByText("emailVerified")).toHaveLength(2);
+  });
+
+  it("redirects to settings after email change verification", async () => {
+    mocks.search = "?token=token-email-change";
+    vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: true } as any);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    render(<VerifyEmailPage />);
+
+    expect(await screen.findByText("emailUpdated")).toBeTruthy();
+    await waitFor(() => {
+      expect(mocks.refreshUser).toHaveBeenCalled();
+    });
+
+    const redirectTimeoutCall = setTimeoutSpy.mock.calls.find((call) => call[1] === 2500);
+    const callback = redirectTimeoutCall?.[0] as (() => void) | undefined;
+    expect(callback).toBeTypeOf("function");
+    callback?.();
+    expect(mocks.navigate).toHaveBeenCalledWith("/settings");
+  });
+});

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -2,6 +2,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { VerifyEmailChangeResponse, VerifyEmailRegistrationResponse, VerifyEmailResponse } from "../lib/api";
 
 const mocks = vi.hoisted(() => ({
   navigate: vi.fn(),
@@ -37,6 +38,24 @@ import { VerifyEmailPage } from "./VerifyEmailPage";
 import { auth as authApi } from "../lib/api";
 
 describe("VerifyEmailPage", () => {
+  const registrationResponse = (overrides: Partial<VerifyEmailRegistrationResponse> = {}): VerifyEmailRegistrationResponse => ({
+    user: {
+      id: "account-1",
+      username: "testuser",
+      displayName: "Test User",
+      email: "test@example.com",
+      emailVerified: true,
+    },
+    expiresAt: "2030-01-01T00:00:00.000Z",
+    ...overrides,
+  });
+
+  const emailChangeResponse = (overrides: Partial<VerifyEmailChangeResponse> = {}): VerifyEmailChangeResponse => ({
+    ok: true,
+    emailChanged: true,
+    ...overrides,
+  });
+
   const settleVerification = async () => {
     await act(async () => {
       await Promise.resolve();
@@ -68,10 +87,10 @@ describe("VerifyEmailPage", () => {
 
   it("deduplicates concurrent verification requests for the same token", async () => {
     mocks.search = "?token=token-dedupe";
-    let resolveVerify: ((value: any) => void) | undefined;
+    let resolveVerify: ((value: VerifyEmailResponse) => void) | undefined;
     vi.mocked(authApi.verifyEmail).mockImplementation(() => new Promise((resolve) => {
       resolveVerify = resolve;
-    }) as Promise<any>);
+    }));
 
     render(
       <>
@@ -85,7 +104,7 @@ describe("VerifyEmailPage", () => {
     });
 
     if (!resolveVerify) throw new Error("Expected verify resolver to be set");
-    resolveVerify({ emailChanged: false });
+    resolveVerify(registrationResponse());
 
     expect(await screen.findAllByText("emailVerified")).toHaveLength(2);
   });
@@ -93,7 +112,7 @@ describe("VerifyEmailPage", () => {
   it("uses server-provided redirect destination", async () => {
     vi.useFakeTimers();
     mocks.search = "?token=token-email-change";
-    vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: false, redirectTo: "/settings" } as any);
+    vi.mocked(authApi.verifyEmail).mockResolvedValue(registrationResponse({ redirectTo: "/settings" }));
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     render(<VerifyEmailPage />);
@@ -118,7 +137,7 @@ describe("VerifyEmailPage", () => {
   it("falls back to emailChanged redirect when server redirect is missing", async () => {
     vi.useFakeTimers();
     mocks.search = "?token=token-email-change-fallback";
-    vi.mocked(authApi.verifyEmail).mockResolvedValue({ emailChanged: true } as any);
+    vi.mocked(authApi.verifyEmail).mockResolvedValue(emailChangeResponse());
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
 
     render(<VerifyEmailPage />);

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -40,6 +40,7 @@ describe("VerifyEmailPage", () => {
   afterEach(() => {
     cleanup();
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   beforeEach(() => {

--- a/packages/web/src/pages/VerifyEmailPage.test.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.test.tsx
@@ -34,8 +34,8 @@ vi.mock("../lib/api", () => ({
   },
 }));
 
-import { VerifyEmailPage } from "./VerifyEmailPage";
-import { auth as authApi } from "../lib/api";
+let VerifyEmailPage: (typeof import("./VerifyEmailPage"))["VerifyEmailPage"];
+let authApi: (typeof import("../lib/api"))["auth"];
 
 describe("VerifyEmailPage", () => {
   const registrationResponse = (overrides: Partial<VerifyEmailRegistrationResponse> = {}): VerifyEmailRegistrationResponse => ({
@@ -71,9 +71,12 @@ describe("VerifyEmailPage", () => {
     vi.restoreAllMocks();
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    vi.resetModules();
     vi.clearAllMocks();
     mocks.search = "?token=token-default";
+    ({ VerifyEmailPage } = await import("./VerifyEmailPage"));
+    ({ auth: authApi } = await import("../lib/api"));
   });
 
   it("shows an error when token is missing", async () => {

--- a/packages/web/src/pages/VerifyEmailPage.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.tsx
@@ -1,8 +1,33 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useSearch } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../hooks/useAuth";
 import { auth as authApi } from "../lib/api";
+
+type VerifyEmailResponse = Awaited<ReturnType<typeof authApi.verifyEmail>>;
+
+const verifyEmailInFlight = new Map<string, Promise<VerifyEmailResponse>>();
+const verifyEmailSucceeded = new Map<string, VerifyEmailResponse>();
+
+function verifyEmailOnce(token: string): Promise<VerifyEmailResponse> {
+  const succeeded = verifyEmailSucceeded.get(token);
+  if (succeeded) return Promise.resolve(succeeded);
+
+  const inFlight = verifyEmailInFlight.get(token);
+  if (inFlight) return inFlight;
+
+  const request = authApi.verifyEmail(token)
+    .then((response) => {
+      verifyEmailSucceeded.set(token, response);
+      return response;
+    })
+    .finally(() => {
+      verifyEmailInFlight.delete(token);
+    });
+
+  verifyEmailInFlight.set(token, request);
+  return request;
+}
 
 export function VerifyEmailPage() {
   const { t } = useTranslation("auth");
@@ -12,6 +37,7 @@ export function VerifyEmailPage() {
   const [status, setStatus] = useState<"loading" | "success" | "error">("loading");
   const [error, setError] = useState("");
   const [emailChanged, setEmailChanged] = useState(false);
+  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const params = new URLSearchParams(search);
   const token = params.get("token");
@@ -24,8 +50,7 @@ export function VerifyEmailPage() {
     }
 
     let cancelled = false;
-    authApi
-      .verifyEmail(token)
+    verifyEmailOnce(token)
       .then(async (res) => {
         if (cancelled) return;
         const wasEmailChange = !!(res && "emailChanged" in res && res.emailChanged);
@@ -34,7 +59,8 @@ export function VerifyEmailPage() {
         await refreshUser();
         if (cancelled) return;
         const redirectTo = wasEmailChange ? "/settings" : "/onboarding";
-        setTimeout(() => navigate(redirectTo), 2500);
+        if (redirectTimeoutRef.current) clearTimeout(redirectTimeoutRef.current);
+        redirectTimeoutRef.current = setTimeout(() => navigate(redirectTo), 2500);
       })
       .catch((err) => {
         if (!cancelled) {
@@ -42,7 +68,13 @@ export function VerifyEmailPage() {
           setError(err.message || t("verificationFailed"));
         }
       });
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+        redirectTimeoutRef.current = null;
+      }
+    };
   }, [token, navigate, refreshUser, t]);
 
   if (status === "loading") {

--- a/packages/web/src/pages/VerifyEmailPage.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.tsx
@@ -2,9 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useLocation, useSearch } from "wouter";
 import { useTranslation } from "react-i18next";
 import { useAuth } from "../hooks/useAuth";
-import { auth as authApi } from "../lib/api";
-
-type VerifyEmailResponse = Awaited<ReturnType<typeof authApi.verifyEmail>>;
+import { auth as authApi, type VerifyEmailResponse } from "../lib/api";
 
 const verifyEmailInFlight = new Map<string, Promise<VerifyEmailResponse>>();
 const verifyEmailSucceeded = new Map<string, VerifyEmailResponse>();
@@ -53,13 +51,12 @@ export function VerifyEmailPage() {
     verifyEmailOnce(token)
       .then(async (res) => {
         if (cancelled) return;
-        const wasEmailChange = !!(res && "emailChanged" in res && res.emailChanged);
+        const wasEmailChange = res.emailChanged === true;
         setEmailChanged(wasEmailChange);
         setStatus("success");
         await refreshUser();
         if (cancelled) return;
-        const responseRedirect = res && "redirectTo" in res ? res.redirectTo : undefined;
-        const redirectTo = responseRedirect || (wasEmailChange ? "/settings" : "/onboarding");
+        const redirectTo = res.redirectTo || (wasEmailChange ? "/settings" : "/onboarding");
         if (redirectTimeoutRef.current) clearTimeout(redirectTimeoutRef.current);
         redirectTimeoutRef.current = setTimeout(() => navigate(redirectTo), 2500);
       })

--- a/packages/web/src/pages/VerifyEmailPage.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.tsx
@@ -58,7 +58,8 @@ export function VerifyEmailPage() {
         setStatus("success");
         await refreshUser();
         if (cancelled) return;
-        const redirectTo = wasEmailChange ? "/settings" : "/onboarding";
+        const responseRedirect = res && "redirectTo" in res ? res.redirectTo : undefined;
+        const redirectTo = responseRedirect || (wasEmailChange ? "/settings" : "/onboarding");
         if (redirectTimeoutRef.current) clearTimeout(redirectTimeoutRef.current);
         redirectTimeoutRef.current = setTimeout(() => navigate(redirectTo), 2500);
       })

--- a/packages/web/src/pages/VerifyEmailPage.tsx
+++ b/packages/web/src/pages/VerifyEmailPage.tsx
@@ -5,18 +5,19 @@ import { useAuth } from "../hooks/useAuth";
 import { auth as authApi, type VerifyEmailResponse } from "../lib/api";
 
 const verifyEmailInFlight = new Map<string, Promise<VerifyEmailResponse>>();
-const verifyEmailSucceeded = new Map<string, VerifyEmailResponse>();
+let verifyEmailLastSucceeded: { token: string; response: VerifyEmailResponse } | null = null;
 
 function verifyEmailOnce(token: string): Promise<VerifyEmailResponse> {
-  const succeeded = verifyEmailSucceeded.get(token);
-  if (succeeded) return Promise.resolve(succeeded);
+  if (verifyEmailLastSucceeded?.token === token) {
+    return Promise.resolve(verifyEmailLastSucceeded.response);
+  }
 
   const inFlight = verifyEmailInFlight.get(token);
   if (inFlight) return inFlight;
 
   const request = authApi.verifyEmail(token)
     .then((response) => {
-      verifyEmailSucceeded.set(token, response);
+      verifyEmailLastSucceeded = { token, response };
       return response;
     })
     .finally(() => {


### PR DESCRIPTION
## Summary
- add a single-flight guard in `VerifyEmailPage` and cache only the most recent successful token so immediate remounts for that token skip duplicate verification calls within a tab/session
- clean up timeout lifecycle in the verify page to avoid duplicate redirect timers
- stabilize auth context callbacks and memoize provider value to reduce effect churn across consumers

## Testing
- pnpm lint
- pnpm test
- pnpm build