### PR TITLE
test(server): harden phase-2 API contract harness coverage

### DIFF
--- a/packages/server/src/lib/paths.ts
+++ b/packages/server/src/lib/paths.ts
@@ -4,4 +4,9 @@ const repoRoot = resolve(process.cwd(), '../..');
 
 export const DATABASE_PATH = process.env.DATABASE_PATH || resolve(repoRoot, "everycal.db");
 export const UPLOAD_DIR = process.env.UPLOAD_DIR || resolve(repoRoot, "uploads");
-export const OG_DIR = process.env.OG_DIR || resolve(repoRoot, "og-images");
+
+export function getOgDir(): string {
+  return process.env.OG_DIR || resolve(repoRoot, "og-images");
+}
+
+export const OG_DIR = getOgDir();

--- a/packages/server/src/routes/og-images.ts
+++ b/packages/server/src/routes/og-images.ts
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
 import { join } from "node:path";
 import { generateOgImage, getOgImageFilename } from "@everycal/og";
 import type { DB } from "../db.js";
-import { OG_DIR } from "../lib/paths.js";
+import { getOgDir } from "../lib/paths.js";
 import { normalizeEventTimezone } from "../lib/event-timezone.js";
 import { validateFederationUrl } from "../lib/federation.js";
 
@@ -89,7 +89,7 @@ export async function clearLocalOgImage(db: DB, eventId: string): Promise<void> 
   if (!filename) return;
 
   const { unlink } = await import("node:fs/promises");
-  const ogPath = join(OG_DIR, filename);
+  const ogPath = join(getOgDir(), filename);
   try {
     await unlink(ogPath);
   } catch (err) {
@@ -115,7 +115,7 @@ export async function clearRemoteOgImage(db: DB, eventUri: string): Promise<void
   if (filename !== expectedFilename) return;
 
   const { unlink } = await import("node:fs/promises");
-  const ogPath = join(OG_DIR, filename);
+  const ogPath = join(getOgDir(), filename);
   try {
     await unlink(ogPath);
   } catch (err) {
@@ -219,12 +219,13 @@ export async function generateAndSaveOgImage(db: DB, eventId: string): Promise<s
     locale,
   });
 
-  if (!existsSync(OG_DIR)) {
-    mkdirSync(OG_DIR, { recursive: true });
+  const ogDir = getOgDir();
+  if (!existsSync(ogDir)) {
+    mkdirSync(ogDir, { recursive: true });
   }
 
   const ogFilename = getOgImageFilename(eventId);
-  const ogPath = join(OG_DIR, ogFilename);
+  const ogPath = join(ogDir, ogFilename);
   await writeFile(ogPath, ogBuffer);
 
   const version = Math.floor(new Date(event.updated_at).getTime() / 1000);
@@ -327,12 +328,13 @@ export async function generateAndSaveRemoteOgImage(db: DB, eventUri: string): Pr
     locale: "en",
   });
 
-  if (!existsSync(OG_DIR)) {
-    mkdirSync(OG_DIR, { recursive: true });
+  const ogDir = getOgDir();
+  if (!existsSync(ogDir)) {
+    mkdirSync(ogDir, { recursive: true });
   }
 
   const ogFilename = getRemoteOgFilename(event.uri);
-  const ogPath = join(OG_DIR, ogFilename);
+  const ogPath = join(ogDir, ogFilename);
   await writeFile(ogPath, ogBuffer);
 
   const version = Math.floor(new Date(event.fetched_at).getTime() / 1000);

--- a/packages/server/src/routes/serve-og-images.ts
+++ b/packages/server/src/routes/serve-og-images.ts
@@ -6,7 +6,7 @@ import { Hono } from "hono";
 import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join, resolve, relative, isAbsolute, sep } from "node:path";
-import { OG_DIR } from "../lib/paths.js";
+import { getOgDir } from "../lib/paths.js";
 
 export function serveOgImagesRoutes(): Hono {
   const router = new Hono();
@@ -15,9 +15,10 @@ export function serveOgImagesRoutes(): Hono {
     const ogImageUrl = c.req.param("ogImageUrl");
 
     const filename = ogImageUrl.split("?")[0];
-    const filepath = join(OG_DIR, filename);
+    const ogDir = getOgDir();
+    const filepath = join(ogDir, filename);
     const resolved = resolve(filepath);
-    const ogDirResolved = resolve(OG_DIR);
+    const ogDirResolved = resolve(ogDir);
     const rel = relative(ogDirResolved, resolved);
     if (!rel || rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
       return c.notFound();

--- a/packages/server/tests/contract/assertions.ts
+++ b/packages/server/tests/contract/assertions.ts
@@ -1,0 +1,54 @@
+import { expect } from "vitest";
+
+type JsonRecord = Record<string, unknown>;
+
+export async function expectJsonStatus(response: Response, expectedStatus: number): Promise<JsonRecord> {
+  const body = await response.json() as JsonRecord;
+  expect(response.status, `expected HTTP ${expectedStatus}`).toBe(expectedStatus);
+  return body;
+}
+
+export function expectObjectKeys(body: JsonRecord, keys: string[]): void {
+  for (const key of keys) {
+    expect(body, `missing key '${key}'`).toHaveProperty(key);
+  }
+}
+
+export async function expectErrorResponse(
+  response: Response,
+  expectedStatus: number,
+  opts: { errorEquals?: string; errorMatches?: RegExp } = {}
+): Promise<JsonRecord> {
+  const body = await expectJsonStatus(response, expectedStatus);
+  expectObjectKeys(body, ["error"]);
+  if (opts.errorEquals) {
+    expect(body.error).toBe(opts.errorEquals);
+  }
+  if (opts.errorMatches) {
+    expect(String(body.error)).toMatch(opts.errorMatches);
+  }
+  return body;
+}
+
+export async function expectAuthFailure(response: Response): Promise<void> {
+  const body = await expectErrorResponse(response, 401);
+  expect(typeof body.error).toBe("string");
+  expect(String(body.error)).toMatch(/auth/i);
+}
+
+export function expectType(value: unknown, expectedType: "string" | "number" | "boolean", label: string): void {
+  expect(typeof value, `${label} should be ${expectedType}`).toBe(expectedType);
+}
+
+export function expectNullableType(
+  value: unknown,
+  expectedType: "string" | "number" | "boolean",
+  label: string,
+): void {
+  if (value === null) return;
+  expectType(value, expectedType, label);
+}
+
+export function expectBoolean(value: unknown, label: string): void {
+  expectType(value, "boolean", label);
+}

--- a/packages/server/tests/contract/auth.contract.test.ts
+++ b/packages/server/tests/contract/auth.contract.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createContractTestApp } from "./test-app.js";
+import {
+  expectAuthFailure,
+  expectBoolean,
+  expectErrorResponse,
+  expectJsonStatus,
+  expectNullableType,
+  expectObjectKeys,
+  expectType,
+} from "./assertions.js";
+import { sanitizeForContractSnapshot } from "./sanitize.js";
+
+describe("auth route contract", () => {
+  beforeEach(() => {
+    process.env.OPEN_REGISTRATIONS = "true";
+  });
+
+  it("POST /register succeeds for valid registration", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/auth/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        username: "contract_auth_register_ok",
+        email: "contract_auth_register_ok@example.com",
+        password: "long-enough-password",
+        city: "Vienna",
+        cityLat: 48.2,
+        cityLng: 16.37,
+      }),
+    });
+
+    const body = await expectJsonStatus(res, 201);
+    expectObjectKeys(body, ["requiresVerification", "email"]);
+    expect(sanitizeForContractSnapshot(body)).toMatchInlineSnapshot(`
+      {
+        "email": "contract_auth_register_ok@example.com",
+        "requiresVerification": true,
+      }
+    `);
+  });
+
+  it("POST /register rejects isBot mutation attempt", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/auth/register", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ username: "contract_bot", isBot: true }),
+    });
+
+    await expectErrorResponse(res, 400, { errorEquals: "common.requestFailed" });
+  });
+
+  it("POST /login returns 400 for malformed JSON", async () => {
+    const { app, seedUser } = createContractTestApp();
+    seedUser({ username: "contract_login_user", password: "pw" });
+    const res = await app.request("http://localhost/api/v1/auth/login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    await expectErrorResponse(res, 400);
+  });
+
+  it("GET /me requires auth", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/auth/me");
+    await expectAuthFailure(res);
+  });
+
+  it("GET /me returns stable schema invariants when authenticated", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ username: "contract_me_user" });
+    const authApp = fixture.asUser(user);
+    const res = await authApp.request("http://localhost/api/v1/auth/me");
+
+    const body = await expectJsonStatus(res, 200);
+    expectObjectKeys(body, [
+      "id",
+      "username",
+      "displayName",
+      "emailVerified",
+      "notificationPrefs",
+      "isBot",
+      "discoverable",
+      "timezone",
+      "dateTimeLocale",
+      "themePreference",
+      "followingCount",
+      "followersCount",
+    ]);
+    expectType(body.id, "string", "id");
+    expectType(body.username, "string", "username");
+    expectNullableType(body.displayName, "string", "displayName");
+    expectNullableType(body.bio, "string", "bio");
+    expectNullableType(body.avatarUrl, "string", "avatarUrl");
+    expectNullableType(body.website, "string", "website");
+    expectNullableType(body.city, "string", "city");
+    expectNullableType(body.cityLat, "number", "cityLat");
+    expectNullableType(body.cityLng, "number", "cityLng");
+    expectNullableType(body.email, "string", "email");
+    expectType(body.createdAt, "string", "createdAt");
+
+    expectBoolean(body.isBot, "isBot");
+    expectBoolean(body.discoverable, "discoverable");
+    expectBoolean(body.emailVerified, "emailVerified");
+    expectType(body.followingCount, "number", "followingCount");
+    expectType(body.followersCount, "number", "followersCount");
+
+    expectType(body.timezone, "string", "timezone");
+    expect((body.timezone as string).length).toBeGreaterThan(0);
+    expectType(body.dateTimeLocale, "string", "dateTimeLocale");
+    expect((body.dateTimeLocale as string).length).toBeGreaterThan(0);
+    expectType(body.themePreference, "string", "themePreference");
+    expect((body.themePreference as string).length).toBeGreaterThan(0);
+
+    const prefs = body.notificationPrefs as Record<string, unknown>;
+    expectObjectKeys(prefs, [
+      "reminderEnabled",
+      "reminderHoursBefore",
+      "eventUpdatedEnabled",
+      "eventCancelledEnabled",
+      "onboardingCompleted",
+    ]);
+    expectBoolean(prefs.reminderEnabled, "notificationPrefs.reminderEnabled");
+    expectType(prefs.reminderHoursBefore, "number", "notificationPrefs.reminderHoursBefore");
+    expectBoolean(prefs.eventUpdatedEnabled, "notificationPrefs.eventUpdatedEnabled");
+    expectBoolean(prefs.eventCancelledEnabled, "notificationPrefs.eventCancelledEnabled");
+    expectBoolean(prefs.onboardingCompleted, "notificationPrefs.onboardingCompleted");
+  });
+
+  it("PATCH /me updates profile but does not mutate is_bot", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ id: "u_patch", username: "contract_patch" });
+    const authApp = fixture.asUser(user);
+
+    const res = await authApp.request("http://localhost/api/v1/auth/me", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ displayName: "Updated Contract", isBot: true }),
+    });
+    await expectJsonStatus(res, 200);
+
+    const row = fixture.db.prepare("SELECT is_bot, display_name FROM accounts WHERE id = ?").get("u_patch") as {
+      is_bot: number;
+      display_name: string;
+    };
+    expect(row.display_name).toBe("Updated Contract");
+    expect(row.is_bot).toBe(0);
+  });
+});

--- a/packages/server/tests/contract/events.contract.test.ts
+++ b/packages/server/tests/contract/events.contract.test.ts
@@ -1,0 +1,372 @@
+import { describe, expect, it } from "vitest";
+import { createContractTestApp } from "./test-app.js";
+import { expectAuthFailure, expectErrorResponse, expectJsonStatus, expectObjectKeys } from "./assertions.js";
+import { sanitizeForContractSnapshot } from "./sanitize.js";
+
+function buildValidCreatePayload() {
+  return {
+    title: "Contract Event Create",
+    startDate: "2026-07-20",
+    eventTimezone: "UTC",
+    allDay: true,
+    visibility: "public",
+    url: "https://example.com/events/contract",
+  };
+}
+
+describe("events route contract", () => {
+  it("GET /events returns shape with events array and cursor semantics", async () => {
+    const fixture = createContractTestApp();
+    const owner = fixture.seedUser({ id: "u_event_owner", username: "events_owner" });
+    fixture.seedEvent({
+      id: "e_contract_1",
+      accountId: owner.id,
+      slug: "e-contract-1",
+      title: "Contract Event 1",
+      startDate: "2026-01-01",
+      startAtUtc: "2026-01-01T00:00:00.000Z",
+    });
+
+    const res = await fixture.app.request("http://localhost/api/v1/events?limit=2");
+    const body = await expectJsonStatus(res, 200) as { events?: unknown[]; nextCursor?: unknown };
+
+    expect(Array.isArray(body.events)).toBe(true);
+    expect(body.events?.length).toBeGreaterThan(0);
+    expect(body.nextCursor === null || typeof body.nextCursor === "string").toBe(true);
+    const firstEvent = body.events?.[0] as Record<string, unknown>;
+    expectObjectKeys(firstEvent, ["id", "slug", "title", "startDate", "startAtUtc", "visibility", "account"]);
+    expect(sanitizeForContractSnapshot(firstEvent)).toMatchInlineSnapshot(`
+      {
+        "account": {
+          "displayName": null,
+          "username": "events_owner",
+        },
+        "accountId": "<redacted>",
+        "allDay": true,
+        "canceled": false,
+        "createdAt": "<redacted>",
+        "description": null,
+        "endDate": null,
+        "eventTimezone": "UTC",
+        "id": "<redacted>",
+        "image": null,
+        "location": null,
+        "ogImageUrl": null,
+        "slug": "e-contract-1",
+        "source": "local",
+        "startAtUtc": "<redacted>",
+        "startDate": "2026-01-01",
+        "tags": [],
+        "timezoneQuality": "exact_tzid",
+        "title": "Contract Event 1",
+        "updatedAt": "<redacted>",
+        "url": null,
+        "visibility": "public",
+      }
+    `);
+  });
+
+  it("GET /events rejects invalid cursor", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/events?cursor=invalid");
+    await expectErrorResponse(res, 400, { errorMatches: /cursor/i });
+  });
+
+  it("GET /events/timeline requires auth", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/events/timeline");
+    await expectAuthFailure(res);
+  });
+
+  it("GET /events/timeline rejects malformed cursor", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ id: "u_timeline_cursor", username: "timeline_cursor_user" });
+    const authApp = fixture.asUser(user);
+
+    const res = await authApp.request("http://localhost/api/v1/events/timeline?cursor=invalid");
+    await expectErrorResponse(res, 400, { errorMatches: /cursor/i });
+  });
+
+  it("POST /events/rsvp returns 400 for malformed JSON", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ id: "u_rsvp", username: "contract_rsvp" });
+    const authApp = fixture.asUser(user);
+
+    const res = await authApp.request("http://localhost/api/v1/events/rsvp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    await expectErrorResponse(res, 400);
+  });
+
+  it("POST /events requires auth", async () => {
+    const { app } = createContractTestApp();
+    const res = await app.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Unauthorized event" }),
+    });
+    await expectAuthFailure(res);
+  });
+
+  it("POST /events returns 400 for malformed JSON", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ id: "u_create_bad_json", username: "create_bad_json" });
+    const authApp = fixture.asUser(user);
+    const res = await authApp.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    await expectErrorResponse(res, 400);
+  });
+
+  it("POST /events rejects invalid create payload classes", async () => {
+    const fixture = createContractTestApp();
+    const user = fixture.seedUser({ id: "u_create_matrix", username: "create_matrix" });
+    const authApp = fixture.asUser(user);
+
+    const cases: Array<{
+      name: string;
+      payload: Record<string, unknown>;
+      status: number;
+      errorPattern: RegExp;
+    }> = [
+      {
+        name: "missing title",
+        payload: { startDate: "2026-07-20", eventTimezone: "UTC" },
+        status: 400,
+        errorPattern: /title|start/i,
+      },
+      {
+        name: "missing date/dateTime",
+        payload: { title: "No date", eventTimezone: "UTC" },
+        status: 400,
+        errorPattern: /title|start/i,
+      },
+      {
+        name: "startDate wrong type",
+        payload: { ...buildValidCreatePayload(), startDate: 123 },
+        status: 400,
+        errorPattern: /title|start/i,
+      },
+      {
+        name: "eventTimezone wrong type",
+        payload: { ...buildValidCreatePayload(), eventTimezone: 123 },
+        status: 400,
+        errorPattern: /timezone/i,
+      },
+      {
+        name: "invalid timezone",
+        payload: { ...buildValidCreatePayload(), eventTimezone: "Mars/Olympus" },
+        status: 400,
+        errorPattern: /timezone/i,
+      },
+      {
+        name: "invalid visibility",
+        payload: { ...buildValidCreatePayload(), visibility: "team_only" },
+        status: 400,
+        errorPattern: /visibility/i,
+      },
+      {
+        name: "allDay with startDateTime",
+        payload: { ...buildValidCreatePayload(), startDateTime: "2026-07-20T12:00:00.000Z" },
+        status: 400,
+        errorPattern: /date|time/i,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const res = await authApp.request("http://localhost/api/v1/events", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(testCase.payload),
+      });
+      await expectErrorResponse(res, testCase.status, { errorMatches: testCase.errorPattern });
+    }
+  });
+
+  it("PUT /events/:id returns 400 for malformed JSON", async () => {
+    const fixture = createContractTestApp();
+    const owner = fixture.seedUser({ id: "u_update_bad_json", username: "update_bad_json" });
+    const event = fixture.seedEvent({
+      id: "e_update_bad_json",
+      accountId: owner.id,
+      slug: "update-bad-json",
+      title: "Update bad json",
+      startDate: "2026-07-21",
+      startAtUtc: "2026-07-21T00:00:00.000Z",
+    });
+    const authApp = fixture.asUser(owner);
+    const res = await authApp.request(`http://localhost/api/v1/events/${event.id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: "{",
+    });
+
+    await expectErrorResponse(res, 400);
+  });
+
+  it("PUT /events/:id rejects invalid update payload classes", async () => {
+    const fixture = createContractTestApp();
+    const owner = fixture.seedUser({ id: "u_update_matrix", username: "update_matrix" });
+    const event = fixture.seedEvent({
+      id: "e_update_matrix",
+      accountId: owner.id,
+      slug: "update-matrix",
+      title: "Update matrix",
+      startDate: "2026-07-22",
+      startAtUtc: "2026-07-22T00:00:00.000Z",
+    });
+    const authApp = fixture.asUser(owner);
+
+    const cases: Array<{
+      name: string;
+      payload: Record<string, unknown>;
+      status: number;
+      errorPattern: RegExp;
+    }> = [
+      {
+        name: "title wrong type",
+        payload: { title: 100 },
+        status: 400,
+        errorPattern: /request/i,
+      },
+      {
+        name: "eventTimezone wrong type",
+        payload: { eventTimezone: 123 },
+        status: 400,
+        errorPattern: /request/i,
+      },
+      {
+        name: "invalid timezone value",
+        payload: { eventTimezone: "Invalid/Zone" },
+        status: 400,
+        errorPattern: /request/i,
+      },
+      {
+        name: "invalid visibility",
+        payload: { visibility: "org-only" },
+        status: 400,
+        errorPattern: /visibility/i,
+      },
+      {
+        name: "allDay wrong type",
+        payload: { allDay: "true" },
+        status: 400,
+        errorPattern: /date|time|request/i,
+      },
+      {
+        name: "partial temporal update with invalid type",
+        payload: { startDate: "2026-08-01", endDate: 123 },
+        status: 400,
+        errorPattern: /date|time|request/i,
+      },
+      {
+        name: "allDay with startDateTime",
+        payload: { allDay: true, startDateTime: "2026-08-01T09:30:00.000Z" },
+        status: 400,
+        errorPattern: /date|time/i,
+      },
+    ];
+
+    for (const testCase of cases) {
+      const res = await authApp.request(`http://localhost/api/v1/events/${event.id}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(testCase.payload),
+      });
+      await expectErrorResponse(res, testCase.status, { errorMatches: testCase.errorPattern });
+    }
+  });
+
+  it("POST then PUT preserves key invariants and persists critical fields", async () => {
+    const fixture = createContractTestApp();
+    const owner = fixture.seedUser({ id: "u_create_update", username: "create_update" });
+    const authApp = fixture.asUser(owner);
+
+    const createRes = await authApp.request("http://localhost/api/v1/events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Contract Created Event",
+        startDate: "2026-09-01",
+        endDate: "2026-09-02",
+        eventTimezone: "Europe/Vienna",
+        allDay: true,
+        visibility: "public",
+      }),
+    });
+    const created = await expectJsonStatus(createRes, 201);
+    expectObjectKeys(created, ["id", "title", "startDate", "eventTimezone", "visibility", "accountId"]);
+    expect(created.title).toBe("Contract Created Event");
+    expect(created.startDate).toBe("2026-09-01");
+    expect(created.eventTimezone).toBe("Europe/Vienna");
+    expect(created.visibility).toBe("public");
+
+    const createdId = String(created.id);
+    const before = fixture.db
+      .prepare("SELECT account_id, created_by_account_id, title, visibility, event_timezone FROM events WHERE id = ?")
+      .get(createdId) as {
+      account_id: string;
+      created_by_account_id: string;
+      title: string;
+      visibility: string;
+      event_timezone: string;
+    };
+    expect(before.account_id).toBe(owner.id);
+    expect(before.created_by_account_id).toBe(owner.id);
+
+    const updateRes = await authApp.request(`http://localhost/api/v1/events/${createdId}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        title: "Contract Updated Event",
+        visibility: "private",
+        eventTimezone: "UTC",
+      }),
+    });
+    const updated = await expectJsonStatus(updateRes, 200);
+    expectObjectKeys(updated, ["id", "title", "eventTimezone", "visibility", "accountId"]);
+    expect(updated.id).toBe(createdId);
+    expect(updated.title).toBe("Contract Updated Event");
+    expect(updated.eventTimezone).toBe("UTC");
+    expect(updated.visibility).toBe("private");
+
+    const after = fixture.db
+      .prepare("SELECT account_id, created_by_account_id, title, visibility, event_timezone FROM events WHERE id = ?")
+      .get(createdId) as {
+      account_id: string;
+      created_by_account_id: string;
+      title: string;
+      visibility: string;
+      event_timezone: string;
+    };
+    expect(after.title).toBe("Contract Updated Event");
+    expect(after.visibility).toBe("private");
+    expect(after.event_timezone).toBe("UTC");
+    expect(after.account_id).toBe(owner.id);
+    expect(after.created_by_account_id).toBe(owner.id);
+  });
+
+  it("DELETE /events/:id requires auth", async () => {
+    const fixture = createContractTestApp();
+    const owner = fixture.seedUser({ id: "u_delete_owner", username: "delete_owner" });
+    const event = fixture.seedEvent({
+      id: "e_delete_target",
+      accountId: owner.id,
+      slug: "delete-target",
+      title: "Delete target",
+      startDate: "2026-04-01",
+      startAtUtc: "2026-04-01T00:00:00.000Z",
+    });
+
+    const res = await fixture.app.request(`http://localhost/api/v1/events/${event.id}`, {
+      method: "DELETE",
+    });
+    await expectAuthFailure(res);
+  });
+});

--- a/packages/server/tests/contract/events.contract.test.ts
+++ b/packages/server/tests/contract/events.contract.test.ts
@@ -1,7 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { createContractTestApp } from "./test-app.js";
 import { expectAuthFailure, expectErrorResponse, expectJsonStatus, expectObjectKeys } from "./assertions.js";
 import { sanitizeForContractSnapshot } from "./sanitize.js";
+
+const previousOgDir = process.env.OG_DIR;
+let contractOgDir: string;
+
+beforeAll(async () => {
+  contractOgDir = await mkdtemp(join(tmpdir(), "everycal-contract-og-"));
+  process.env.OG_DIR = contractOgDir;
+});
+
+afterAll(async () => {
+  if (previousOgDir === undefined) {
+    delete process.env.OG_DIR;
+  } else {
+    process.env.OG_DIR = previousOgDir;
+  }
+  if (contractOgDir) {
+    await rm(contractOgDir, { recursive: true, force: true });
+  }
+});
 
 function buildValidCreatePayload() {
   return {

--- a/packages/server/tests/contract/route-wiring.contract.test.ts
+++ b/packages/server/tests/contract/route-wiring.contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { createContractTestApp } from "./test-app.js";
+
+type Probe = {
+  method: string;
+  path: string;
+  wrongMethod: string;
+  label: string;
+  allowedWrongStatuses?: number[];
+};
+
+async function expectRouteWired(probe: Probe): Promise<void> {
+  const fixture = createContractTestApp();
+  const app = fixture.app;
+  const url = `http://localhost${probe.path}`;
+
+  const init = probe.method === "POST" || probe.method === "PATCH" || probe.method === "PUT"
+    ? { method: probe.method, headers: { "content-type": "application/json" }, body: "{}" }
+    : { method: probe.method };
+  const expectedMethodRes = await app.request(url, init);
+  expect(
+    expectedMethodRes.status,
+    `${probe.label}: expected ${probe.method} ${probe.path} to be a registered route (should not be 404)`,
+  ).not.toBe(404);
+
+  const wrongInit = probe.wrongMethod === "POST" || probe.wrongMethod === "PATCH" || probe.wrongMethod === "PUT"
+    ? { method: probe.wrongMethod, headers: { "content-type": "application/json" }, body: "{}" }
+    : { method: probe.wrongMethod };
+  const wrongMethodRes = await app.request(url, wrongInit);
+  const expectedWrongStatuses = probe.allowedWrongStatuses ?? [404, 405];
+  expect(
+    expectedWrongStatuses,
+    `${probe.label}: expected ${probe.wrongMethod} ${probe.path} to fail as wrong method`,
+  ).toContain(wrongMethodRes.status);
+}
+
+describe("route wiring contract", () => {
+  it("auth routes are mounted with expected methods", async () => {
+    process.env.OPEN_REGISTRATIONS = "true";
+    const probes: Probe[] = [
+      { method: "POST", path: "/api/v1/auth/register", wrongMethod: "GET", label: "auth register" },
+      { method: "POST", path: "/api/v1/auth/login", wrongMethod: "GET", label: "auth login" },
+      { method: "GET", path: "/api/v1/auth/me", wrongMethod: "POST", label: "auth me read" },
+      {
+        method: "PATCH",
+        path: "/api/v1/auth/me",
+        wrongMethod: "DELETE",
+        label: "auth me update",
+        allowedWrongStatuses: [401, 404, 405],
+      },
+    ];
+
+    for (const probe of probes) {
+      await expectRouteWired(probe);
+    }
+  });
+
+  it("events routes are mounted with expected methods", async () => {
+    const probes: Probe[] = [
+      { method: "GET", path: "/api/v1/events", wrongMethod: "PATCH", label: "events list" },
+      { method: "GET", path: "/api/v1/events/timeline", wrongMethod: "PATCH", label: "events timeline" },
+      { method: "POST", path: "/api/v1/events", wrongMethod: "PATCH", label: "events create" },
+      { method: "POST", path: "/api/v1/events/rsvp", wrongMethod: "GET", label: "events rsvp" },
+      { method: "DELETE", path: "/api/v1/events/e_contract_wire", wrongMethod: "PATCH", label: "events delete" },
+    ];
+
+    for (const probe of probes) {
+      await expectRouteWired(probe);
+    }
+  });
+});

--- a/packages/server/tests/contract/route-wiring.contract.test.ts
+++ b/packages/server/tests/contract/route-wiring.contract.test.ts
@@ -43,16 +43,17 @@ describe("route wiring contract", () => {
       {
         method: "PATCH",
         path: "/api/v1/auth/me",
-        wrongMethod: "DELETE",
+        wrongMethod: "PUT",
         label: "auth me update",
-        allowedWrongStatuses: [401, 404, 405],
       },
     ];
 
     const fixture = createContractTestApp();
+    const user = fixture.seedUser();
+    const authApp = fixture.asUser(user);
 
     for (const probe of probes) {
-      await expectRouteWired(fixture.app, probe);
+      await expectRouteWired(authApp, probe);
     }
   });
 

--- a/packages/server/tests/contract/route-wiring.contract.test.ts
+++ b/packages/server/tests/contract/route-wiring.contract.test.ts
@@ -1,3 +1,4 @@
+import { type Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { createContractTestApp } from "./test-app.js";
 
@@ -9,9 +10,7 @@ type Probe = {
   allowedWrongStatuses?: number[];
 };
 
-async function expectRouteWired(probe: Probe): Promise<void> {
-  const fixture = createContractTestApp();
-  const app = fixture.app;
+async function expectRouteWired(app: Hono, probe: Probe): Promise<void> {
   const url = `http://localhost${probe.path}`;
 
   const init = probe.method === "POST" || probe.method === "PATCH" || probe.method === "PUT"
@@ -50,8 +49,10 @@ describe("route wiring contract", () => {
       },
     ];
 
+    const fixture = createContractTestApp();
+
     for (const probe of probes) {
-      await expectRouteWired(probe);
+      await expectRouteWired(fixture.app, probe);
     }
   });
 
@@ -64,8 +65,10 @@ describe("route wiring contract", () => {
       { method: "DELETE", path: "/api/v1/events/e_contract_wire", wrongMethod: "PATCH", label: "events delete" },
     ];
 
+    const fixture = createContractTestApp();
+
     for (const probe of probes) {
-      await expectRouteWired(probe);
+      await expectRouteWired(fixture.app, probe);
     }
   });
 });

--- a/packages/server/tests/contract/sanitize.ts
+++ b/packages/server/tests/contract/sanitize.ts
@@ -1,0 +1,22 @@
+type JsonValue = null | boolean | number | string | JsonValue[] | { [k: string]: JsonValue };
+
+const VOLATILE_KEY = /(id|token|secret|hash|createdAt|updatedAt|expiresAt|atUtc|timestamp)$/i;
+
+export function sanitizeForContractSnapshot<T>(value: T): T {
+  return sanitizeValue(value) as T;
+}
+
+function sanitizeValue(value: unknown): JsonValue {
+  if (value === null) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
+  if (Array.isArray(value)) return value.map((entry) => sanitizeValue(entry));
+  if (typeof value !== "object") return String(value);
+
+  const entries = Object.entries(value as Record<string, unknown>).map(([key, entry]) => {
+    if (VOLATILE_KEY.test(key)) {
+      return [key, "<redacted>"];
+    }
+    return [key, sanitizeValue(entry)];
+  });
+  return Object.fromEntries(entries) as JsonValue;
+}

--- a/packages/server/tests/contract/test-app.ts
+++ b/packages/server/tests/contract/test-app.ts
@@ -1,0 +1,89 @@
+import { Hono } from "hono";
+import { initDatabase, type DB } from "../../src/db.js";
+import { authRoutes } from "../../src/routes/auth.js";
+import { eventRoutes } from "../../src/routes/events.js";
+import { hashPassword } from "../../src/middleware/auth.js";
+
+export type AuthUserContext = { id: string; username: string };
+
+export type ContractTestApp = {
+  app: Hono;
+  db: DB;
+  asUser: (user: AuthUserContext | null) => Hono;
+  seedUser: (overrides?: Partial<SeedUserInput>) => AuthUserContext;
+  seedEvent: (input: SeedEventInput) => { id: string };
+};
+
+type SeedUserInput = {
+  id: string;
+  username: string;
+  email: string | null;
+  emailVerified: number;
+  isBot: number;
+  password: string | null;
+};
+
+type SeedEventInput = {
+  id: string;
+  accountId: string;
+  slug: string;
+  title: string;
+  startDate: string;
+  startAtUtc: string;
+};
+
+function createMountedApp(db: DB, user: AuthUserContext | null = null): Hono {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    if (user) c.set("user", user);
+    await next();
+  });
+  app.route("/api/v1/auth", authRoutes(db));
+  app.route("/api/v1/events", eventRoutes(db));
+  return app;
+}
+
+export function createContractTestApp(user: AuthUserContext | null = null): ContractTestApp {
+  const db = initDatabase(":memory:");
+  let userCounter = 0;
+
+  const seedUser = (overrides: Partial<SeedUserInput> = {}): AuthUserContext => {
+    userCounter += 1;
+    const id = overrides.id ?? `u${userCounter}`;
+    const username = overrides.username ?? `user_${userCounter}`;
+    const email = overrides.email === undefined ? `${username}@example.com` : overrides.email;
+    const emailVerified = overrides.emailVerified ?? 1;
+    const isBot = overrides.isBot ?? 0;
+    const password = overrides.password === undefined ? "pw" : overrides.password;
+    const passwordHash = password ? hashPassword(password) : null;
+
+    db.prepare(
+      "INSERT INTO accounts (id, username, password_hash, email, email_verified, is_bot) VALUES (?, ?, ?, ?, ?, ?)"
+    ).run(id, username, passwordHash, email, emailVerified, isBot);
+
+    db.prepare(
+      `INSERT OR IGNORE INTO account_notification_prefs (
+        account_id, reminder_enabled, reminder_hours_before, event_updated_enabled, event_cancelled_enabled
+      ) VALUES (?, 1, 24, 1, 1)`
+    ).run(id);
+
+    return { id, username };
+  };
+
+  const seedEvent = (input: SeedEventInput): { id: string } => {
+    db.prepare(
+      `INSERT INTO events (
+        id, account_id, slug, title, start_date, start_at_utc, event_timezone, all_day, visibility
+      ) VALUES (?, ?, ?, ?, ?, ?, 'UTC', 1, 'public')`
+    ).run(input.id, input.accountId, input.slug, input.title, input.startDate, input.startAtUtc);
+    return { id: input.id };
+  };
+
+  return {
+    app: createMountedApp(db, user),
+    db,
+    asUser: (nextUser: AuthUserContext | null) => createMountedApp(db, nextUser),
+    seedUser,
+    seedEvent,
+  };
+}

--- a/packages/server/tests/serve-og-images-routes.test.ts
+++ b/packages/server/tests/serve-og-images-routes.test.ts
@@ -5,15 +5,9 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 
 async function makeApp(ogDir: string): Promise<Hono> {
-  const previousOgDir = process.env.OG_DIR;
   process.env.OG_DIR = ogDir;
   vi.resetModules();
   const { serveOgImagesRoutes } = await import("../src/routes/serve-og-images.js");
-  if (previousOgDir === undefined) {
-    delete process.env.OG_DIR;
-  } else {
-    process.env.OG_DIR = previousOgDir;
-  }
 
   const app = new Hono();
   app.route("/og-images", serveOgImagesRoutes());
@@ -23,8 +17,10 @@ async function makeApp(ogDir: string): Promise<Hono> {
 describe("serveOgImagesRoutes", () => {
   let ogDir: string;
   let maliciousSiblingDir: string | null;
+  let previousOgDir: string | undefined;
 
   beforeEach(() => {
+    previousOgDir = process.env.OG_DIR;
     ogDir = mkdtempSync(join(tmpdir(), "everycal-og-test-"));
     maliciousSiblingDir = null;
   });
@@ -33,6 +29,11 @@ describe("serveOgImagesRoutes", () => {
     rmSync(ogDir, { recursive: true, force: true });
     if (maliciousSiblingDir) {
       rmSync(maliciousSiblingDir, { recursive: true, force: true });
+    }
+    if (previousOgDir === undefined) {
+      delete process.env.OG_DIR;
+    } else {
+      process.env.OG_DIR = previousOgDir;
     }
   });
 


### PR DESCRIPTION
## Summary
- add explicit contract wiring probes for required auth/events endpoints to catch route registration or method drift
- expand contract coverage with table-driven event create/update validation matrices, malformed JSON checks, and timeline malformed-cursor assertions
- strengthen authenticated `/api/v1/auth/me` contracts from key presence to schema/type invariants with reusable assertion helpers

## Validation
- pnpm lint
- pnpm test
- pnpm --filter @everycal/server test -- "tests/contract/**/*.test.ts"
- pnpm --filter @everycal/server test