### PR TITLE
Harden private feed token auth and standardize non-AP pagination parsing

### DIFF
--- a/docs/non-ap-hardening-closure-checklist.md
+++ b/docs/non-ap-hardening-closure-checklist.md
@@ -1,0 +1,11 @@
+# Non-ActivityPub API hardening completion checklist
+
+- **1) Token hardening completion** — **done in this run**: removed plaintext fallback lookup from calendar feed token resolver; runtime lookup now uses signed tokens or hashed token lookup only. (`packages/server/src/routes/private-feeds.ts`)
+- **2) Schema guardrails / hashing expectations** — **done in this run**: expanded token hashing tests to enforce hash-only lookup semantics and 64-hex storage expectations for token secrets. (`packages/server/tests/token-secrets.test.ts`)
+- **3) Maintainability decomposition for oversized route modules** — **intentionally deferred**: no safe, reviewable multi-file extraction was completed in this pass without risking endpoint regressions; defer to a dedicated refactor PR with behavior-lock tests first. (`packages/server/src/routes/auth.ts`, `packages/server/src/routes/events.ts`)
+- **4) Pagination consistency (non-AP)** — **done in this run**: replaced manual `limit`/`offset` parsing with shared pagination utility handling in users and directory routes. (`packages/server/src/routes/users.ts`, `packages/server/src/routes/directory.ts`)
+- **5) Duplication cleanup (easy wins)** — **already satisfied** in the touched token lookup path and pagination parsing path by reusing shared helpers (`findByTokenHash`, `parseLimitOffset`) instead of bespoke parsing/lookup. (`packages/server/src/routes/private-feeds.ts`, `packages/server/src/routes/users.ts`, `packages/server/src/routes/directory.ts`)
+- **6) Regression test for legacy plaintext calendar feed tokens** — **done in this run**: added explicit test for plaintext token row rejection and signed token acceptance. (`packages/server/tests/feeds-cors.test.ts`)
+- **7) Prompt closure artifact** — **done in this run**: this checklist file.
+- **8) Deployment and migration playbook note** — **done in this run**: operator note added with deploy/rollback guidance for hash-only lookup behavior. (`docs/non-ap-hardening-deploy-playbook.md`)
+- **9) Lightweight performance sanity checks** — **done in this run**: targeted auth/events/private-feed adjacent test runs executed and summarized in implementation report output.

--- a/docs/non-ap-hardening-deploy-playbook.md
+++ b/docs/non-ap-hardening-deploy-playbook.md
@@ -1,0 +1,16 @@
+# Non-ActivityPub hardening deploy/migration playbook
+
+## Recommended deploy order
+1. Deploy server build containing hash-only calendar feed token lookup + pagination parser consolidation.
+2. Run/confirm targeted test suites in CI before full rollout.
+3. Roll out gradually (canary/one-instance first) and observe private feed 401/200 ratios.
+
+## One-time migration/runtime expectations
+- Signed calendar feed tokens (`ecal_cal_...`) continue to authenticate.
+- Existing migrated hashed `calendar_feed_tokens.token` rows continue to authenticate via hash lookup.
+- Legacy plaintext token rows no longer authenticate after this deploy.
+
+## Rollback implications
+- Rolling back to a build with plaintext fallback would re-accept legacy plaintext token rows (security regression).
+- No schema migration is required in this run, so rollback is code-only.
+- If rollback is unavoidable, rotate affected calendar feed tokens after re-upgrade to re-establish hash-only behavior.

--- a/packages/server/src/routes/directory.ts
+++ b/packages/server/src/routes/directory.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import type { DB } from "../db.js";
+import { PaginationParamError, parseLimitOffset } from "../lib/pagination.js";
 
 function getBaseUrl(): string {
   return process.env.BASE_URL || "http://localhost:3000";
@@ -27,8 +28,14 @@ export function directoryRoutes(db: DB): Hono {
   const router = new Hono();
 
   router.get("/directory", (c) => {
-    const offset = parseInt(c.req.query("offset") || "0", 10);
-    const limit = Math.min(parseInt(c.req.query("limit") || "40", 10), 80);
+    let limit: number;
+    let offset: number;
+    try {
+      ({ limit, offset } = parseLimitOffset(c, { defaultLimit: 40, maxLimit: 80 }));
+    } catch (error) {
+      if (error instanceof PaginationParamError) return c.json({ error: error.message }, 400);
+      throw error;
+    }
     const order = c.req.query("order") || "active";
     const baseUrl = getBaseUrl();
 

--- a/packages/server/src/routes/private-feeds.ts
+++ b/packages/server/src/routes/private-feeds.ts
@@ -118,9 +118,6 @@ function resolveAccountFromCalendarToken(db: DB, token: string): string | null {
     return null;
   }
 
-  const exact = db.prepare("SELECT account_id FROM calendar_feed_tokens WHERE token = ?").get(token) as { account_id: string } | undefined;
-  if (exact?.account_id) return exact.account_id;
-
   const row = findByTokenHash<{ account_id: string }>(
     db,
     "SELECT account_id FROM calendar_feed_tokens WHERE token = ?",

--- a/packages/server/src/routes/users.ts
+++ b/packages/server/src/routes/users.ts
@@ -28,6 +28,7 @@ import {
   summarizeActorSelection,
 } from "../lib/actor-selection.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
+import { PaginationParamError, parseLimitOffset } from "../lib/pagination.js";
 
 export function userRoutes(db: DB): Hono {
   const router = new Hono();
@@ -35,8 +36,14 @@ export function userRoutes(db: DB): Hono {
   // List users (public — only discoverable accounts)
   router.get("/", (c) => {
     const q = c.req.query("q") || "";
-    const limit = Math.min(parseInt(c.req.query("limit") || "20", 10), 100);
-    const offset = parseInt(c.req.query("offset") || "0", 10);
+    let limit: number;
+    let offset: number;
+    try {
+      ({ limit, offset } = parseLimitOffset(c, { defaultLimit: 20, maxLimit: 100 }));
+    } catch (error) {
+      if (error instanceof PaginationParamError) return c.json({ error: error.message }, 400);
+      throw error;
+    }
 
     let sql: string;
     let params: unknown[];
@@ -192,8 +199,14 @@ export function userRoutes(db: DB): Hono {
       throw error;
     }
     const sort = c.req.query("sort")?.toLowerCase() === "desc" ? "DESC" : "ASC";
-    const limit = Math.min(parseInt(c.req.query("limit") || "50", 10), 200);
-    const offset = parseInt(c.req.query("offset") || "0", 10);
+    let limit: number;
+    let offset: number;
+    try {
+      ({ limit, offset } = parseLimitOffset(c, { defaultLimit: 50, maxLimit: 200 }));
+    } catch (error) {
+      if (error instanceof PaginationParamError) return c.json({ error: error.message }, 400);
+      throw error;
+    }
 
     // Remote profile: username@domain format
     const atIdx = username.indexOf("@");

--- a/packages/server/tests/feeds-cors.test.ts
+++ b/packages/server/tests/feeds-cors.test.ts
@@ -105,6 +105,29 @@ describe("feed CORS policy", () => {
     expect(allowlistedRes.headers.get("access-control-allow-credentials")).toBe("true");
   });
 
+
+  it("rejects legacy plaintext calendar token rows while accepting signed tokens", async () => {
+    const { app, db } = createApp();
+    db.prepare("INSERT INTO accounts (id, username, account_type) VALUES (?, ?, 'person')").run("u1", "alice");
+    db.prepare("INSERT INTO calendar_feed_tokens (account_id, token) VALUES (?, ?)").run("u1", "legacy-plaintext-token");
+
+    const legacyRes = await app.request("http://localhost/api/v1/private-feeds/calendar.ics?token=legacy-plaintext-token");
+    expect(legacyRes.status).toBe(401);
+
+    const { token } = createSession(db, "u1");
+    const signedUrlRes = await app.request("http://localhost/api/v1/private-feeds/calendar-url", {
+      headers: { Cookie: `everycal_session=${token}` },
+    });
+    expect(signedUrlRes.status).toBe(200);
+
+    const signedBody = await signedUrlRes.json() as { url: string };
+    const signedToken = tokenFromCalendarUrl(signedBody.url);
+    expect(signedToken).toMatch(/^ecal_cal_/);
+
+    const signedFeedRes = await app.request(`http://localhost/api/v1/private-feeds/calendar.ics?token=${encodeURIComponent(signedToken!)}`);
+    expect(signedFeedRes.status).toBe(200);
+  });
+
   it("sets private feed no-store headers on token errors", async () => {
     const { app } = createApp();
 

--- a/packages/server/tests/non-ap-pagination-routes.test.ts
+++ b/packages/server/tests/non-ap-pagination-routes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { Hono } from "hono";
+import { initDatabase } from "../src/db.js";
+import { userRoutes } from "../src/routes/users.js";
+import { directoryRoutes } from "../src/routes/directory.js";
+
+function createApp() {
+  const db = initDatabase(":memory:");
+  const app = new Hono();
+  app.route("/api/v1/users", userRoutes(db));
+  app.route("/api/v1", directoryRoutes(db));
+  db.prepare("INSERT INTO accounts (id, username, account_type, discoverable) VALUES (?, ?, 'person', 1)").run("u1", "alice");
+  return { app };
+}
+
+describe("non-ActivityPub pagination parsing", () => {
+  it("rejects invalid users limit with shared parser behavior", async () => {
+    const { app } = createApp();
+    const res = await app.request("http://localhost/api/v1/users?limit=-4");
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain("limit");
+  });
+
+  it("rejects invalid directory offset with shared parser behavior", async () => {
+    const { app } = createApp();
+    const res = await app.request("http://localhost/api/v1/directory?offset=-1");
+    expect(res.status).toBe(400);
+    const body = await res.json() as { error: string };
+    expect(body.error).toContain("offset");
+  });
+});

--- a/packages/server/tests/token-secrets.test.ts
+++ b/packages/server/tests/token-secrets.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import Database from "better-sqlite3";
 import type { DB } from "../src/db.js";
-import { hashTokenSecret, storeHashedToken } from "../src/lib/token-secrets.js";
+import { findByTokenHash, hashTokenSecret, storeHashedToken } from "../src/lib/token-secrets.js";
 
 describe("storeHashedToken", () => {
   let db: DB | undefined;
@@ -54,5 +54,44 @@ describe("storeHashedToken", () => {
         1,
       );
     }).toThrow("Token parameter at index 1 must be a string (got number)");
+  });
+});
+
+
+describe("token hash lookup guardrails", () => {
+  let db: DB | undefined;
+
+  afterEach(() => {
+    db?.close();
+  });
+
+  it("does not resolve plaintext token rows through hash-only lookup", () => {
+    db = new Database(":memory:");
+    db.exec("CREATE TABLE calendar_feed_tokens (account_id TEXT, token TEXT)");
+    db.prepare("INSERT INTO calendar_feed_tokens (account_id, token) VALUES (?, ?)").run("acct-1", "raw-token");
+
+    const row = findByTokenHash<{ account_id: string }>(
+      db,
+      "SELECT account_id FROM calendar_feed_tokens WHERE token = ?",
+      "raw-token",
+    );
+
+    expect(row).toBeUndefined();
+  });
+
+  it("stores token-like secrets as 64-char hex hashes", () => {
+    db = new Database(":memory:");
+    db.exec("CREATE TABLE email_change_requests (account_id TEXT, token TEXT)");
+
+    storeHashedToken(
+      db,
+      "INSERT INTO email_change_requests (account_id, token) VALUES (?, ?)",
+      ["acct-1", "change-token"],
+      1,
+    );
+
+    const row = db.prepare("SELECT token FROM email_change_requests WHERE account_id = ?").get("acct-1") as { token: string };
+    expect(row.token).toMatch(/^[a-f0-9]{64}$/);
+    expect(row.token).toBe(hashTokenSecret("change-token"));
   });
 });


### PR DESCRIPTION
### Motivation
- Remove a legacy plaintext-token DB lookup in private calendar feed resolution to close a token-security footgun while preserving signed-token compatibility.
- Reduce manual pagination parsing on non-ActivityPub routes to a single shared utility so behavior and error handling are consistent.
- Add guarded tests to detect reintroduction of plaintext token behavior and to cover the tightened pagination semantics.
- Provide an operator checklist and deploy notes so rollout and rollback are clear for infra/operators.

### Description
- Private feed token hardening: removed the raw-token SELECT fallback from `resolveAccountFromCalendarToken` and now validate signed tokens first then perform hash-only lookups via `findByTokenHash` (file: `packages/server/src/routes/private-feeds.ts`).
- Pagination consolidation: replaced manual `limit`/`offset` parsing with `parseLimitOffset` and unified `PaginationParamError` handling in `GET /api/v1/users`, `GET /api/v1/:username/events`, and `GET /api/v1/directory` (files: `packages/server/src/routes/users.ts`, `packages/server/src/routes/directory.ts`).
- Tests and guardrails: added a regression test that legacy plaintext rows in `calendar_feed_tokens` do not authenticate while signed tokens still do (modified `packages/server/tests/feeds-cors.test.ts`), and extended `token-secrets` unit tests to assert hash-only lookup and 64-hex hashed storage expectations (modified `packages/server/tests/token-secrets.test.ts`).
- Pagination tests: added `packages/server/tests/non-ap-pagination-routes.test.ts` to assert consistent invalid-parameter handling for non-AP routes.
- Docs/playbook/checklist: added `docs/non-ap-hardening-closure-checklist.md` mapping requirements to status, and `docs/non-ap-hardening-deploy-playbook.md` with recommended deploy order and rollback implications.
- Low-risk duplication reduction: reused existing helpers (`findByTokenHash`, `parseLimitOffset`) instead of bespoke parsing/lookup logic in the touched routes.
- Intentional deferment: full decomposition of oversized `auth.ts` and `events.ts` was intentionally deferred and recorded in the checklist to avoid high-risk endpoint drift in this hardening pass.

### Testing
- Commands run:
  - `pnpm --filter @everycal/core build`
  - `pnpm --filter @everycal/og build`
  - `pnpm --filter @everycal/server exec vitest run tests/feeds-cors.test.ts tests/token-secrets.test.ts tests/non-ap-pagination-routes.test.ts`
  - `pnpm --filter @everycal/server exec vitest run tests/auth-bot-passwords.test.ts tests/events-pagination-routes.test.ts`
- Test results summary:
  - Initial broad `pnpm --filter @everycal/server test` surfaced unrelated failures caused by unbuilt local packages; building `@everycal/core` and `@everycal/og` resolved import failures.
  - Focused suite run for the changed tests passed: the three targeted files (`feeds-cors.test.ts`, `token-secrets.test.ts`, `non-ap-pagination-routes.test.ts`) completed successfully (`Test Files 3 passed, Tests 20 passed`).
  - Additional targeted sanity suites covering auth/events adjacency passed (`Test Files 2 passed, Tests 25 passed`).
- Automated coverage impact: the added tests exercise hash-only token lookup and invalid pagination paths and will fail if plaintext-token lookups or manual pagination parsing are reintroduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0848f69a08321b0464224f50b2bd7)