### PR TITLE
fix(scrapers): validate configured API keys

### DIFF
--- a/packages/scrapers/package.json
+++ b/packages/scrapers/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "scrape": "tsx src/cli.ts",
-    "test": "vitest run",
+    "test": "pnpm --filter @everycal/core build && vitest run",
     "lint": "tsc -b --pretty false"
   },
   "dependencies": {

--- a/packages/scrapers/src/lib/select-run-scrapers.ts
+++ b/packages/scrapers/src/lib/select-run-scrapers.ts
@@ -1,0 +1,10 @@
+import type { Scraper } from "../scraper.js";
+
+export function selectRunScrapers(options: {
+  requestedScrapers: Scraper[] | null;
+  registry: Scraper[];
+  apiKeys: Record<string, string>;
+}): Scraper[] {
+  if (options.requestedScrapers) return options.requestedScrapers;
+  return options.registry.filter((scraper) => options.apiKeys[scraper.id]);
+}

--- a/packages/scrapers/src/run.test.ts
+++ b/packages/scrapers/src/run.test.ts
@@ -2,6 +2,8 @@ import { spawn } from "node:child_process";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { registry } from "./registry.js";
+import { selectRunScrapers } from "./lib/select-run-scrapers.js";
 
 const packageDir = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 
@@ -32,6 +34,34 @@ function runScraper(env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdo
 }
 
 describe("scraper runner", () => {
+  it("defaults to configured scrapers when SCRAPER_IDS is unset", () => {
+    const scrapers = selectRunScrapers({
+      requestedScrapers: null,
+      registry,
+      apiKeys: {
+        critical_mass_vienna: "test-key-1",
+        flex_at: "test-key-2",
+        unrelated: "ignored",
+      },
+    });
+
+    expect(scrapers.map((scraper) => scraper.id)).toEqual(["flex_at", "critical_mass_vienna"]);
+  });
+
+  it("keeps explicit scraper requests strict even when other keys exist", () => {
+    const requestedScrapers = [registry.find((scraper) => scraper.id === "radlobby_wien")!];
+
+    const scrapers = selectRunScrapers({
+      requestedScrapers,
+      registry,
+      apiKeys: {
+        flex_at: "test-key",
+      },
+    });
+
+    expect(scrapers.map((scraper) => scraper.id)).toEqual(["radlobby_wien"]);
+  });
+
   it("fails when the configured API key file is missing", async () => {
     const result = await runScraper({
       SCRAPER_API_KEYS_FILE: resolve(packageDir, "missing-scraper-api-keys.json"),
@@ -54,17 +84,5 @@ describe("scraper runner", () => {
     expect(result.code).toBe(1);
     expect(result.stdout).toBe("");
     expect(result.stderr).toContain("Missing scraper API key(s) for: flex_at");
-  });
-
-  it("fails when running all scrapers and configured API keys do not cover the registry", async () => {
-    const result = await runScraper({
-      SCRAPER_API_KEYS_JSON: JSON.stringify({ flex_at: "test-key" }),
-      JOBS_API_SERVER: "http://localhost:3000",
-    });
-
-    expect(result.code).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("Missing scraper API key(s) for:");
-    expect(result.stderr).toContain("critical_mass_vienna");
   });
 });

--- a/packages/scrapers/src/run.test.ts
+++ b/packages/scrapers/src/run.test.ts
@@ -1,0 +1,70 @@
+import { spawn } from "node:child_process";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const packageDir = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
+
+function runScraper(env: NodeJS.ProcessEnv): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, ["--import", "tsx", "src/run.ts"], {
+      cwd: packageDir,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolvePromise({ code, stdout, stderr });
+    });
+  });
+}
+
+describe("scraper runner", () => {
+  it("fails when the configured API key file is missing", async () => {
+    const result = await runScraper({
+      SCRAPER_API_KEYS_FILE: resolve(packageDir, "missing-scraper-api-keys.json"),
+      JOBS_API_SERVER: "http://localhost:3000",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("SCRAPER_API_KEYS_FILE");
+    expect(result.stderr).toContain("not found");
+  });
+
+  it("fails when a requested scraper key is missing from configured API keys", async () => {
+    const result = await runScraper({
+      SCRAPER_API_KEYS_JSON: JSON.stringify({ unrelated: "test-key" }),
+      SCRAPER_IDS: "flex_at",
+      JOBS_API_SERVER: "http://localhost:3000",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Missing scraper API key(s) for: flex_at");
+  });
+
+  it("fails when running all scrapers and configured API keys do not cover the registry", async () => {
+    const result = await runScraper({
+      SCRAPER_API_KEYS_JSON: JSON.stringify({ flex_at: "test-key" }),
+      JOBS_API_SERVER: "http://localhost:3000",
+    });
+
+    expect(result.code).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Missing scraper API key(s) for:");
+    expect(result.stderr).toContain("critical_mass_vienna");
+  });
+});

--- a/packages/scrapers/src/run.ts
+++ b/packages/scrapers/src/run.ts
@@ -20,6 +20,7 @@ import { getScraperById, registry } from "./registry.js";
 import type { Scraper } from "./scraper.js";
 import type { EveryCalEvent } from "@everycal/core";
 import { buildSyncPayload } from "./lib/build-sync-payload.js";
+import { selectRunScrapers } from "./lib/select-run-scrapers.js";
 
 const CONCURRENCY = parseInt(process.env.SCRAPE_CONCURRENCY || "6", 10);
 const DRY_RUN = process.env.SCRAPER_DRY_RUN === "true";
@@ -139,7 +140,11 @@ async function main() {
 
   const server = requireEnv("JOBS_API_SERVER");
 
-  const candidateScrapers = requestedScrapers ?? registry;
+  const candidateScrapers = selectRunScrapers({
+    requestedScrapers,
+    registry,
+    apiKeys,
+  });
   const missingKeys = candidateScrapers.filter((scraper) => !apiKeys[scraper.id]).map((scraper) => scraper.id);
   if (missingKeys.length > 0) {
     console.error(`❌ Missing scraper API key(s) for: ${missingKeys.join(", ")}`);

--- a/packages/scrapers/src/run.ts
+++ b/packages/scrapers/src/run.ts
@@ -140,14 +140,14 @@ async function main() {
   const server = requireEnv("JOBS_API_SERVER");
 
   const candidateScrapers = requestedScrapers ?? registry;
-  // Only run scrapers that have API keys configured
-  const scrapers = candidateScrapers.filter((s) => apiKeys[s.id]);
-  const skipped = candidateScrapers.filter((s) => !apiKeys[s.id]);
-
-  if (scrapers.length === 0) {
-    console.log("⏭️  Scrapers skipped: no matching API keys in config");
-    return;
+  const missingKeys = candidateScrapers.filter((scraper) => !apiKeys[scraper.id]).map((scraper) => scraper.id);
+  if (missingKeys.length > 0) {
+    console.error(`❌ Missing scraper API key(s) for: ${missingKeys.join(", ")}`);
+    process.exit(1);
   }
+
+  const scrapers = candidateScrapers;
+  const skipped: Scraper[] = [];
 
   console.log(`🗓️  EveryCal Scraper Run — ${new Date().toISOString()}`);
   console.log(`   Server: ${server}`);

--- a/packages/server/src/lib/admin-jobs.ts
+++ b/packages/server/src/lib/admin-jobs.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, resolve } from "node:path";
 import { toErrorMessage } from "@everycal/core";
 import { fileURLToPath } from "node:url";
 import type { DB } from "../db.js";
@@ -11,6 +11,7 @@ const SCRAPER_OUTPUT_MAX_BYTES = 1024 * 1024;
 const ADMIN_JOB_INTERVAL_MS_DEFAULT = 5000;
 const adminJobQueueRuns = new WeakMap<DB, Promise<{ processed: number; succeeded: number; failed: number }>>();
 const serverLibDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(serverLibDir, "../../../..");
 const scraperScriptPath = resolve(serverLibDir, "../../../scrapers/dist/run.js");
 
 export type AdminJobPayload = {
@@ -72,6 +73,9 @@ export async function executeScraperAdminJob(job: AdminJob): Promise<Record<stri
     ...process.env,
     SCRAPER_DRY_RUN: job.payload.dryRun ? "true" : "false",
   };
+  if (env.SCRAPER_API_KEYS_FILE && !isAbsolute(env.SCRAPER_API_KEYS_FILE)) {
+    env.SCRAPER_API_KEYS_FILE = resolve(repoRoot, env.SCRAPER_API_KEYS_FILE);
+  }
   if (job.payload.scraper) env.SCRAPER_IDS = job.payload.scraper;
   else delete env.SCRAPER_IDS;
 

--- a/packages/server/src/lib/admin-jobs.ts
+++ b/packages/server/src/lib/admin-jobs.ts
@@ -179,10 +179,12 @@ export async function processAdminJobQueue(
           jobType: row.job_type,
           payload: parsePayload(row.payload_json),
         };
+        console.log(`[Admin] ${row.job_type} job ${row.id} started`);
         const result = await executor(job);
         db.prepare(
           "UPDATE admin_job_runs SET status = 'succeeded', result_json = ?, finished_at = datetime('now') WHERE id = ? AND status = 'running'"
         ).run(JSON.stringify(result), row.id);
+        console.log(`[Admin] ${row.job_type} job ${row.id} succeeded`);
         succeeded++;
       } catch (err) {
         const baseResult = err instanceof AdminJobExecutionError ? err.result : {};
@@ -193,7 +195,7 @@ export async function processAdminJobQueue(
         db.prepare(
           "UPDATE admin_job_runs SET status = 'failed', result_json = ?, finished_at = datetime('now') WHERE id = ? AND status = 'running'"
         ).run(JSON.stringify(result), row.id);
-        console.error(`[Admin] ${row.job_type} job ${row.id} failed`, result);
+        console.error(`[Admin] ${row.job_type} job ${row.id} failed`);
         failed++;
       }
     }

--- a/packages/server/src/lib/admin-jobs.ts
+++ b/packages/server/src/lib/admin-jobs.ts
@@ -193,6 +193,7 @@ export async function processAdminJobQueue(
         db.prepare(
           "UPDATE admin_job_runs SET status = 'failed', result_json = ?, finished_at = datetime('now') WHERE id = ? AND status = 'running'"
         ).run(JSON.stringify(result), row.id);
+        console.error(`[Admin] ${row.job_type} job ${row.id} failed`, result);
         failed++;
       }
     }

--- a/packages/server/tests/admin-job-worker.test.ts
+++ b/packages/server/tests/admin-job-worker.test.ts
@@ -21,24 +21,31 @@ describe("admin job worker", () => {
       .run(JSON.stringify({ scraper: 'all', dryRun: true }));
 
     const seen: Array<{ id: string; scraper: string | null; dryRun: boolean }> = [];
-    const result = await processAdminJobQueue(db, 5, async (job) => {
-      seen.push({ id: job.id, scraper: job.payload.scraper, dryRun: job.payload.dryRun });
-      return { ok: true, scraper: job.payload.scraper ?? 'all', dryRun: job.payload.dryRun };
-    });
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const result = await processAdminJobQueue(db, 5, async (job) => {
+        seen.push({ id: job.id, scraper: job.payload.scraper, dryRun: job.payload.dryRun });
+        return { ok: true, scraper: job.payload.scraper ?? 'all', dryRun: job.payload.dryRun };
+      });
 
-    expect(result).toEqual({ processed: 1, succeeded: 1, failed: 0 });
-    expect(seen).toEqual([{ id: 'job1', scraper: null, dryRun: true }]);
+      expect(result).toEqual({ processed: 1, succeeded: 1, failed: 0 });
+      expect(seen).toEqual([{ id: 'job1', scraper: null, dryRun: true }]);
 
-    const row = db.prepare("SELECT status, started_at, finished_at, result_json FROM admin_job_runs WHERE id = 'job1'").get() as {
-      status: string;
-      started_at: string | null;
-      finished_at: string | null;
-      result_json: string | null;
-    };
-    expect(row.status).toBe("succeeded");
-    expect(row.started_at).toBeTruthy();
-    expect(row.finished_at).toBeTruthy();
-    expect(JSON.parse(row.result_json || "null")).toEqual({ ok: true, scraper: 'all', dryRun: true });
+      const row = db.prepare("SELECT status, started_at, finished_at, result_json FROM admin_job_runs WHERE id = 'job1'").get() as {
+        status: string;
+        started_at: string | null;
+        finished_at: string | null;
+        result_json: string | null;
+      };
+      expect(row.status).toBe("succeeded");
+      expect(row.started_at).toBeTruthy();
+      expect(row.finished_at).toBeTruthy();
+      expect(JSON.parse(row.result_json || "null")).toEqual({ ok: true, scraper: 'all', dryRun: true });
+      expect(consoleLog).toHaveBeenCalledWith('[Admin] scraper job job1 started');
+      expect(consoleLog).toHaveBeenCalledWith('[Admin] scraper job job1 succeeded');
+    } finally {
+      consoleLog.mockRestore();
+    }
   });
 
   it("coalesces overlapping queue runs in process", async () => {
@@ -92,7 +99,7 @@ describe("admin job worker", () => {
       };
       expect(row.status).toBe('failed');
       expect(JSON.parse(row.result_json || 'null')).toEqual({ error: 'missing scraper api key' });
-      expect(consoleError).toHaveBeenCalledWith('[Admin] scraper job job1 failed', { error: 'missing scraper api key' });
+      expect(consoleError).toHaveBeenCalledWith('[Admin] scraper job job1 failed');
     } finally {
       consoleError.mockRestore();
     }

--- a/packages/server/tests/admin-job-worker.test.ts
+++ b/packages/server/tests/admin-job-worker.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import { initDatabase } from "../src/db.js";
 import { processAdminJobQueue } from "../src/lib/admin-jobs.js";
 
@@ -70,6 +70,32 @@ describe("admin job worker", () => {
     const [result1, result2] = await Promise.all([run1, run2]);
     expect(result1).toEqual({ processed: 1, succeeded: 1, failed: 0 });
     expect(result2).toEqual({ processed: 1, succeeded: 1, failed: 0 });
+  });
+
+  it("stores and logs failure details for failed jobs", async () => {
+    const db = initDatabase(":memory:");
+    db.prepare("INSERT INTO accounts (id, username, is_admin) VALUES ('admin1', 'admin', 1)").run();
+    db.prepare("INSERT INTO admin_job_runs (id, job_type, status, payload_json, created_by_account_id, created_at) VALUES ('job1', 'scraper', 'queued', ?, 'admin1', datetime('now'))")
+      .run(JSON.stringify({ scraper: 'flex_at', dryRun: false }));
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await processAdminJobQueue(db, 5, async () => {
+        throw new Error('missing scraper api key');
+      });
+
+      expect(result).toEqual({ processed: 1, succeeded: 0, failed: 1 });
+
+      const row = db.prepare("SELECT status, result_json FROM admin_job_runs WHERE id = 'job1'").get() as {
+        status: string;
+        result_json: string | null;
+      };
+      expect(row.status).toBe('failed');
+      expect(JSON.parse(row.result_json || 'null')).toEqual({ error: 'missing scraper api key' });
+      expect(consoleError).toHaveBeenCalledWith('[Admin] scraper job job1 failed', { error: 'missing scraper api key' });
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("reclaims stale running jobs but leaves fresh running jobs alone", async () => {

--- a/packages/server/tests/admin-jobs-scraper-path.test.ts
+++ b/packages/server/tests/admin-jobs-scraper-path.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { EventEmitter } from "node:events";
@@ -10,11 +10,19 @@ vi.mock("node:child_process", () => ({
 }));
 
 describe("executeScraperAdminJob", () => {
+  const originalScraperApiKeysFile = process.env.SCRAPER_API_KEYS_FILE;
+
   beforeEach(() => {
     spawnMock.mockReset();
   });
 
+  afterEach(() => {
+    if (originalScraperApiKeysFile === undefined) delete process.env.SCRAPER_API_KEYS_FILE;
+    else process.env.SCRAPER_API_KEYS_FILE = originalScraperApiKeysFile;
+  });
+
   it("resolves the scraper script relative to the server module, not cwd", async () => {
+    process.env.SCRAPER_API_KEYS_FILE = "./scraper-api-keys.json";
     spawnMock.mockImplementation(() => {
       const child = new EventEmitter() as EventEmitter & {
         stdout: EventEmitter;
@@ -40,6 +48,7 @@ describe("executeScraperAdminJob", () => {
 
     const testsDir = dirname(fileURLToPath(import.meta.url));
     const expectedScriptPath = resolve(testsDir, "../../scrapers/dist/run.js");
+    const expectedApiKeysPath = resolve(testsDir, "../../..", "scraper-api-keys.json");
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledWith("node", [expectedScriptPath], {
@@ -47,6 +56,7 @@ describe("executeScraperAdminJob", () => {
       env: expect.objectContaining({
         SCRAPER_DRY_RUN: "true",
         SCRAPER_IDS: "demo-source",
+        SCRAPER_API_KEYS_FILE: expectedApiKeysPath,
       }),
       stdio: ["ignore", "pipe", "pipe"],
     });

--- a/packages/web/src/pages/AdminPage.test.tsx
+++ b/packages/web/src/pages/AdminPage.test.tsx
@@ -239,6 +239,61 @@ describe("AdminPage audit payload rendering", () => {
   });
 });
 
+describe("AdminPage job run failure rendering", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.authStatus = "authenticated";
+    mocks.loading = false;
+    mocks.user = { isAdmin: true };
+    vi.stubGlobal("IntersectionObserver", class {
+      observe() {}
+      disconnect() {}
+      unobserve() {}
+    });
+    vi.stubGlobal("fetch", vi.fn((input: string | URL | Request) => {
+      const url = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      if (url.includes("/api/v1/admin/jobs/runs")) {
+        return Promise.resolve(jsonResponse({
+          items: [
+            {
+              id: "job-failed",
+              job_type: "scraper",
+              status: "failed",
+              result_json: JSON.stringify({
+                error: "scraper job exited with code 1",
+                stderr: "Missing scraper API key(s) for: flex_at",
+              }),
+              created_at: "2026-06-06 12:00:00",
+              started_at: "2026-06-06 12:00:01",
+              finished_at: "2026-06-06 12:00:02",
+            },
+          ],
+        }, { status: 200 }));
+      }
+      return Promise.resolve(jsonResponse({ items: [] }, { status: 200 }));
+    }));
+    ({ AdminPage } = await import("./AdminPage"));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows failed job summaries and full stored result payloads", async () => {
+    render(<AdminPage />);
+
+    expect(await screen.findByText("job-failed")).not.toBeNull();
+    expect(screen.getByText("scraper job exited with code 1")).not.toBeNull();
+    expect(screen.getByText((_, element) => element?.tagName.toLowerCase() === "pre" && element.textContent?.includes('"stderr": "Missing scraper API key(s) for: flex_at"'))).not.toBeNull();
+  });
+});
+
 describe("AdminPage proactive federation suppression", () => {
   beforeEach(async () => {
     vi.resetModules();

--- a/packages/web/src/pages/AdminPage.tsx
+++ b/packages/web/src/pages/AdminPage.tsx
@@ -6,7 +6,7 @@ import { CalendarIcon, CheckCalendarIcon, FlagIcon, GlobeIcon, SettingsIcon, Shi
 import { ModerationDecisionActions } from '../components/ModerationDecisionActions';
 import { adminFetch } from '../lib/adminFetch';
 import type { AdminHealthResponse, Account, AccountsResponse, ModerationItem, FederationBlock, FederationActor, FederationDomain, FederationTombstone, AdminSetting, JobRun, AuditItem, ConfirmState, AdminSectionKey, AdminAuditResponse, AdminModerationResponse, AdminFederationBlocksResponse, AdminFederationActorsResponse, AdminFederationDomainsResponse, AdminFederationTombstonesResponse, AdminSettingsResponse, AdminJobRunsResponse, AdminScraperTriggerResponse } from './admin-types';
-import { AVAILABLE_SCRAPERS, formatAuditPayload } from './admin-types';
+import { AVAILABLE_SCRAPERS, formatAuditPayload, formatJobRunResult, parseJobRunResult } from './admin-types';
 import { AdminAccountsSection } from './AdminAccountsSection';
 import { ReasonModal } from '../components/ReasonModal';
 import './SharedLayout.css';
@@ -47,6 +47,7 @@ export function AdminPage() {
   const [refreshCountdownSec, setRefreshCountdownSec] = useState(60);
   const [lastRefreshedAt, setLastRefreshedAt] = useState<Date | null>(null);
   const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+  const [trackedJobRunId, setTrackedJobRunId] = useState<string | null>(null);
   const [runtimeDraftValues, setRuntimeDraftValues] = useState<Record<string, string>>({});
   const [dirtyRuntimeSettingKeys, setDirtyRuntimeSettingKeys] = useState<Set<string>>(new Set());
   const [runtimeSettingsQuery, setRuntimeSettingsQuery] = useState('');
@@ -293,6 +294,14 @@ export function AdminPage() {
     setJobRuns(data.items || []);
   }
 
+  const summarizeJobRunFailure = useCallback((run: JobRun): string => {
+    const parsed = parseJobRunResult(run.result_json);
+    const error = typeof parsed?.error === 'string' && parsed.error.trim() ? parsed.error.trim() : null;
+    const stderr = typeof parsed?.stderr === 'string' && parsed.stderr.trim() ? parsed.stderr.trim() : null;
+    const stdout = typeof parsed?.stdout === 'string' && parsed.stdout.trim() ? parsed.stdout.trim() : null;
+    return error || stderr || stdout || 'No failure details were recorded.';
+  }, []);
+
   async function refreshSettings() {
     const data = await adminFetch<AdminSettingsResponse>('/api/v1/admin/settings');
     setSettings(data.items || []);
@@ -390,6 +399,44 @@ export function AdminPage() {
     }, 1000);
     return () => window.clearInterval(interval);
   }, [user?.isAdmin, refreshAllData]);
+
+  useEffect(() => {
+    if (!trackedJobRunId) return;
+
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const data = await adminFetch<AdminJobRunsResponse>('/api/v1/admin/jobs/runs');
+        if (cancelled) return;
+        const items = data.items || [];
+        setJobRuns(items);
+        const run = items.find((item) => item.id === trackedJobRunId);
+        if (!run) return;
+        if (run.status === 'succeeded') {
+          setStatus(`Scraper run ${run.id} succeeded`);
+          setTrackedJobRunId(null);
+          return;
+        }
+        if (run.status === 'failed') {
+          setError(`Scraper run ${run.id} failed: ${summarizeJobRunFailure(run)}`);
+          setTrackedJobRunId(null);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        setError(toErrorMessage(err, 'Failed to refresh job runs'));
+        setTrackedJobRunId(null);
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, 2000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [summarizeJobRunFailure, trackedJobRunId]);
 
   if (loading) return <div className='empty-state mt-3'><h2>Loading</h2><p>Checking admin access...</p></div>;
   if (!user?.isAdmin) return <div className='empty-state mt-3'><h2>Redirecting</h2><p>Admin access is required.</p></div>;
@@ -1033,6 +1080,7 @@ export function AdminPage() {
                       }),
                     });
                     setStatus(`Queued scraper run ${data.runId} (${scraperDryRun ? 'dry-run' : 'live'})`);
+                    setTrackedJobRunId(data.runId);
                     await refreshJobRuns();
                     await refreshAudit();
                   } catch (err) {
@@ -1064,9 +1112,17 @@ export function AdminPage() {
               <p className='admin-record-title'>{run.job_type}</p>
               <p className='admin-record-subtitle'>{run.id}</p>
               <div className='text-sm text-muted'>created: {run.created_at || 'n/a'}</div>
+              {run.started_at || run.finished_at ? <div className='text-sm text-muted'>started: {run.started_at || 'n/a'} · finished: {run.finished_at || 'n/a'}</div> : null}
+              {run.status === 'failed' ? <div className='text-sm' style={{ color: 'var(--danger)', marginTop: '0.35rem' }}>{summarizeJobRunFailure(run)}</div> : null}
+              <details className='mt-1' style={{ fontSize: '0.8rem', background: 'var(--bg-raised)', padding: '0.45rem 0.65rem', borderRadius: 'var(--radius-sm)', border: '1px solid var(--border)' }}>
+                <summary style={{ cursor: 'pointer', userSelect: 'none', color: 'var(--text-muted)', fontWeight: 600 }}>View full job result</summary>
+                <pre style={{ margin: '0.4rem 0 0', overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-all', fontFamily: 'var(--font-mono)', fontSize: '0.75rem', color: 'var(--text-dim)' }}>
+                  {formatJobRunResult(run.result_json)}
+                </pre>
+              </details>
             </div>
             <div className='admin-record-meta'>
-              <span className='admin-record-pill'>{run.status}</span>
+              <span className={`admin-record-pill ${run.status === 'failed' ? 'is-danger' : run.status === 'succeeded' ? 'is-success' : 'is-accent'}`}>{run.status}</span>
             </div>
             <div className='admin-record-actions' />
           </li>

--- a/packages/web/src/pages/admin-types.ts
+++ b/packages/web/src/pages/admin-types.ts
@@ -85,3 +85,22 @@ export function formatAuditPayload(payload?: string | null) {
     return payload;
   }
 }
+
+export function parseJobRunResult(payload?: string | null): Record<string, unknown> | null {
+  if (!payload?.trim()) return null;
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, unknown> : null;
+  } catch {
+    return null;
+  }
+}
+
+export function formatJobRunResult(payload?: string | null) {
+  if (!payload?.trim()) return 'n/a';
+  try {
+    return JSON.stringify(JSON.parse(payload), null, 2);
+  } catch {
+    return payload;
+  }
+}


### PR DESCRIPTION
## Summary
- fail scraper runs when the configured API key file path is missing
- fail scraper runs when the configured keys do not cover the selected scrapers
- add runner tests for missing file and missing key coverage

## Testing
- pnpm --filter @everycal/scrapers test -- run.test.ts